### PR TITLE
fix default value for array

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,7 +1,7 @@
 # Main ossec server config
 class wazuh::server (
   $smtp_server                         = undef,
-  $ossec_emailto                       = undef,
+  $ossec_emailto                       = [],
   $ossec_emailfrom                     = "wazuh@${::domain}",
   $ossec_active_response               = true,
   $ossec_rootcheck                     = true,


### PR DESCRIPTION
You validate below that it should be an array. But the default and undef. Causes 
`` Error while evaluating a Function Call, nil is not an Array.  It looks to be a NilClass (file: /etc/puppetlabs/code/environments/wazuh/modules/wazuh/manifests/server.pp, line: 74, column: 5)``