### PR TITLE
Say which variable should be really set.

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -48,7 +48,7 @@ class wazuh::server (
   validate_array($ossec_ignorepaths)
   if ( $ossec_emailnotification ) {
     if $smtp_server == undef {
-      fail('$ossec_emailnotification is enabled but $ossec_emailnotification was not set')
+      fail('$ossec_emailnotification is enabled but $smtp_server was not set')
     }
     validate_string($smtp_server)
     validate_string($ossec_emailfrom)


### PR DESCRIPTION
Error message:
_Evaluation Error: Error while evaluating a Function Call, $ossec_emailnotification is enabled but $ossec_emailnotification was not set at /etc/puppetlabs/code/modules/wazuh/manifests/server.pp:51:7_
makes little sense. One has to check sources when sees it.