### PR TITLE
Fix the $manage_repos attribute.

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -62,9 +62,9 @@ class wazuh::client(
         } else {
           Class['wazuh::repo'] -> Package[$agent_package_name]
         }
-      }
-      package { $agent_package_name:
-        ensure => $agent_package_version
+        package { $agent_package_name:
+          ensure => $agent_package_version
+        }
       }
     }
     'windows' : {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -86,11 +86,10 @@ class wazuh::server (
       Class['wazuh::repo'] -> Package[$wazuh::params::server_package]
     }
 
-  }
-
-  # install package
-  package { $wazuh::params::server_package:
-    ensure  => $server_package_version
+    # install package
+    package { $wazuh::params::server_package:
+      ensure  => $server_package_version
+    }
   }
 
   file {


### PR DESCRIPTION
Closes: #50 

@jlruizmlg [intended](https://github.com/wazuh/wazuh-puppet/issues/50#issuecomment-350917597) for the `$manage_repos` attribute to control whether this module installs the package (either [wazuh-agent](https://github.com/wazuh/wazuh-puppet/blob/master/manifests/client.pp#L66) or [wazuh-manager](https://github.com/wazuh/wazuh-puppet/blob/master/manifests/server.pp#L92), as appropriate).

This PR moves the `package` resource into the `if $manage_repos {` conditional block.