### PR TITLE
Reserved words should be quoted

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -171,7 +171,7 @@ class wazuh::params {
               if ( $::operatingsystemrelease =~ /^(23|24|25).*/ ) {
                 $wodle_openscap_content = {
                   'ssg-fedora-ds.xml' => {
-                    type => 'xccdf',
+                    'type' => 'xccdf',
                     profiles => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',]
                   },
                 }


### PR DESCRIPTION
Fixes:
```
Use of reserved word: type, must be quoted if intended to be a String value at /etc/puppetlabs/code/environments/staging/modules/wazuh/manifests/params.pp:174:21
```