### PR TITLE
Preventing Duplicated declaration issues regarding apt-transport-https package

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,7 +5,9 @@ class wazuh::repo (
 
   case $::osfamily {
     'Debian' : {
-      ensure_packages(['apt-transport-https'], {'ensure' => 'present'})
+      if ! defined(Package['apt-transport-https']) {
+        ensure_packages(['apt-transport-https'], {'ensure' => 'present'})
+      }
       # apt-key added by issue #34
       apt::key { 'wazuh':
         id     => '0DCFCA5547B19D2A6099506096B3EE5F29111145',


### PR DESCRIPTION
Many modules try to declare apt-transport-https package resource, so this is a patch to prevent the following error when this resource is already being managed elsewhere:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, Duplicate declaration: Package[apt-transport-https] is already declared in file /etc/puppetlabs/code/environments/staging/modules/newrelic_infra/manifests/agent.pp:57; cannot redeclare at /etc/puppetlabs/code/environments/staging/modules/wazuh/manifests/repo.pp:8 at /etc/puppetlabs/code/environments/staging/modules/wazuh/manifests/repo.pp:8:7 on node your-node-name.your.domain
```

This is a backwards-compatible change.