### PR TITLE
Use $name to define wazuh::addlog unique resource

### DIFF
--- a/manifests/addlog.pp
+++ b/manifests/addlog.pp
@@ -1,15 +1,15 @@
 # Wazuh App Copyright (C) 2018 Wazuh Inc. (License GPLv2)
 #Define a log-file to add to ossec
-define wazuh::addlog(
+define wazuh::addlog (
   $logfile      = undef,
   $logtype      = 'syslog',
-  $logcommand      = undef,
+  $logcommand   = undef,
   $commandalias = undef,
   $frequency    = undef,
 ) {
   require wazuh::params
 
-  concat::fragment { "ossec.conf_localfile-${logfile}":
+  concat::fragment { "ossec.conf_localfile-${name}":
     target  => 'ossec.conf',
     content => template('wazuh/fragments/_localfile.erb'),
     order   => 20,


### PR DESCRIPTION
Since $logfile is optional and not guaranteed to be defined, let’s use
$name to define a unique addlog resource. Otherwise you’ll get a
collision if you add more than one thing that’s not a log, such as a
command.