### PR TITLE
refac(description) remove undefined repotype variable

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -48,7 +48,7 @@ class wazuh::repo (
         }
       # Set up OSSEC repo
       yumrepo { 'wazuh':
-        descr    => "WAZUH OSSEC Repository - www.wazuh.com # ${repotype}",
+        descr    => "WAZUH OSSEC Repository - www.wazuh.com",
         enabled  => true,
         gpgcheck => 1,
         gpgkey   => $gpgkey,


### PR DESCRIPTION
Constantly rewrites the repo description and restarting the service
Repotype isn't defined so I don't think we need that.
``Notice: /Stage[main]/Wazuh::Repo/Yumrepo[wazuh]/descr: descr changed 'WAZUH OSSEC Repository - www.wazuh.com #' to 'WAZUH OSSEC Repository - www.wazuh.com # '``