### PR TITLE
Adding support for changing the client protocol and validating the manager by CA

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -8,6 +8,7 @@ class wazuh::client(
   $ossec_server_ip            = undef,
   $ossec_server_hostname      = undef,
   $ossec_server_port          = '1514',
+  $ossec_server_protocol      = 'udp',
   $ossec_scanpaths            = [],
   $ossec_emailnotification    = 'yes',
   $ossec_ignorepaths          = [],

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -27,6 +27,7 @@ class wazuh::client(
   $agent_service_name         = $::wazuh::params::agent_service,
   $manage_client_keys         = 'export',
   $agent_auth_password        = undef,
+  $wazuh_manager_root_ca_pem  = undef,
   $agent_seed                 = undef,
   $max_clients                = 3000,
   $ar_repeated_offenders      = '',
@@ -146,9 +147,26 @@ class wazuh::client(
       mode  => $wazuh::params::keys_mode,
     }
 
+    # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
+    $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${agent_name} -D /var/ossec/"
+    if $wazuh_manager_root_ca_pem != undef {
+      validate_string($wazuh_manager_root_ca_pem)
+      file { '/var/ossec/etc/rootCA.pem':
+        owner   => $wazuh::params::keys_owner,
+        group   => $wazuh::params::keys_group,
+        mode    => $wazuh::params::keys_mode,
+        content => $wazuh_manager_root_ca_pem,
+        require => Package[$agent_package_name],
+      }
+
+      $agent_auth_command = "${agent_auth_base_command} -v /var/ossec/etc/rootCA.pem"
+    } else {
+      $agent_auth_command = $agent_auth_base_command
+    }
+
     if $agent_auth_password {
       exec { 'agent-auth-with-pwd':
-        command => "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${agent_name} -P '${agent_auth_password}' -D /var/ossec/",
+        command => "${agent_auth_command} -P '${agent_auth_password}'",
         unless  => "/bin/egrep -q '.' ${::wazuh::params::keys_file}",
         require => Package[$agent_package_name],
         notify  => Service[$agent_service_name],
@@ -156,7 +174,7 @@ class wazuh::client(
       }
     } else {
       exec { 'agent-auth-without-pwd':
-        command => "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${agent_name} -D /var/ossec/",
+        command => "${agent_auth_command}",
         unless  => "/bin/egrep -q '.' ${::wazuh::params::keys_file}",
         require => Package[$agent_package_name],
         notify  => Service[$agent_service_name],

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -25,6 +25,8 @@ class wazuh::server (
   $ossec_service_provider              = $::wazuh::params::ossec_service_provider,
   $api_service_provider                = $::wazuh::params::api_service_provider,
   $ossec_server_port                   = '1514',
+  $ossec_server_protocol               = 'udp',
+  $ossec_authd_enabled                 = false,
   $server_package_version              = 'installed',
   $api_package_version                 = 'installed',
   $manage_repos                        = true,
@@ -165,6 +167,32 @@ class wazuh::server (
       content => $agent_auth_password,
       require => Package[$wazuh::params::server_package],
     }
+  }
+
+  # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
+  if $wazuh_manager_verify_manager_ssl {
+    validate_string(
+      $wazuh_manager_server_crt, $wazuh_manager_server_key
+    )
+
+    file { '/var/ossec/etc/sslmanager.key':
+      content => $wazuh_manager_server_key,
+      owner   => 'root',
+      group   => 'ossec',
+      mode    => '0640',
+      require => Package[$wazuh::params::server_package],
+      notify  => Service[$wazuh::params::server_service],
+    }
+
+    file { '/var/ossec/etc/sslmanager.cert':
+      content => $wazuh_manager_server_crt,
+      owner   => 'root',
+      group   => 'ossec',
+      mode    => '0640',
+      require => Package[$wazuh::params::server_package],
+      notify  => Service[$wazuh::params::server_service],
+    }
+
   }
 
   ### Wazuh API

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -45,11 +45,14 @@ class wazuh::server (
   $local_decoder_template              = 'wazuh/local_decoder.xml.erb',
   $local_rules_template                = 'wazuh/local_rules.xml.erb',
   $shared_agent_template               = 'wazuh/ossec_shared_agent.conf.erb',
+  $wazuh_manager_verify_manager_ssl    = false,
+  $wazuh_manager_server_crt            = undef,
+  $wazuh_manager_server_key            = undef,
 ) inherits wazuh::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
     $manage_repos, $manage_epel_repo, $syslog_output,
-    $install_wazuh_api
+    $install_wazuh_api, $wazuh_manager_verify_manager_ssl
   )
 
   # This allows arrays of integers, sadly

--- a/templates/process_list.erb
+++ b/templates/process_list.erb
@@ -3,6 +3,3 @@
 <% if @syslog_output -%>
 CSYSLOG_DAEMON=ossec-csyslogd
 <% end -%>
-<% if @ossec_authd_enabled -%>
-AUTH_DAEMON=ossec-authd
-<% end -%>

--- a/templates/process_list.erb
+++ b/templates/process_list.erb
@@ -3,3 +3,6 @@
 <% if @syslog_output -%>
 CSYSLOG_DAEMON=ossec-csyslogd
 <% end -%>
+<% if @ossec_authd_enabled -%>
+AUTH_DAEMON=ossec-authd
+<% end -%>

--- a/templates/wazuh_agent.conf.erb
+++ b/templates/wazuh_agent.conf.erb
@@ -5,6 +5,9 @@
   <%- if @ossec_server_hostname then -%>
     <server-hostname><%= @ossec_server_hostname %></server-hostname>
   <%- end -%>
+  <%- if @ossec_server_protocol then -%>
+    <protocol><%= @ossec_server_protocol %></protocol>
+  <%- end -%>
     <port><%= @ossec_server_port %></port>
   <%- if @ossec_config_profiles then -%>
     <config-profile><%= @ossec_config_profiles.join(',') %></config-profile>

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -22,7 +22,7 @@
     <%- @ossec_white_list.each do |ipaddress| -%><white_list><%= ipaddress %></white_list>
     <%- end -%>
   </global>
-  
+
 <%- if @syslog_output -%>
   <syslog_output>
     <server><%= @syslog_output_server %></server>
@@ -53,7 +53,7 @@
   <remote>
     <connection>secure</connection>
     <port><%= @ossec_server_port %></port>
-    <protocol>udp</protocol>
+    <protocol><%= @ossec_server_protocol %></protocol>
   </remote>
 
 <%= scope.function_template(["wazuh/fragments/_common.erb"]) -%>


### PR DESCRIPTION
This PR allows changing the agent communication protocol (useful for scenarios with a TCP load balancer on top of it) and also drops a custom CA in the agent /var/ossec/etc folder/rootCA.pem, basically to support https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl.

Also, this PR fixes the accidental revert introduced in https://github.com/wazuh/wazuh-puppet/pull/31/commits/a59dd8c48b84b30b3c3eb433db78b0e8bf142ce1.

This change is backwards-compatible, as the default protocol remains udp and the CA will only be written to the system if you specify it.