### PR TITLE
Managing wazuh-api alongside with wazuh-manager

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class wazuh::params {
           $agent_package  = 'wazuh-agent'
           $service_has_status  = false
           $ossec_service_provider = undef
+          $api_service_provider = undef
 
           $default_local_files = {
             '/var/log/syslog'                      => 'syslog',
@@ -45,6 +46,8 @@ class wazuh::params {
             'xenial': {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
+              $api_service = 'wazuh-api'
+              $api_package = 'wazuh-api'
               $wodle_openscap_content = {
                 'ssg-ubuntu-1604-ds.xml' => {
                   'type' => 'xccdf',
@@ -55,6 +58,8 @@ class wazuh::params {
             'jessie': {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
+              $api_service = 'wazuh-api'
+              $api_package = 'wazuh-api'
               $wodle_openscap_content = {
                 'ssg-debian-8-ds.xml' => {
                   'type' => 'xccdf',
@@ -68,6 +73,8 @@ class wazuh::params {
             /^(wheezy|stretch|sid|precise|trusty|vivid|wily|xenial)$/: {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
+              $api_service = 'wazuh-api'
+              $api_package = 'wazuh-api'
               $wodle_openscap_content = undef
             }
         default: {
@@ -82,8 +89,11 @@ class wazuh::params {
           $agent_package  = 'wazuh-agent'
           $server_service = 'wazuh-manager'
           $server_package = 'wazuh-manager'
+          $api_service = 'wazuh-api'
+          $api_package = 'wazuh-api'
           $service_has_status  = true
           $ossec_service_provider = 'redhat'
+          $api_service_provider = 'redhat'
 
           $default_local_files = {
             '/var/log/messages'         => 'syslog',
@@ -167,6 +177,8 @@ class wazuh::params {
       $agent_package  = 'Wazuh Agent 2.0'
       $server_service = ''
       $server_package = ''
+      $api_service = ''
+      $api_package = ''
       $service_has_status  = true
 
       # TODO

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -25,7 +25,6 @@ class wazuh::server (
   $ossec_service_provider              = $::wazuh::params::ossec_service_provider,
   $api_service_provider                = $::wazuh::params::api_service_provider,
   $ossec_server_port                   = '1514',
-  $ossec_server_protocol               = 'udp',
   $server_package_version              = 'installed',
   $api_package_version                 = 'installed',
   $manage_repos                        = true,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -24,6 +24,7 @@ class wazuh::server (
   $ossec_prefilter                     = false,
   $ossec_service_provider              = $::wazuh::params::ossec_service_provider,
   $ossec_server_port                   = '1514',
+  $ossec_server_protocol               = 'udp',
   $server_package_version              = 'installed',
   $manage_repos                        = true,
   $manage_epel_repo                    = true,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh-wazuh",
-  "version": "2.0.22",
+  "version": "2.1.0",
   "author": "WAZUH",
   "summary": "Install and configure Wazuh-HIDS client and server",
   "license": "Apache-2.0",
@@ -86,6 +86,10 @@
     {
       "name": "puppet/selinux",
       "version_range": ">= 0.8.0"
+    },
+    {
+      "name": "puppet/nodejs",
+      "version_range": ">= 3.0.0 < 4.0.0"
     }
   ]
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "wazuh-wazuh",
-  "version": "2.1.0",
+  "version": "2.0.22",
   "author": "WAZUH",
   "summary": "Install and configure Wazuh-HIDS client and server",
   "license": "Apache-2.0",

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -22,7 +22,7 @@
     <%- @ossec_white_list.each do |ipaddress| -%><white_list><%= ipaddress %></white_list>
     <%- end -%>
   </global>
-  
+
 <%- if @syslog_output -%>
   <syslog_output>
     <server><%= @syslog_output_server %></server>
@@ -53,7 +53,7 @@
   <remote>
     <connection>secure</connection>
     <port><%= @ossec_server_port %></port>
-    <protocol>udp</protocol>
+    <protocol><%= @ossec_server_protocol %></protocol>
   </remote>
 
 <%= scope.function_template(["wazuh/fragments/_common.erb"]) -%>

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -22,7 +22,7 @@
     <%- @ossec_white_list.each do |ipaddress| -%><white_list><%= ipaddress %></white_list>
     <%- end -%>
   </global>
-
+  
 <%- if @syslog_output -%>
   <syslog_output>
     <server><%= @syslog_output_server %></server>
@@ -53,7 +53,7 @@
   <remote>
     <connection>secure</connection>
     <port><%= @ossec_server_port %></port>
-    <protocol><%= @ossec_server_protocol %></protocol>
+    <protocol>udp</protocol>
   </remote>
 
 <%= scope.function_template(["wazuh/fragments/_common.erb"]) -%>


### PR DESCRIPTION
The module currently doesn't support installing the wazuh-api package, as described in the docs (https://documentation.wazuh.com/current/installation-guide/installing-wazuh-server/wazuh_server_rpm.html#installing-wazuh-api). This change is backwards-compatible, as the installation is bound to a parameter `install_wazuh_api` which defaults to `false`.