### PR TITLE
Feature/agent auth cert key

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -31,6 +31,8 @@ class wazuh::client(
   $manage_client_keys          = 'export',
   $agent_auth_password         = undef,
   $wazuh_manager_root_ca_pem   = undef,
+  $wazuh_agent_cert            = undef,
+  $wazuh_agent_key             = undef,
   $agent_seed                  = undef,
   $max_clients                 = 3000,
   $ar_repeated_offenders       = '',
@@ -163,10 +165,32 @@ class wazuh::client(
         require => Package[$agent_package_name],
       }
 
-      $agent_auth_command = "${agent_auth_base_command} -v /var/ossec/etc/rootCA.pem"
-    } else {
-      $agent_auth_command = $agent_auth_base_command
+      $agent_auth_option_manager = "-v /var/ossec/etc/rootCA.pem"
     }
+
+    # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-agents-via-ssl
+    if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
+      validate_string($wazuh_agent_cert)
+      validate_string($wazuh_agent_key)
+      file { '/var/ossec/etc/sslagent.cert':
+        owner   => $wazuh::params::keys_owner,
+        group   => $wazuh::params::keys_group,
+        mode    => $wazuh::params::keys_mode,
+        content => $wazuh_agent_cert,
+        require => Package[$agent_package_name],
+      }
+      file { '/var/ossec/etc/sslagent.key':
+        owner   => $wazuh::params::keys_owner,
+        group   => $wazuh::params::keys_group,
+        mode    => $wazuh::params::keys_mode,
+        content => $wazuh_agent_key,
+        require => Package[$agent_package_name],
+      }
+
+      $agent_auth_option_agent = "-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key"
+    }
+
+    $agent_auth_command = "$agent_auth_base_command $agent_auth_option_manager $agent_auth_option_agent"
 
     if $agent_auth_password {
       exec { 'agent-auth-with-pwd':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -124,7 +124,7 @@ class wazuh::params {
               # Probably best to leave this undef until we can
               # write/find a release-specific file.
               $wodle_openscap_content = undef
-           }
+            }
             'CentOS': {
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
                 $wodle_openscap_content = {


### PR DESCRIPTION
Allow managing and using agent SSL keys and certs when using "manage_client_keys == 'authd'" 