### PR TITLE
Grouping agents

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -24,6 +24,7 @@ class wazuh::client(
   $selinux                         = false,
   $agent_name                      = $::hostname,
   $agent_ip_address                = $::ipaddress,
+  $agent_group                     = 'default',
   $manage_repo                     = true,
   $manage_epel_repo                = true,
   $agent_package_name              = $::wazuh::params::agent_package,
@@ -157,7 +158,8 @@ class wazuh::client(
     }
 
     # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
-    $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${agent_name} -D /var/ossec/"
+
+    $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${ossec_server_address} -A ${agent_name} -G ${agent_group} -D /var/ossec/"
     if $wazuh_manager_root_ca_pem != undef {
       validate_string($wazuh_manager_root_ca_pem)
       file { '/var/ossec/etc/rootCA.pem':

--- a/metadata.json
+++ b/metadata.json
@@ -92,7 +92,7 @@
       "version_range": ">= 3.0.0 < 4.0.0"
     },
     {
-      "name": "puppet/firewall",
+      "name": "puppetlabs/firewall",
       "version_range": ">= 1.7.0"
     }
   ]


### PR DESCRIPTION
[agent-auth](https://documentation.wazuh.com/3.x/user-manual/reference/tools/agent-auth.html) has `-G <group>` option for setting the group for centralized configuration.
