### PR TITLE
Make Wazuh Agent able to register and report to different IPs

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -354,7 +354,7 @@ class wazuh::agent(
 
       # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
 
-      $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${ossec_reporting_ip}"
+      $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${ossec_registration_ip}"
 
       if $wazuh_manager_root_ca_pem != undef {
         validate_string($wazuh_manager_root_ca_pem)

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -82,9 +82,8 @@ class wazuh::params_agent {
 
       ## Server block configuration
 
-      $ossec_ip                          = 'YOUR_MANAGER_IP'
-      $ossec_hostname                    = undef
-      $ossec_address                     = undef
+      $ossec_registration_ip             = undef
+      $ossec_reporting_ip                = undef
       $ossec_port                        = '1514'
       $ossec_protocol                    = 'udp'
       $ossec_notify_time                 = 10

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -82,8 +82,8 @@ class wazuh::params_agent {
 
       ## Server block configuration
 
-      $ossec_registration_ip             = undef
-      $ossec_reporting_ip                = undef
+      $wazuh_register_endpoint           = undef
+      $wazuh_reporting_endpoint          = undef
       $ossec_port                        = '1514'
       $ossec_protocol                    = 'udp'
       $ossec_notify_time                 = 10

--- a/templates/wazuh_agent.conf.erb
+++ b/templates/wazuh_agent.conf.erb
@@ -1,13 +1,7 @@
   <client>
   <server>
-  <%- if @ossec_ip then -%>
-    <address><%= @ossec_ip %></address>
-  <%- end -%>
-  <%- if @ossec_hostname then -%>
-    <address><%= @ossec_hostname %></address>
-  <%- end -%>
-  <%- if @ossec_address then -%>
-    <address><%= @ossec_address %></address>
+  <%- if @ossec_reporting_ip then -%>
+    <address><%= @ossec_reporting_ip %></address>
   <%- end -%>
   <%- if @ossec_protocol then -%>
     <protocol><%= @ossec_protocol %></protocol>

--- a/templates/wazuh_agent.conf.erb
+++ b/templates/wazuh_agent.conf.erb
@@ -1,7 +1,7 @@
   <client>
   <server>
-  <%- if @ossec_reporting_ip then -%>
-    <address><%= @ossec_reporting_ip %></address>
+  <%- if @wazuh_reporting_endpoint then -%>
+    <address><%= @wazuh_reporting_endpoint %></address>
   <%- end -%>
   <%- if @ossec_protocol then -%>
     <protocol><%= @ossec_protocol %></protocol>


### PR DESCRIPTION
Hi team,

This PR fixes #110 , there are two new parameters `$ossec_registration_ip` which is used by authd to register the Agent and `$ossec_reporting_ip` which will establish to which IP will the agent report.

The parameters `$ossec_ip` and `$ossec_hostname` have been deprecated in favor of the new ones.

Best regards,

Jose