### PR TITLE
Puppet 3.8/Ubuntu Trusty compatibility (agent + master)

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -106,10 +106,12 @@ class wazuh::client(
     notify  => Service[$agent_service_name],
   }
 
+  Concat::Fragment {
+    target => 'ossec.conf',
+    notify => Service[$agent_service_name]
+  }
+
   concat::fragment {
-    default:
-      target => 'ossec.conf',
-      notify => Service[$agent_service_name];
     'ossec.conf_header':
       order   => 00,
       content => "<ossec_config>\n";

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -87,7 +87,7 @@ class wazuh::params {
               $server_package = 'wazuh-manager'
               $api_service = 'wazuh-api'
               $api_package = 'wazuh-api'
-              $wodle_openscap_content = undef
+              $wodle_openscap_content = {}
             }
         default: {
           fail("Module ${module_name} is not supported on ${::operatingsystem}")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,11 @@ class wazuh::params {
       $processlist_mode = '0440'
       $processlist_owner = 'root'
       $processlist_group = 'ossec'
+      
+      $package_subtree = '3.x'
 
       # this hash is currently only covering the basic config section of config.js
+
       # TODO: allow customization of the entire config.js
       # for reference: https://documentation.wazuh.com/current/user-manual/api/configuration.html
       $api_config_params = [

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -165,8 +165,8 @@ class wazuh::params {
               if ( $::operatingsystemrelease =~ /^(23|24|25).*/ ) {
                 $wodle_openscap_content = {
                   'ssg-fedora-ds.xml' => {
-                    type => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',]
+                    'type' => 'xccdf',
+                    'profiles' => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',]
                 },
               }
               }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,7 @@
 # Repo installation
 class wazuh::repo (
   $redhat_manage_epel = true,
+  $package_subtree    = '',
 ) {
 
   case $::osfamily {
@@ -15,20 +16,19 @@ class wazuh::repo (
         server => 'pgp.mit.edu'
       }
       case $::lsbdistcodename {
-        /(precise|trusty|vivid|wily|xenial|yakketi)/: {
+        /(precise|trusty|vivid|wily|xenial|yakkety|bionic)/: {
 
           apt::source { 'wazuh':
             ensure   => present,
             comment  => 'This is the WAZUH Ubuntu repository',
-            location => 'https://packages.wazuh.com/apt',
-            release  => $::lsbdistcodename,
+            location => "https://packages.wazuh.com/${package_subtree}/apt",
+            release  => 'stable',
             repos    => 'main',
             include  => {
               'src' => false,
               'deb' => true,
             },
           }
-
         }
         /^(jessie|wheezy|stretch|sid)$/: {
           apt::source { 'wazuh':
@@ -81,6 +81,7 @@ class wazuh::repo (
               $baseurl  = 'https://packages.wazuh.com/yum/fc/$releasever/$basearch'
               $gpgkey   = 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
           }
+          default: { fail('This ossec module has not been tested on your distribution') }
         }
       }
       # Set up OSSEC repo

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -32,6 +32,7 @@ class wazuh::server (
   $api_config_params                   = $::wazuh::params::api_config_params,
   $manage_repos                        = true,
   $manage_epel_repo                    = true,
+  $package_subtree                     = $::wazuh::params::package_subtree,
   $manage_client_keys                  = 'export',
   $install_wazuh_api                   = false,
   $wazuh_api_enable_https              = false,
@@ -78,7 +79,10 @@ class wazuh::server (
 
   if $manage_repos {
     # TODO: Allow filtering of EPEL requirement
-    class { 'wazuh::repo': redhat_manage_epel => $manage_epel_repo }
+    class { 'wazuh::repo':
+      redhat_manage_epel => $manage_epel_repo,
+      package_subtree    => $package_subtree,
+    }
     if $::osfamily == 'Debian' {
       Class['wazuh::repo'] -> Class['apt::update'] -> Package[$wazuh::params::server_package]
     } else {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -219,7 +219,10 @@ class wazuh::server (
     validate_bool($manage_nodejs)
     if $manage_nodejs {
       validate_string($nodejs_repo_url_suffix)
-      class { '::nodejs': repo_url_suffix => $nodejs_repo_url_suffix }
+      class { '::nodejs':
+        repo_url_suffix        => $nodejs_repo_url_suffix,
+        legacy_debian_symlinks => false,
+      }
       Class['nodejs'] -> Package[$wazuh::params::api_package]
     }
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -54,6 +54,10 @@ class wazuh::server (
   $wazuh_manager_verify_manager_ssl    = false,
   $wazuh_manager_server_crt            = undef,
   $wazuh_manager_server_key            = undef,
+  $wazuh_cluster_enable                = false,
+  $wazuh_cluster_name                  = 'wazuh',
+  $wazuh_cluster_master_hostname       = undef,
+  $wazuh_cluster_key                   = undef,
 ) inherits wazuh::params {
   validate_bool(
     $ossec_active_response, $ossec_rootcheck,
@@ -274,4 +278,10 @@ class wazuh::server (
     }
   }
 
+  ### Wazuh cluster
+  if $wazuh_cluster_enable {
+    validate_string($wazuh_cluster_name)
+    validate_string($wazuh_cluster_key)
+    validate_string($wazuh_cluster_master_hostname)
+  }
 }

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -67,3 +67,20 @@
     <log_alert_level>3</log_alert_level>
     <email_alert_level><%= @ossec_email_alert_level %></email_alert_level>
   </alerts>
+
+<% if @wazuh_cluster_enable %>
+  <cluster>
+    <name><%= @wazuh_cluster_name %></name>
+    <node_name><%= @hostname %></node_name>
+    <key><%= @wazuh_cluster_key %></key>
+    <node_type><%- if @hostname == @wazuh_cluster_master_hostname -%>master<%- else -%>client<%- end -%></node_type>
+    <port>1516</port>
+    <bind_addr>0.0.0.0</bind_addr>
+    <nodes>
+      <node><%= @wazuh_cluster_master_hostname %></node>
+    </nodes>
+    <hidden>no</hidden>
+    <disabled>no</disabled>
+  </cluster>
+<% end %>
+


### PR DESCRIPTION
Fixed two bugs that affected compatibilty in our own infrastructure:

* Puppet 3.8 does not support the `default` syntax in resource
  declarations, so instead use `Concat::Fragment` (uppercased) to
  declare resource defaults.
* `$wodle_openscap_content` was being declared as `undef` for
  unsupported OSes, which caused an undefined-method error on that
  variable in the template `fragments/_wodle_openscap.erb`.

FWIW, the `wazuh::agent` module appears to be fully compatible with Puppet 3.8 except for this small change, and the `puppet3-compat` branch does not appear to be maintained. We do not have the future parser enabled on our puppet master.