### PR TITLE
Fix integration when group is not specified

### DIFF
--- a/templates/fragments/_integration.erb
+++ b/templates/fragments/_integration.erb
@@ -12,7 +12,9 @@
     <% if @in_level != '' -%>
       <level><%= @in_level %></level>
     <% end %>
-    <group><%= @in_group %></group>
+    <% if @in_group != '' -%>
+      <group><%= @in_group %></group>
+    <% end %>  
     <% if @in_location != '' -%>
       <event_location><%= @in_location %></event_location>
     <% end %>


### PR DESCRIPTION
Using wazuh::integration seems to failed and dont send alert if we dont specify the optionnal group:

2019/08/04 19:26:11 ossec-integratord[15960] integrator.c:131 at OS_IntegratorD(): DEBUG: sending new alert.
2019/08/04 19:26:11 ossec-integratord[15960] integrator.c:209 at OS_IntegratorD(): DEBUG: skipping: group doesn't match
2019/08/04 19:26:11 ossec-integratord[15960] integrator.c:126 at OS_IntegratorD(): DEBUG: jqueue_next()

Group should be conditionnal in template