### PR TITLE
Update outdated dependency versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,27 +10,27 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0 < 6.0.0"
+      "version_requirement": ">= 1.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.0.0 < 6.0.0"
+      "version_requirement": ">= 1.0.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">= 2.0.0 < 7.0.0"
+      "version_requirement": ">= 2.0.0 < 8.0.0"
     },
     {
       "name": "puppet/selinux",
-      "version_requirement": ">= 0.8.0 < 3.0.0"
+      "version_requirement": ">= 0.8.0 < 4.0.0"
     },
     {
       "name": "puppet/nodejs",
-      "version_requirement": ">= 3.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 8.0.0"
     },
     {
       "name": "puppetlabs/firewall",
-      "version_requirement": ">= 1.7.0 < 2.0.0"
+      "version_requirement": ">= 1.7.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I have updated the dependency versions for the external Forge modules (which were all out of date). This will allow Forge module users who keep their Forge modules up to date to be able to actually use the wazuh module.