### PR TITLE
Adding support for changing ossec_server_protocol

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -24,6 +24,7 @@ class wazuh::server (
   $ossec_prefilter                     = false,
   $ossec_service_provider              = $::wazuh::params::ossec_service_provider,
   $ossec_server_port                   = '1514',
+  $ossec_server_protocol               = 'udp',
   $server_package_version              = 'installed',
   $manage_repos                        = true,
   $manage_epel_repo                    = true,

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -22,7 +22,7 @@
     <%- @ossec_white_list.each do |ipaddress| -%><white_list><%= ipaddress %></white_list>
     <%- end -%>
   </global>
-  
+
 <%- if @syslog_output -%>
   <syslog_output>
     <server><%= @syslog_output_server %></server>
@@ -53,7 +53,7 @@
   <remote>
     <connection>secure</connection>
     <port><%= @ossec_server_port %></port>
-    <protocol>udp</protocol>
+    <protocol><%= @ossec_server_protocol %></protocol>
   </remote>
 
 <%= scope.function_template(["wazuh/fragments/_common.erb"]) -%>


### PR DESCRIPTION
This will allow overriding the ossec_server_protocol, currently hardcoded to udp in the ossec.conf. This is a backwards compatible change, as it introduces a new parameters with a default value compatible with the existing behaviour.