### PR TITLE
Fixing process_list.erb performance

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -107,8 +107,6 @@ class wazuh::params {
           $api_service = 'wazuh-api'
           $api_package = 'wazuh-api'
           $service_has_status  = true
-          $ossec_service_provider = 'redhat'
-          $api_service_provider = 'redhat'
 
           $default_local_files = {
             '/var/log/messages'         => 'syslog',
@@ -128,6 +126,8 @@ class wazuh::params {
             }
             'CentOS': {
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
+                $ossec_service_provider = 'redhat'
+                $api_service_provider = 'redhat'
                 $wodle_openscap_content = {
                   'ssg-centos-6-ds.xml' => {
                     'type' => 'xccdf',
@@ -136,6 +136,8 @@ class wazuh::params {
                 }
               }
               if ( $::operatingsystemrelease =~ /^7.*/ ) {
+                $ossec_service_provider = 'systemd'
+                $api_service_provider = 'systemd'
                 $wodle_openscap_content = {
                   'ssg-centos-7-ds.xml' => {
                     'type' => 'xccdf',
@@ -146,6 +148,8 @@ class wazuh::params {
             }
             /^(RedHat|OracleLinux)$/: {
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
+                $ossec_service_provider = 'redhat'
+                $api_service_provider = 'redhat'
                 $wodle_openscap_content = {
                   'ssg-rhel-6-ds.xml' => {
                     'type' => 'xccdf',
@@ -157,6 +161,8 @@ class wazuh::params {
                 }
               }
               if ( $::operatingsystemrelease =~ /^7.*/ ) {
+                $ossec_service_provider = 'systemd'
+                $api_service_provider = 'systemd'
                 $wodle_openscap_content = {
                   'ssg-rhel-7-ds.xml' => {
                     'type' => 'xccdf',
@@ -170,6 +176,8 @@ class wazuh::params {
             }
             'Fedora': {
               if ( $::operatingsystemrelease =~ /^(23|24|25).*/ ) {
+                $ossec_service_provider = 'redhat'
+                $api_service_provider = 'redhat'
                 $wodle_openscap_content = {
                   'ssg-fedora-ds.xml' => {
                     'type' => 'xccdf',

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,7 +29,6 @@ class wazuh::server (
   $ossec_server_port                   = '1514',
   $ossec_server_protocol               = 'udp',
   $ossec_authd_enabled                 = true,
-  $ossec_restart_command               = '/var/ossec/bin/ossec-control restart',
   $ossec_integratord_enabled           = false,
   $server_package_version              = 'installed',
   $api_package_version                 = 'installed',
@@ -283,10 +282,4 @@ class wazuh::server (
         'ESTABLISHED'],
     }
   }
-
-  exec{ 'ossec-restart':
-    command => $ossec_restart_command,
-    require   => Package[$wazuh::params::server_package],
-  }
-
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,6 +29,7 @@ class wazuh::server (
   $ossec_server_port                   = '1514',
   $ossec_server_protocol               = 'udp',
   $ossec_authd_enabled                 = true,
+  $ossec_restart_command               = '/var/ossec/bin/ossec-control restart',
   $ossec_integratord_enabled           = false,
   $server_package_version              = 'installed',
   $api_package_version                 = 'installed',
@@ -282,4 +283,10 @@ class wazuh::server (
         'ESTABLISHED'],
     }
   }
+
+  exec{ 'ossec-restart':
+    command => $ossec_restart_command,
+    require   => Package[$wazuh::params::server_package],
+  }
+
 }


### PR DESCRIPTION
Hello team,

This PR solves issue #91 

When we execute a manifest to install a Wazuh manager the following list of processes is loaded:

https://github.com/wazuh/wazuh-puppet/blob/master/templates/process_list.erb

On the server.pp

https://github.com/wazuh/wazuh-puppet/blob/master/manifests/server.pp#L117

We can see how the template is added according to the enabled daemons, in this case, **authd** and **integratord**. 

```
[root@centos-1 vagrant]# cat /var/ossec/bin/.process_list
# This file managed by Puppet.
# Any changes will be overwritten
AUTH_DAEMON=ossec-authd
INTEGRATOR_DAEMON=ossec-integratord
```

But if we check ossec-control status:

```
[root@centos-1 vagrant]# /var/ossec/bin/ossec-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
ossec-monitord is running...
ossec-logcollector is running...
ossec-remoted is running...
ossec-syscheckd is running...
ossec-analysisd is running...
ossec-maild not running...
ossec-execd is running...
wazuh-db is running...
ossec-integratord not running...
ossec-authd not running...
```
And the corresponding processes do not start (**In the tests done on Debian it did work**).

If we perform a restart for example by means of the command `/var/ossec/bin/ossec.control restart`, the demons do start after launching the manifest, solving the problem. 

```
[root@centos-1 vagrant]# /var/ossec/bin/ossec-control status
wazuh-clusterd not running...
wazuh-modulesd is running...
ossec-monitord is running...
ossec-logcollector is running...
ossec-remoted is running...
ossec-syscheckd is running...
ossec-analysisd is running...
ossec-maild is running...
ossec-execd is running...
wazuh-db is running...
ossec-integratord is running...
ossec-authd is running...
```

And the agents will be able to register without any problems. 

Regards,

Alfonso Ruiz-Bravo