### PR TITLE
Updating params.pp and _common.erb so all the options of localfile can be used

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,16 +47,14 @@ class wazuh::params {
           $service_has_status  = false
           $ossec_service_provider = undef
           $api_service_provider = undef
-
-          $default_local_files = {
-            '/var/log/syslog'                      => 'syslog',
-            '/var/log/kern.log'                    => 'syslog',
-            '/var/log/auth.log'                    => 'syslog',
-            '/var/log/mail.log'                    => 'syslog',
-            '/var/log/dpkg.log'                    => 'syslog',
-            '/var/ossec/logs/active-responses.log' => 'syslog',
-          }
-
+          $default_local_files = [
+            {  'location' => '/var/log/syslog' , 'log_format' => 'syslog'},
+            {  'location' => '/var/log/kern.log' , 'log_format' => 'syslog'},
+            {  'location' => '/var/log/auth.log' , 'log_format' => 'syslog'},
+            {  'location' => '/var/log/mail.log' , 'log_format' => 'syslog'},
+            {  'location' => '/var/log/dpkg.log', 'log_format' => 'syslog'},
+            {  'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog'},
+          ]
           case $::lsbdistcodename {
             'xenial': {
               $server_service = 'wazuh-manager'
@@ -108,14 +106,14 @@ class wazuh::params {
           $api_package = 'wazuh-api'
           $service_has_status  = true
 
-          $default_local_files = {
-            '/var/log/messages'         => 'syslog',
-            '/var/log/secure'           => 'syslog',
-            '/var/log/maillog'          => 'syslog',
-            '/var/log/yum.log'          => 'syslog',
-            '/var/log/httpd/access_log' => 'apache',
-            '/var/log/httpd/error_log'  => 'apache'
-          }
+          $default_local_files =[
+              {  'location' => '/var/log/messages' , 'log_format' => 'syslog'},
+              {  'location' => '/var/log/secure' , 'log_format' => 'syslog'},
+              {  'location' => '/var/log/maillog', 'log_format' => 'syslog'},
+              {  'location' => '/var/log/yum.log' , 'log_format' => 'syslog'},
+              {  'location' => '/var/log/httpd/access_log' , 'log_format' => 'apache'},
+              {  'location' => '/var/log/httpd/error_log' , 'log_format' => 'apache'},
+          ]
           case $::operatingsystem {
             'Amazon': {
               # Amazon is based on Centos-6 with some improvements
@@ -216,7 +214,12 @@ class wazuh::params {
       # TODO
       $validate_cmd_conf = undef
       # Pushed by shared agent config now
-      $default_local_files = {}
+      $default_local_files =  [
+        {'location' => 'Security' , 'log_format' => 'eventchannel', 'query' => 'Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID != 4703 and EventID != 4907]'},
+        {'location' => 'System' , 'log_format' =>  'eventlog'  },
+        {'location' => 'active-response\active-responses.log' , 'log_format' =>  'syslog'  },
+      ]
+
     }
   default: { fail('This ossec module has not been tested on your distribution') }
   }

--- a/templates/fragments/_common.erb
+++ b/templates/fragments/_common.erb
@@ -48,10 +48,36 @@
 
 
   <!-- Files to monitor (localfiles) -->
-<%- @ossec_local_files.sort.each do |path, format| -%>
+<%- @ossec_local_files.each do |localfile| -%>
   <localfile>
-    <log_format><%= format %></log_format>
-    <location><%= path %></location>
+    <log_format><%= localfile['log_format'] %></log_format>
+    <%- if localfile.key?('location') -%>
+    <location><%= localfile['location'] %></location>
+    <%- end -%>
+    <%- if localfile.key?('frequency') -%>
+    <frequency><%= localfile['frequency'] %></frequency>
+    <%- end -%>
+    <%- if localfile.key?('query') -%>
+    <query><%= localfile['query'] %></query>
+    <%- end -%>
+    <%- if localfile.key?('command') -%>
+    <command><%= localfile['command'] %></command>
+    <%- end -%>
+    <%- if localfile.key?('alias') -%>
+    <alias><%= localfile['alias'] %></alias>
+    <%- end -%>
+    <%- if localfile.key?('label') -%>
+    <label <%- if localfile['label'].key?('attributes') and localfile['label']['attributes'].key?('key')  -%>key="<%= localfile['label']['attributes']['key'] %>"<%- end -%> ><%= localfile['label']['value']%></label>
+    <%- end -%>
+    <%- if localfile.key?('only-future-events') -%>
+    <only-future-events><%= localfile['only-future-events'] %></only-future-events>
+    <%- end -%>
+    <%- if localfile.key?('target') -%>
+    <target><%= localfile['target'] %></target>
+    <%- end -%>
+    <%- if localfile.key?('out_format') -%>
+    <out_format <%- if localfile['out_format'].key?('attributes') and  localfile['out_format']['attributes'].key?('target') -%>target="<%= localfile['out_format']['attributes']['target'] %>"<%- end -%> ><%= localfile['out_format']['value'] %></out_format>
+    <%- end -%>
   </localfile>
 <%- end %>
 


### PR DESCRIPTION
Localfile  is used to configure the collection of log data from files, Windows events, and from the output of commands. Right now it has 10 options (location, command, alias, frequency) but only two can be used with Puppet (location and log_format). This PR solves that. It allows to define the options for localfiles using hashes. For example if we wanted to define  the following localfiles to ossec.conf: 
~~~~
<localfile>
  <log_format>syslog</log_format>
  <location>/var/log/syslog</location>
</localfile>

<localfile>
  <log_format>command</log_format>
  <command>df -P</command>
  <frequency>360</frequency>
</localfile>

<localfile>
  <log_format>syslog</log_format>
  <location>/var/log/auth.log</location>
  <target>agent,custom_socket</target>
  <out_format target="custom_socket">$(timestamp %Y-%m-%d %H:%M:%S): $(log)</out_format>
</localfile>

~~~~
We would write:
~~~~
[
            {  'location' => '/var/log/syslog' , 'log_format' => 'syslog'},
            {  'command' => 'df -P' , 'log_format' => 'command',  'frequency => '360'},
            {  'location' => '/var/log/auth.log' , 'log_format' => 'syslog', 'target' => 'agent,custom_socket', 'out_format' => {'value' => '$(timestamp %Y-%m-%d %H:%M:%S): $(log)' , 'attributes' => {'target' => 'custom_socket'}}},
    
]
~~~~
This PR also closes #77 , because it adds the [ default configuration for Windows ](https://github.com/wazuh/wazuh/blob/master/src/win32/ossec.conf) to the Wazuh agent.