### PR TITLE
Add manage_package param; fixes for AmazonLinux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -294,3 +294,4 @@ Jose Luis Ruiz <jose@wazuh.com>:
   * Set the same file permissions than the installed package, fixed #41
   * Adding the ability to set "type" attribute for "ignore" tag, fixed #19
   * Adding support to OracleLinux, Fixed #43
+  * Add manage_package option on client.pp and server.pp

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -116,22 +116,29 @@ class wazuh::params {
             '/var/log/httpd/error_log'  => 'apache'
           }
           case $::operatingsystem {
+            'Amazon': {
+              # Amazon is based on Centos-6 with some improvements
+              # taken from RHEL-7 but uses SysV-Init, not Systemd.
+              # Probably best to leave this undef until we can
+              # write/find a release-specific file.
+              $wodle_openscap_content = undef
+           }
             'CentOS': {
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
                 $wodle_openscap_content = {
                   'ssg-centos-6-ds.xml' => {
                     'type' => 'xccdf',
                     profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
+                  }
                 }
-              }
               }
               if ( $::operatingsystemrelease =~ /^7.*/ ) {
                 $wodle_openscap_content = {
                   'ssg-centos-7-ds.xml' => {
                     'type' => 'xccdf',
                     profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
+                  }
                 }
-              }
               }
             }
             /^(RedHat|OracleLinux)$/: {
@@ -140,22 +147,22 @@ class wazuh::params {
                   'ssg-rhel-6-ds.xml' => {
                     'type' => 'xccdf',
                     profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
-                },
-                'cve-redhat-6-ds.xml' => {
-                'type' => 'xccdf',
+                  },
+                  'cve-redhat-6-ds.xml' => {
+                    'type' => 'xccdf',
                   }
-              }
+                }
               }
               if ( $::operatingsystemrelease =~ /^7.*/ ) {
                 $wodle_openscap_content = {
                   'ssg-rhel-7-ds.xml' => {
                     'type' => 'xccdf',
                     profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
-                },
-                'cve-redhat-7-ds.xml' => {
-                'type' => 'xccdf',
+                  },
+                  'cve-redhat-7-ds.xml' => {
+                    'type' => 'xccdf',
                   }
-              }
+                }
               }
             }
             'Fedora': {
@@ -164,16 +171,16 @@ class wazuh::params {
                   'ssg-fedora-ds.xml' => {
                     type => 'xccdf',
                     profiles => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',]
-                },
-              }
+                  },
+                }
               }
             }
             default: { fail('This ossec module has not been tested on your distribution') }
-            }
           }
+        }
         default: { fail('This ossec module has not been tested on your distribution') }
+      }
     }
-  }
     'windows': {
       $config_file = regsubst(sprintf('c:/Program Files (x86)/ossec-agent/ossec.conf'), '\\\\', '/')
       $shared_agent_config_file = regsubst(sprintf('c:/Program Files (x86)/ossec-agent/shared/agent.conf'), '\\\\', '/')


### PR DESCRIPTION
Closes: #50 
We need to install packages outside of standard repos.  Also, we're running AmazonLinux.

Update: removed errant dependency pointed out by @hex2a and left `$wodle_openscap_content = undef` until I can find/write an Amazon-specific openscap file.

Update2: expanded description

Package resources may be declared only once. Therefore, two modules which depend on the same package cannot both declare that package resource. (At least) one of them has to defer package installation. The usual way to manage that deferral is to support a boolean attribute, usually called $manage_package which defaults to true but skips package installation if set to false.