### PR TITLE
Feature/agent auth cert key

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -37,6 +37,8 @@ class wazuh::client(
   $manage_client_keys              = 'authd',
   $agent_auth_password             = undef,
   $wazuh_manager_root_ca_pem       = undef,
+  $wazuh_agent_cert                = undef,
+  $wazuh_agent_key                 = undef,
   $agent_seed                      = undef,
   $max_clients                     = 3000,
   $ar_repeated_offenders           = '',
@@ -178,11 +180,33 @@ class wazuh::client(
           content => $wazuh_manager_root_ca_pem,
           require => Package[$agent_package_name],
         }
-
-        $agent_auth_command = "${agent_auth_base_command} -v /var/ossec/etc/rootCA.pem"
-      } else {
-        $agent_auth_command = $agent_auth_base_command
+       $agent_auth_option_manager = "-v /var/ossec/etc/rootCA.pem"
       }
+
+			# https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-agents-via-ssl
+			if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
+				validate_string($wazuh_agent_cert)
+				validate_string($wazuh_agent_key)
+				file { '/var/ossec/etc/sslagent.cert':
+					owner   => $wazuh::params::keys_owner,
+					group   => $wazuh::params::keys_group,
+					mode    => $wazuh::params::keys_mode,
+					content => $wazuh_agent_cert,
+					require => Package[$agent_package_name],
+				}
+				file { '/var/ossec/etc/sslagent.key':
+					owner   => $wazuh::params::keys_owner,
+					group   => $wazuh::params::keys_group,
+					mode    => $wazuh::params::keys_mode,
+					content => $wazuh_agent_key,
+					require => Package[$agent_package_name],
+				}
+
+				$agent_auth_option_agent = "-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key"
+			}
+
+			$agent_auth_command = "$agent_auth_base_command $agent_auth_option_manager $agent_auth_option_agent"
+
 
       if $agent_auth_password {
         exec { 'agent-auth-with-pwd':

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -183,29 +183,29 @@ class wazuh::client(
        $agent_auth_option_manager = "-v /var/ossec/etc/rootCA.pem"
       }
 
-			# https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-agents-via-ssl
-			if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
-				validate_string($wazuh_agent_cert)
-				validate_string($wazuh_agent_key)
-				file { '/var/ossec/etc/sslagent.cert':
-					owner   => $wazuh::params::keys_owner,
-					group   => $wazuh::params::keys_group,
-					mode    => $wazuh::params::keys_mode,
-					content => $wazuh_agent_cert,
-					require => Package[$agent_package_name],
-				}
-				file { '/var/ossec/etc/sslagent.key':
-					owner   => $wazuh::params::keys_owner,
-					group   => $wazuh::params::keys_group,
-					mode    => $wazuh::params::keys_mode,
-					content => $wazuh_agent_key,
-					require => Package[$agent_package_name],
-				}
+    # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-agents-via-ssl
+    if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
+      validate_string($wazuh_agent_cert)
+      validate_string($wazuh_agent_key)
+      file { '/var/ossec/etc/sslagent.cert':
+        owner   => $wazuh::params::keys_owner,
+        group   => $wazuh::params::keys_group,
+        mode    => $wazuh::params::keys_mode,
+        content => $wazuh_agent_cert,
+        require => Package[$agent_package_name],
+      }
+      file { '/var/ossec/etc/sslagent.key':
+        owner   => $wazuh::params::keys_owner,
+        group   => $wazuh::params::keys_group,
+        mode    => $wazuh::params::keys_mode,
+        content => $wazuh_agent_key,
+        require => Package[$agent_package_name],
+      }
 
-				$agent_auth_option_agent = "-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key"
-			}
+      $agent_auth_option_agent = "-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key"
+    }
 
-			$agent_auth_command = "$agent_auth_base_command $agent_auth_option_manager $agent_auth_option_agent"
+    $agent_auth_command = "$agent_auth_base_command $agent_auth_option_manager $agent_auth_option_agent"
 
 
       if $agent_auth_password {


### PR DESCRIPTION
This PR was made by @brettmiller - https://github.com/wazuh/wazuh-puppet/pull/70. Because of conflicts a new PR was needed.
It allows to define the content of the agent.cert and the agent.key at the Wazuh agent so it is possible to [verify the agent using SSL ](https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#host-verification-using-ssl) .

In order to try the changes that includes this PR a manifest need to be defined specifying the content of the agent.cert and agent.key:

~~~~
node "debian-n" {

  class { "wazuh::client":
    ossec_server_ip => "x.x.y.y",
    wazuh_manager_root_ca_pem =>'-----BEGIN CERTIFICATE-----
    MIIDKzCCAhOgAwIBAgIJAIrW2nHTFcjWMA0GCSqGSIb3DQEBCwUAMCwxCzAJBgNV
    -----END CERTIFICATE-----
    ',
    wazuh_agent_key_content =>'-----BEGIN PRIVATE KEY-----
    MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC/heNpsQXGmOzG
    -----END PRIVATE KEY-----
    ',
    wazuh_agent_cert_content =>'-----BEGIN CERTIFICATE-----
    MIIC7TCCAdUCCQDegENY9CSgyjANBgkqhkiG9w0BAQsFADAsMQswCQYDVQQGEwJV
    -----END CERTIFICATE-----
    ',
  }

}
~~~~