### PR TITLE
explicitly use the windows package provider

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -71,6 +71,7 @@ class wazuh::client(
 
       package { $agent_package_name:
         ensure          => $agent_package_version,
+        provider        => 'windows',
         source          => 'C:/wazuh-agent-2.0.exe',
         install_options => [ '/S' ],  # Nullsoft installer silent installation
         require         => File['C:/wazuh-agent-2.0.exe'],


### PR DESCRIPTION
The use of package here assumes that the windows package provider
is the default, which in some configurations it is not.