### PR TITLE
Added legacy mcollective facts file to the list of the ignored directories

### DIFF
--- a/templates/fragments/_syscheck_linux.erb
+++ b/templates/fragments/_syscheck_linux.erb
@@ -17,4 +17,5 @@
     <ignore>/etc/dumpdates</ignore>
     <ignore>/etc/svc/volatile</ignore>
     <ignore>/etc/puppetlabs/mcollective/facts.yaml</ignore>
+    <ignore>/etc/mcollective/facts.yaml</ignore>
   </syscheck>


### PR DESCRIPTION
Older installations of mcollective (prior to the AIO package) used /etc/mcollective instead of /etc/puppetlabs/mcollective.

Added the old directory to the list of the ignored ones.