### PR TITLE
Adding Filebeat module and adapted Elasticsearch IP 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,15 @@ All notable changes to this project will be documented in this file.
 
 - Update to Wazuh version 3.9.4_7.2.0
 
-- Added Filebeat module and adapted Elasticsearch IP[rshad](https://github.com/rshad) [PR#144] (https://github.com/wazuh/wazuh-puppet/pull/144)
+- Added Filebeat module and adapted Elasticsearch IP ([rshad](https://github.com/rshad)) [PR#144](https://github.com/wazuh/wazuh-puppet/pull/144)
 
-- Added Kitchen testing for Wazuh deployment with Puppet. [rshad](https://github.com/rshad) [PR#139](https://github.com/wazuh/wazuh-puppet/pull/139)
+- Added Kitchen testing for Wazuh deployment with Puppet. ([rshad](https://github.com/rshad)) [PR#139](https://github.com/wazuh/wazuh-puppet/pull/139)
 
-- Moved command and email_alert templates to templates/fragments. [rshad](https://github.com/rshad) [PR#143](https://github.com/wazuh/wazuh-puppet/pull/143).
+- Moved command and email_alert templates to templates/fragments. ([rshad](https://github.com/rshad)) [PR#143](https://github.com/wazuh/wazuh-puppet/pull/143).
 
-- Fixed integration when group is not specified. [TheoPoc](https://github.com/TheoPoc) [PR#142](https://github.com/wazuh/wazuh-puppet/pull/142).
+- Fixed integration when group is not specified. ([TheoPoc](https://github.com/TheoPoc)) [PR#142](https://github.com/wazuh/wazuh-puppet/pull/142).
 
-- Added Ubuntu as a recognized operating system to Puppet manifests. [rshad](https://github.com/rshad) [PR#141](https://github.com/wazuh/wazuh-puppet/pull/141).
+- Added Ubuntu as a recognized operating system to Puppet manifests. ([rshad](https://github.com/rshad)) [PR#141](https://github.com/wazuh/wazuh-puppet/pull/141).
 
 - Made Wazuh Agent able to register and report to different IPs. ([@jm404](https://github.com/jm404)) [PR#136](https://github.com/wazuh/wazuh-puppet/pull/136).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ All notable changes to this project will be documented in this file.
 
 - Added Kitchen testing for Wazuh deployment with Puppet. ([rshad](https://github.com/rshad)) [PR#139](https://github.com/wazuh/wazuh-puppet/pull/139)
 
-- Moved command and email_alert templates to templates/fragments. ([rshad](https://github.com/rshad)) [PR#143](https://github.com/wazuh/wazuh-puppet/pull/143).
+- Moved command and email_alert templates to templates/fragments. ([rshad](https://github.com/rshad)) [PR#143](https://github.com/wazuh/wazuh-puppet/pull/143)
 
-- Fixed integration when group is not specified. ([TheoPoc](https://github.com/TheoPoc)) [PR#142](https://github.com/wazuh/wazuh-puppet/pull/142).
+- Fixed integration when group is not specified. ([TheoPoc](https://github.com/TheoPoc)) [PR#142](https://github.com/wazuh/wazuh-puppet/pull/142)
 
-- Added Ubuntu as a recognized operating system to Puppet manifests. ([rshad](https://github.com/rshad)) [PR#141](https://github.com/wazuh/wazuh-puppet/pull/141).
+- Added Ubuntu as a recognized operating system to Puppet manifests. ([rshad](https://github.com/rshad)) [PR#141](https://github.com/wazuh/wazuh-puppet/pull/141)
 
-- Made Wazuh Agent able to register and report to different IPs. ([@jm404](https://github.com/jm404)) [PR#136](https://github.com/wazuh/wazuh-puppet/pull/136).
+- Made Wazuh Agent able to register and report to different IPs. ([@jm404](https://github.com/jm404)) [PR#136](https://github.com/wazuh/wazuh-puppet/pull/136)
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - Update to Wazuh version 3.9.4_7.2.0
 
+- Added Filebeat module and adapted Elasticsearch IP[rshad](https://github.com/rshad) [PR#144] (https://github.com/wazuh/wazuh-puppet/pull/144)
+
+- Added Kitchen testing for Wazuh deployment with Puppet. [rshad](https://github.com/rshad) [PR#139](https://github.com/wazuh/wazuh-puppet/pull/139)
+
 - Moved command and email_alert templates to templates/fragments. [rshad](https://github.com/rshad) [PR#143](https://github.com/wazuh/wazuh-puppet/pull/143).
 
 - Fixed integration when group is not specified. [TheoPoc](https://github.com/TheoPoc) [PR#142](https://github.com/wazuh/wazuh-puppet/pull/142).

--- a/manifests/elasticsearch.pp
+++ b/manifests/elasticsearch.pp
@@ -17,7 +17,7 @@ class wazuh::elasticsearch (
   $elasticsearch_path_logs = '/var/log/elasticsearch',
 
 
-  $elasticsearch_ip = 'localhost',
+  $elasticsearch_ip = '<Put Elasticsearch IP>',
   $elasticsearch_port = '9200',
   $elasticsearch_discovery_option = 'discovery.type: single-node',
   $elasticsearch_cluster_initial_master_nodes = "#cluster.initial_master_nodes: ['es-node-01']",

--- a/manifests/elasticsearch.pp
+++ b/manifests/elasticsearch.pp
@@ -27,8 +27,6 @@ class wazuh::elasticsearch (
 
 ){
 
-  class {'wazuh::repo_elastic':}
-
   # install package
   package { 'Installing elasticsearch...':
     ensure => $elasticsearch_version,

--- a/manifests/elasticsearch.pp
+++ b/manifests/elasticsearch.pp
@@ -17,7 +17,7 @@ class wazuh::elasticsearch (
   $elasticsearch_path_logs = '/var/log/elasticsearch',
 
 
-  $elasticsearch_ip = '<Put Elasticsearch IP>',
+  $elasticsearch_ip = '<YOUR_ELASTICSEARCH_IP>',
   $elasticsearch_port = '9200',
   $elasticsearch_discovery_option = 'discovery.type: single-node',
   $elasticsearch_cluster_initial_master_nodes = "#cluster.initial_master_nodes: ['es-node-01']",

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 # Setup for Filebeat
 class wazuh::filebeat (
-  $filebeat_elasticsearch_ip = '<Put Elasticsearch IP>',
+  $filebeat_elasticsearch_ip = '<YOUR_ELASTICSEARCH_IP>',
   $filebeat_elasticsearch_port = '9200',
   $elasticsearch_server_ip = "\"${filebeat_elasticsearch_ip}:${filebeat_elasticsearch_port}\"",
 
@@ -45,17 +45,9 @@ class wazuh::filebeat (
     notify  => Service['filebeat']
   }
 
-  class directory_tree {
-
-    # or you can assign them to a variable and use them in the resource
-    $whisper_dirs = [ '/usr/share/filebeat/module/wazuh',
-                    ]
-
-    file { $whisper_dirs:
-      ensure => 'directory',
-      mode   => '0755',
-    }
-
+  file { '/usr/share/filebeat/module/wazuh':
+    ensure => 'directory',
+    mode   => '0755',
   }
 
   service { 'filebeat':

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -1,7 +1,5 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 # Setup for Filebeat
-class {'wazuh::repo_elastic':}
-
 class wazuh::filebeat (
   $filebeat_elasticsearch_ip = 'localhost',
   $filebeat_elasticsearch_port = '9200',
@@ -15,6 +13,7 @@ class wazuh::filebeat (
   $wazuh_module_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){
 
+  class {'wazuh::repo_elastic':}
 
   package { 'Installing Filebeat...':
     ensure => $filebeat_version,

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -1,5 +1,7 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 # Setup for Filebeat
+class {'wazuh::repo_elastic':}
+
 class wazuh::filebeat (
   $filebeat_elasticsearch_ip = 'localhost',
   $filebeat_elasticsearch_port = '9200',
@@ -10,7 +12,9 @@ class wazuh::filebeat (
   $filebeat_version = '7.2.0',
   $wazuh_app_version = '3.9.4_7.2.0',
   $wazuh_extensions_version = 'v3.9.4',
+  $wazuh_module_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){
+
 
   package { 'Installing Filebeat...':
     ensure => $filebeat_version,
@@ -32,23 +36,23 @@ class wazuh::filebeat (
     notify  => Service['filebeat']
   }
 
-  exec { 'Installing filebeat module ...':
-    path    => '/usr/bin',
-    command => "curl -s https://packages-dev.wazuh.com/3.x/filebeat/wazuh-filebeat-0.1.tar.gz | tar -xvz -C /usr/share/filebeat/module",
+  exec { 'Installing filebeat module ... Downloading package':
+    command => "/usr/bin/wget -c https://packages-dev.wazuh.com/3.x/filebeat/${$wazuh_module_filebeat_module} -P /root/",
+  }
+
+  exec { 'Unpackaging ...':
+    command => "/bin/tar -xzvf /root/wazuh-filebeat-0.1.tar.gz -C /usr/share/filebeat/module",
     notify  => Service['filebeat']
   }
 
   class directory_tree {
 
     # or you can assign them to a variable and use them in the resource
-    $whisper_dirs = [ '/usr/share/filebeat', '/usr/share/filebeat/module',
-                      '/usr/share/filebeat/module/wazuh',
+    $whisper_dirs = [ '/usr/share/filebeat/module/wazuh',
                     ]
 
     file { $whisper_dirs:
       ensure => 'directory',
-      owner  => 'root',
-      group  => 'wheel',
       mode   => '0755',
     }
 
@@ -58,6 +62,4 @@ class wazuh::filebeat (
     ensure => running,
     enable => true,
   }
-
-
 }

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -38,13 +38,21 @@ class wazuh::filebeat (
     notify  => Service['filebeat']
   }
 
-  directory "/usr/share/filebeat/module/wazuh" do
-    owner 'root'
-    group 'root'
-    recursive true
-    action :create
-    mode '0755'
-  end
+  class directory_tree {
+
+    # or you can assign them to a variable and use them in the resource
+    $whisper_dirs = [ '/usr/share/filebeat', '/usr/share/filebeat/module',
+                      '/usr/share/filebeat/module/wazuh',
+                    ]
+
+    file { $whisper_dirs:
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'wheel',
+      mode   => '0755',
+    }
+
+  }
 
   service { 'filebeat':
     ensure => running,

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -10,7 +10,7 @@ class wazuh::filebeat (
   $filebeat_version = '7.2.0',
   $wazuh_app_version = '3.9.4_7.2.0',
   $wazuh_extensions_version = 'v3.9.4',
-  $wazuh_module_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
+  $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){
 
   class {'wazuh::repo_elastic':}
@@ -37,7 +37,7 @@ class wazuh::filebeat (
 
   exec { 'Installing filebeat module ... Downloading package':
    path    => '/usr/bin',
-   command => "curl -o /root/${$wazuh_module_filebeat_module} https://packages-dev.wazuh.com/3.x/filebeat/${$wazuh_module_filebeat_module}",
+   command => "curl -o /root/${$wazuh_filebeat_module} https://packages-dev.wazuh.com/3.x/filebeat/${$wazuh_filebeat_module}",
   }
 
   exec { 'Unpackaging ...':

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -36,7 +36,8 @@ class wazuh::filebeat (
   }
 
   exec { 'Installing filebeat module ... Downloading package':
-    command => "/usr/bin/wget -c https://packages-dev.wazuh.com/3.x/filebeat/${$wazuh_module_filebeat_module} -P /root/",
+   path    => '/usr/bin',
+   command => "curl -o /root/${$wazuh_module_filebeat_module} https://packages-dev.wazuh.com/3.x/filebeat/${$wazuh_module_filebeat_module}",
   }
 
   exec { 'Unpackaging ...':

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -1,7 +1,7 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 # Setup for Filebeat
 class wazuh::filebeat (
-  $filebeat_elasticsearch_ip = 'localhost',
+  $filebeat_elasticsearch_ip = '<Put Elasticsearch IP>',
   $filebeat_elasticsearch_port = '9200',
   $elasticsearch_server_ip = "\"${filebeat_elasticsearch_ip}:${filebeat_elasticsearch_port}\"",
 

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -32,6 +32,20 @@ class wazuh::filebeat (
     notify  => Service['filebeat']
   }
 
+  exec { 'Installing filebeat module ...':
+    path    => '/usr/bin',
+    command => "curl -s https://packages-dev.wazuh.com/3.x/filebeat/wazuh-filebeat-0.1.tar.gz | tar -xvz -C /usr/share/filebeat/module",
+    notify  => Service['filebeat']
+  }
+
+  directory "/usr/share/filebeat/module/wazuh" do
+    owner 'root'
+    group 'root'
+    recursive true
+    action :create
+    mode '0755'
+  end
+
   service { 'filebeat':
     ensure => running,
     enable => true,

--- a/manifests/kibana.pp
+++ b/manifests/kibana.pp
@@ -6,7 +6,7 @@ class wazuh::kibana (
   $kibana_version = '7.2.0',
   $kibana_app_version = '3.9.4_7.2.0',
 
-  $kibana_elasticsearch_ip = '<Put Elasticsearch IP>',
+  $kibana_elasticsearch_ip = '<YOUR_ELASTICSEARCH_IP>',
   $kibana_elasticsearch_port = '9200',
 
   $kibana_server_port = '5601',

--- a/manifests/kibana.pp
+++ b/manifests/kibana.pp
@@ -6,7 +6,7 @@ class wazuh::kibana (
   $kibana_version = '7.2.0',
   $kibana_app_version = '3.9.4_7.2.0',
 
-  $kibana_elasticsearch_ip = 'localhost',
+  $kibana_elasticsearch_ip = '<Put Elasticsearch IP>',
   $kibana_elasticsearch_port = '9200',
 
   $kibana_server_port = '5601',


### PR DESCRIPTION
Hi all!

**Resolution for https://github.com/wazuh/wazuh-puppet/issues/145**

This PR includes the corresponding changes to add `Filebeat` module to `Wazuh` installation using `Puppet`. We also adapted `Elasticsearch` IP so to not be assigned as `localhost` due to proven errors we got during the installation.

**Filebeat module installation**

https://github.com/wazuh/wazuh-puppet/blob/1301d408b350d150f40ea1e58dbace59119cc99a/manifests/filebeat.pp#L38-L51

**Adapting Elasticsearch IP in [Filebeat, Elasticsearch and Kibana] manifests**

https://github.com/wazuh/wazuh-puppet/blob/1301d408b350d150f40ea1e58dbace59119cc99a/manifests/filebeat.pp#L4

https://github.com/wazuh/wazuh-puppet/blob/1301d408b350d150f40ea1e58dbace59119cc99a/manifests/elasticsearch.pp#L20

https://github.com/wazuh/wazuh-puppet/blob/1301d408b350d150f40ea1e58dbace59119cc99a/manifests/kibana.pp#L9

Kind regards,

Rshad