### PR TITLE
Profile name for Centos 7 is not _server, it's _common like RHEL7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -129,7 +129,7 @@ class wazuh::params {
                 $wodle_openscap_content = {
                   'ssg-centos-7-ds.xml' => {
                     'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
+                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
                 }
               }
               }


### PR DESCRIPTION
The name of the profile in ssg-centos-7-ds.xml is xccdf_org.ssgproject.content_profile_common not xccdf_org.ssgproject.content_profile_server