### PR TITLE
Add the server option to the apt :: key section

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,6 +10,7 @@ class wazuh::repo (
       apt::key { 'wazuh':
         id     => '0DCFCA5547B19D2A6099506096B3EE5F29111145',
         source => 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
+        server => 'pgp.mit.edu'
       }
       case $::lsbdistcodename {
         /(precise|trusty|vivid|wily|xenial|yakketi)/: {


### PR DESCRIPTION
Based on the information that is in the document https://forge.puppet.com/puppetlabs/apt/readme#add-gpg-keys, add

Add the option of server, although in the documentation it appears that all the values are optional.

This changes are tested on debian 8 Puppet Client and Server v4.10.6

Thanks