### PR TITLE
Configuring wazuh-api from puppet

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,18 @@ class wazuh::params {
       $processlist_owner = 'root'
       $processlist_group = 'ossec'
 
+      # this hash is currently only covering the basic config section of config.js
+      # TODO: allow customization of the entire config.js
+      # for reference: https://documentation.wazuh.com/current/user-manual/api/configuration.html
+      $api_config_params = [
+        {'name' => 'ossec_path', 'value' => '/var/ossec'},
+        {'name' => 'host', 'value' => '0.0.0.0'},
+        {'name' => 'port', 'value' => '55000'},
+        {'name' => 'https', 'value' => 'no'},
+        {'name' => 'basic_auth', 'value' => 'yes'},
+        {'name' => 'BehindProxyServer', 'value' => 'no'},
+      ]
+
       case $::osfamily {
         'Debian': {
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -207,14 +207,9 @@ class wazuh::server (
     }
 
     # wazuh-api config.js
-    $api_config_params = [
-      {'name' => 'ossec_path', 'value' => '/var/ossec'},
-      {'name' => 'host', 'value' => '0.0.0.0'},
-      {'name' => 'port', 'value' => '55000'},
-      {'name' => 'https', 'value' => 'yes'},
-      {'name' => 'basic_auth', 'value' => 'no'},
-      {'name' => 'BehindProxyServer', 'value' => 'no'},
-    ]
+    # this hash is currently only covering the basic config section of config.js
+    # TODO: allow customization of the entire config.js
+    # for reference: https://documentation.wazuh.com/current/user-manual/api/configuration.html
 
     file { '/var/ossec/api/configuration/config.js':
       content => template($api_config_template),

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -32,9 +32,6 @@ class wazuh::server (
   $manage_epel_repo                    = true,
   $manage_client_keys                  = 'export',
   $install_wazuh_api                   = false,
-  $wazuh_api_enable_https              = false,
-  $wazuh_api_server_crt                = undef,
-  $wazuh_api_server_key                = undef,
   $manage_nodejs                       = true,
   $nodejs_repo_url_suffix              = '6.x',
   $agent_auth_password                 = undef,
@@ -52,7 +49,7 @@ class wazuh::server (
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
     $manage_repos, $manage_epel_repo, $syslog_output,
-    $install_wazuh_api, $wazuh_manager_verify_manager_ssl
+    $install_wazuh_api
   )
 
   # This allows arrays of integers, sadly
@@ -185,32 +182,10 @@ class wazuh::server (
       ensure  => $api_package_version
     }
 
-    if $wazuh_api_enable_https {
-      validate_string($wazuh_api_server_crt, $wazuh_api_server_key)
-      file { '/var/ossec/api/configuration/ssl/server.key':
-        content => $wazuh_api_server_key,
-        owner   => 'root',
-        group   => 'ossec',
-        mode    => '0600',
-        require => Package[$wazuh::params::api_package],
-        notify  => Service[$wazuh::params::api_service],
-      }
-
-      file { '/var/ossec/api/configuration/ssl/server.crt':
-        content => $wazuh_api_server_crt,
-        owner   => 'root',
-        group   => 'ossec',
-        mode    => '0600',
-        require => Package[$wazuh::params::api_package],
-        notify  => Service[$wazuh::params::api_service],
-      }
-    }
-
     # wazuh-api config.js
     # this hash is currently only covering the basic config section of config.js
     # TODO: allow customization of the entire config.js
     # for reference: https://documentation.wazuh.com/current/user-manual/api/configuration.html
-
     file { '/var/ossec/api/configuration/config.js':
       content => template($api_config_template),
       owner   => 'root',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -43,11 +43,12 @@ class wazuh::server (
   $local_decoder_template              = 'wazuh/local_decoder.xml.erb',
   $local_rules_template                = 'wazuh/local_rules.xml.erb',
   $shared_agent_template               = 'wazuh/ossec_shared_agent.conf.erb',
+  $api_config_template                 = 'wazuh/api/config.js.erb',
 ) inherits wazuh::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
     $manage_repos, $manage_epel_repo, $syslog_output,
-    $install_wazuh_api
+    $install_wazuh_api, $wazuh_manager_verify_manager_ssl
   )
 
   # This allows arrays of integers, sadly

--- a/templates/api/config.js.erb
+++ b/templates/api/config.js.erb
@@ -1,0 +1,42 @@
+
+var config = {};
+
+// Basic configuration
+<% @api_config_params.each do |config| -%>
+config.<%= config['name'] %> = "<%= config['value'] %>";
+<% end -%>
+
+// Advanced configuration
+
+// Values for API log: disabled, info, warning, error, debug (each level includes the previous level).
+config.logs = "info";
+// Cross-origin resource sharing. Values: yes, no.
+config.cors = "yes";
+// Cache (time in milliseconds)
+config.cache_enabled = "yes";
+config.cache_debug = "no";
+config.cache_time = "750";
+// Log path
+config.log_path = config.ossec_path + "/logs/api.log";
+// Python
+config.python = [
+    // Default installation
+    {
+        bin: "python",
+        lib: ""
+    },
+    // Python 3
+    {
+        bin: "python3",
+        lib: ""
+    },
+    // Package 'python27' for CentOS 6
+    {
+        bin: "/opt/rh/python27/root/usr/bin/python",
+        lib: "/opt/rh/python27/root/usr/lib64"
+    }
+];
+// Shared library path
+config.ld_library_path = config.ossec_path + "/api/framework/lib"
+
+module.exports = config;


### PR DESCRIPTION
Following up on https://github.com/wazuh/wazuh-puppet/pull/31, here's a patch to manage the basic items of the wazuh-api configuration from puppet.