### PR TITLE
Add syslog port & level support level to manager configuration

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -64,7 +64,7 @@ class wazuh::client(
           Class['wazuh::repo'] -> Package[$agent_package_name]
         }
         package { $agent_package_name:
-          ensure => $agent_package_version
+          ensure => $agent_package_version, # lint:ignore:security_package_pinned_version
         }
       }
     }
@@ -80,7 +80,7 @@ class wazuh::client(
       }
 
       package { $agent_package_name:
-        ensure          => $agent_package_version,
+        ensure          => $agent_package_version, # lint:ignore:security_package_pinned_version
         provider        => 'windows',
         source          => 'C:/wazuh-winagent-v2.1.1-1.exe',
         install_options => [ '/S' ],  # Nullsoft installer silent installation
@@ -196,16 +196,16 @@ class wazuh::client(
     }
   }
   # Manage firewall
- if $manage_firewall {
-   include firewall
-   firewall { '1514 wazuh-agent':
-     dport  => $ossec_server_port,
-     proto  => $ossec_server_protocol,
-     action => 'accept',
-     state  => [
-       'NEW',
-       'RELATED',
-       'ESTABLISHED'],
-   }
+  if $manage_firewall {
+    include firewall
+    firewall { '1514 wazuh-agent':
+      dport  => $ossec_server_port,
+      proto  => $ossec_server_protocol,
+      action => 'accept',
+      state  => [
+        'NEW',
+        'RELATED',
+        'ESTABLISHED'],
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -124,7 +124,7 @@ class wazuh::params {
               # Probably best to leave this undef until we can
               # write/find a release-specific file.
               $wodle_openscap_content = undef
-           }
+            }
             'CentOS': {
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
                 $wodle_openscap_content = {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -43,6 +43,8 @@ class wazuh::server (
   $agent_auth_password                 = undef,
   $ar_repeated_offenders               = '',
   $syslog_output                       = false,
+  $syslog_output_level                 = 2,
+  $syslog_output_port                  = 514,
   $syslog_output_server                = undef,
   $syslog_output_format                = undef,
   $enable_wodle_openscap               = false,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -89,7 +89,7 @@ class wazuh::server (
 
     # install package
     package { $wazuh::params::server_package:
-      ensure  => $server_package_version
+      ensure  => $server_package_version, # lint:ignore:security_package_pinned_version
     }
   }
 
@@ -214,7 +214,7 @@ class wazuh::server (
     }
 
     package { $wazuh::params::api_package:
-      ensure  => $api_package_version
+      ensure => $api_package_version, # lint:ignore:security_package_pinned_version
     }
 
     if $wazuh_api_enable_https {
@@ -261,16 +261,16 @@ class wazuh::server (
     }
   }
   # Manage firewall
-   if $manage_firewall {
-     include firewall
-     firewall { '1514 wazuh-manager':
-       dport  => $ossec_server_port,
-       proto  => $ossec_server_protocol,
-       action => 'accept',
-       state  => [
-         'NEW',
-         'RELATED',
-         'ESTABLISHED'],
+  if $manage_firewall {
+    include firewall
+    firewall { '1514 wazuh-manager':
+      dport  => $ossec_server_port,
+      proto  => $ossec_server_protocol,
+      action => 'accept',
+      state  => [
+        'NEW',
+        'RELATED',
+        'ESTABLISHED'],
     }
   }
 }

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -26,7 +26,9 @@
 <%- if @syslog_output -%>
   <syslog_output>
     <server><%= @syslog_output_server %></server>
+    <port><%= @syslog_output_port %></port>
     <format><%= @syslog_output_format %></format>
+    <level><%= @syslog_output_level %></level>
   </syslog_output>
 <%- end -%>
 <%- if @use_mysql -%>

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -3,11 +3,11 @@
     <alerts_log>yes</alerts_log>
     <logall>no</logall>
     <logall_json>no</logall_json>
-  <% if @ossec_emailnotification -%>
+  <%- if @ossec_emailnotification -%>
     <email_notification>yes</email_notification>
-    <% @ossec_emailto.each do |emailto| -%>
+    <%- @ossec_emailto.each do |emailto| -%>
     <email_to><%= emailto %></email_to>
-    <% end -%>
+    <%- end -%>
     <smtp_server><%= @smtp_server %></smtp_server>
     <email_from><%= @ossec_emailfrom %></email_from>
     <email_maxperhour><%= @ossec_email_maxperhour %></email_maxperhour>


### PR DESCRIPTION
Current template for the manager's ossec.conf file does not allow the specification of the destination port nor of the alert level.  This adds both.

Additionally, several puppet-lint nits were cleaned up (whitespace changes)