### PR TITLE
Enable HTTPS in wazuh-api

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -216,19 +216,6 @@ class wazuh::server (
       ensure  => $api_package_version
     }
 
-    # wazuh-api config.js
-    # this hash is currently only covering the basic config section of config.js
-    # TODO: allow customization of the entire config.js
-    # for reference: https://documentation.wazuh.com/current/user-manual/api/configuration.html
-    file { '/var/ossec/api/configuration/config.js':
-      content => template($api_config_template),
-      owner   => 'root',
-      group   => 'ossec',
-      mode    => '0750',
-      require => Package[$wazuh::params::api_package],
-      notify  => Service[$wazuh::params::api_service],
-    }
-
     if $wazuh_api_enable_https {
       validate_string($wazuh_api_server_crt, $wazuh_api_server_key)
       file { '/var/ossec/api/configuration/ssl/server.key':
@@ -248,6 +235,19 @@ class wazuh::server (
         require => Package[$wazuh::params::api_package],
         notify  => Service[$wazuh::params::api_service],
       }
+    }
+
+    # wazuh-api config.js
+    # this hash is currently only covering the basic config section of config.js
+    # TODO: allow customization of the entire config.js
+    # for reference: https://documentation.wazuh.com/current/user-manual/api/configuration.html
+    file { '/var/ossec/api/configuration/config.js':
+      content => template($api_config_template),
+      owner   => 'root',
+      group   => 'ossec',
+      mode    => '0750',
+      require => Package[$wazuh::params::api_package],
+      notify  => Service[$wazuh::params::api_service],
     }
 
     service { $wazuh::params::api_service:

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -34,6 +34,9 @@ class wazuh::server (
   $manage_epel_repo                    = true,
   $manage_client_keys                  = 'export',
   $install_wazuh_api                   = false,
+  $wazuh_api_enable_https              = false,
+  $wazuh_api_server_crt                = undef,
+  $wazuh_api_server_key                = undef,
   $manage_nodejs                       = true,
   $nodejs_repo_url_suffix              = '6.x',
   $agent_auth_password                 = undef,
@@ -224,6 +227,27 @@ class wazuh::server (
       mode    => '0750',
       require => Package[$wazuh::params::api_package],
       notify  => Service[$wazuh::params::api_service],
+    }
+
+    if $wazuh_api_enable_https {
+      validate_string($wazuh_api_server_crt, $wazuh_api_server_key)
+      file { '/var/ossec/api/configuration/ssl/server.key':
+        content => $wazuh_api_server_key,
+        owner   => 'root',
+        group   => 'ossec',
+        mode    => '0600',
+        require => Package[$wazuh::params::api_package],
+        notify  => Service[$wazuh::params::api_service],
+      }
+
+      file { '/var/ossec/api/configuration/ssl/server.crt':
+        content => $wazuh_api_server_crt,
+        owner   => 'root',
+        group   => 'ossec',
+        mode    => '0600',
+        require => Package[$wazuh::params::api_package],
+        notify  => Service[$wazuh::params::api_service],
+      }
     }
 
     service { $wazuh::params::api_service:


### PR DESCRIPTION
This PR is to enable https as described in https://documentation.wazuh.com/current/user-manual/api/configuration.html#manually-enable-https-support and https://documentation.wazuh.com/current/user-manual/api/configuration.html#configuration-script.

Changes are bound to a feature flag disabled by default, therefore it's backwards-compatible.