### PR TITLE
Fix the Wazuh agent installation on Windows

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -1,12 +1,13 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 # Setup for ossec client
-class wazuh::agent(
+class wazuh::agent (
 
   # Versioning and package names
 
   $agent_package_version             = $wazuh::params_agent::agent_package_version,
   $agent_package_name                = $wazuh::params_agent::agent_package_name,
   $agent_service_name                = $wazuh::params_agent::agent_service_name,
+  $agent_service_ensure              = $wazuh::params_agent::agent_service_ensure,
 
   # Manage repository
 
@@ -139,28 +140,27 @@ class wazuh::agent(
   ## Windows
 
   $download_path                     = $wazuh::params_agent::download_path,
-
-
 ) inherits wazuh::params_agent {
   # validate_bool(
   #   $ossec_active_response, $ossec_rootcheck,
-  #   $selinux, $manage_repo, 
+  #   $selinux, $manage_repo,
   # )
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)
   validate_string($agent_package_name)
   validate_string($agent_service_name)
 
-  if (($manage_client_keys == 'yes')){
-      if ( ( $wazuh_register_endpoint == undef ) ) {
-        fail('The $wazuh_register_endpoint parameter is needed in order to register the Agent.')
-      }
+  if $manage_client_keys == 'yes' {
+    if $wazuh_register_endpoint == undef {
+      fail('The $wazuh_register_endpoint parameter is needed in order to register the Agent.')
+    }
   }
 
+  # Package installation
   case $::kernel {
-    'Linux' : {
+    'Linux': {
       if $manage_repo {
-        class { 'wazuh::repo':}
+        class { 'wazuh::repo': }
         if $::osfamily == 'Debian' {
           Class['wazuh::repo'] -> Class['apt::update'] -> Package[$agent_package_name]
         } else {
@@ -171,64 +171,88 @@ class wazuh::agent(
         ensure => $agent_package_version, # lint:ignore:security_package_pinned_version
       }
     }
-    'windows' : {
+    'windows': {
+      $install_options = [
+        '/q',
+        "WAZUH_MANAGER=$wazuh_reporting_endpoint",
+        "WAZUH_PROTOCOL=$ossec_protocol",
+      ]
 
-      file { 'wazuh-agent':
-          path               => "${download_path}wazuh-agent-${agent_package_version}.msi",
-          owner              => 'Administrator',
-          group              => 'Administrators',
-          mode               => '0774',
-          source             => "http://packages.wazuh.com/3.x/windows/wazuh-agent-${agent_package_version}.msi",
-          source_permissions => ignore
+      if $manage_client_keys == 'yes' {
+        $registration_options = [
+          "WAZUH_REGISTRATION_SERVER=$wazuh_register_endpoint"
+        ]
+      } else {
+        $registration_options = []
       }
 
-      if ( $manage_client_keys == 'yes' ) {
-        package { $agent_package_name:
-          ensure          => $agent_package_version, # lint:ignore:security_package_pinned_version
-          provider        => 'windows',
-          source          => "${download_path}/wazuh-agent-${agent_package_version}.msi",
-          install_options => [ '/q', "ADDRESS=${wazuh_register_endpoint}", "AUTHD_SERVER=${wazuh_register_endpoint}" ],
-          require         => File["${download_path}wazuh-agent-${agent_package_version}.msi"],
-        }
+      if $agent_auth_password {
+        $registration_auth = [
+          "WAZUH_REGISTRATION_PASSWORD=$agent_auth_password"
+        ]
+      } else {
+        $registration_auth = []
       }
-      else {
-        package { $agent_package_name:
-          ensure          => $agent_package_version, # lint:ignore:security_package_pinned_version
-          provider        => 'windows',
-          source          => "${download_path}wazuh-agent-${agent_package_version}.msi",
-          install_options => [ '/q' ],  # silent installation
-          require         => File["${download_path}wazuh-agent-${agent_package_version}.msi"],
-        }
+
+      file { $download_path:
+        ensure => directory,
+      }
+
+      -> file { 'wazuh-agent':
+        path               => "${download_path}wazuh-agent-${agent_package_version}.msi",
+        owner              => 'Administrator',
+        group              => 'Administrators',
+        mode               => '0774',
+        source             => "http://packages.wazuh.com/3.x/windows/wazuh-agent-${agent_package_version}.msi",
+        source_permissions => ignore
+      }
+
+      # We dont need to pin the package version on Windows since we install if from the right MSI.
+      -> package { $agent_package_name:
+        ensure          => 'installed',
+        provider        => 'windows',
+        source          => "${download_path}\\wazuh-agent-${agent_package_version}.msi",
+        install_options => concat($install_options, $registration_options, $registration_auth),
       }
     }
     default: { fail('OS not supported') }
   }
 
   ## ossec.conf generation concats
-
-  case $::operatingsystem{
-    'Redhat', 'redhat':{
-      $apply_template_os = 'rhel'
-      if ( $::operatingsystemrelease     =~ /^7.*/ ){
-        $rhel_version = '7'
-      }elsif ( $::operatingsystemrelease =~ /^6.*/ ){
-        $rhel_version = '6'
-      }elsif ( $::operatingsystemrelease =~ /^5.*/ ){
-        $rhel_version = '5'
-      }else{
-        fail('This ossec module has not been tested on your distribution')
+  case $::kernel {
+    'Linux': {
+      case $::osfamily {
+        'Redhat', 'redhat': {
+          $apply_template_os = 'rhel'
+          if ( $::operatingsystemrelease =~ /^7.*/ ) {
+            $rhel_version = '7'
+          } elsif ( $::operatingsystemrelease =~ /^6.*/ ) {
+            $rhel_version = '6'
+          } elsif ( $::operatingsystemrelease =~ /^5.*/ ) {
+            $rhel_version = '5'
+          } else {
+            fail('This ossec module has not been tested on your distribution')
+          }
+        }
+        'Debian', 'debian', 'Ubuntu', 'ubuntu': {
+          $apply_template_os = 'debian'
+          if ( $::lsbdistcodename == 'wheezy') or ($::lsbdistcodename == 'jessie') {
+            $debian_additional_templates = 'yes'
+          }
+        }
+        'Amazon': {
+          $apply_template_os = 'amazon'
+        }
+        'CentOS', 'Centos', 'centos': {
+          $apply_template_os = 'centos'
+        }
+        default: { fail('This ossec module has not been tested on your distribution') }
       }
-    }'Debian', 'debian', 'Ubuntu', 'ubuntu':{
-      $apply_template_os = 'debian'
-      if ( $::lsbdistcodename == 'wheezy') or ($::lsbdistcodename == 'jessie'){
-        $debian_additional_templates = 'yes'
-      }
-    }'Amazon':{
-      $apply_template_os = 'amazon'
-    }'CentOS','Centos','centos':{
-      $apply_template_os = 'centos'
     }
-    default: { fail('This ossec module has not been tested on your distribution') }
+    'windows': {
+      $apply_template_os = 'windows'
+    }
+    default: { fail('OS not supported') }
   }
 
   concat { 'ossec.conf':
@@ -236,205 +260,207 @@ class wazuh::agent(
     owner   => $wazuh::params_agent::config_owner,
     group   => $wazuh::params_agent::config_group,
     mode    => $wazuh::params_agent::config_mode,
+    before  => Service[$agent_service_name],
     require => Package[$agent_package_name],
   }
 
   concat::fragment {
-    default:
-      target => 'ossec.conf';
     'ossec.conf_header':
+      target  => 'ossec.conf',
       order   => 00,
       before  => Service[$agent_service_name],
       content => "<ossec_config>\n";
     'ossec.conf_agent':
+      target  => 'ossec.conf',
       order   => 10,
       before  => Service[$agent_service_name],
       content => template($ossec_conf_template);
   }
-  if ($configure_rootcheck == true){
+
+  if ($configure_rootcheck == true) {
     concat::fragment {
-        'ossec.conf_rootcheck':
+      'ossec.conf_rootcheck':
         target  => 'ossec.conf',
         order   => 15,
         before  => Service[$agent_service_name],
         content => template($ossec_rootcheck_template);
     }
   }
-  if ($configure_wodle_openscap == true){
+  if ($configure_wodle_openscap == true) {
     concat::fragment {
-        'ossec.conf_openscap':
+      'ossec.conf_openscap':
         target  => 'ossec.conf',
         order   => 16,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_openscap_template);
     }
   }
-  if ($configure_wodle_cis_cat == true){
+  if ($configure_wodle_cis_cat == true) {
     concat::fragment {
-        'ossec.conf_cis_cat':
+      'ossec.conf_cis_cat':
         target  => 'ossec.conf',
         order   => 17,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_cis_cat_template);
     }
   }
-  if ($configure_wodle_osquery == true){
+  if ($configure_wodle_osquery == true) {
     concat::fragment {
-        'ossec.conf_osquery':
+      'ossec.conf_osquery':
         target  => 'ossec.conf',
         order   => 18,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_osquery_template);
     }
   }
-  if ($configure_wodle_syscollector == true){
+  if ($configure_wodle_syscollector == true) {
     concat::fragment {
-        'ossec.conf_syscollector':
+      'ossec.conf_syscollector':
         target  => 'ossec.conf',
         order   => 19,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_syscollector_template);
     }
   }
-  if ($configure_sca == true){
+  if ($configure_sca == true) {
     concat::fragment {
-        'ossec.conf_sca':
+      'ossec.conf_sca':
         target  => 'ossec.conf',
         order   => 25,
         before  => Service[$agent_service_name],
         content => template($ossec_sca_template);
     }
   }
-  if ($configure_syscheck == true){
+  if ($configure_syscheck == true) {
     concat::fragment {
-        'ossec.conf_syscheck':
+      'ossec.conf_syscheck':
         target  => 'ossec.conf',
         order   => 30,
         before  => Service[$agent_service_name],
         content => template($ossec_syscheck_template);
     }
   }
-  if ($configure_localfile == true){
+  if ($configure_localfile == true) {
     concat::fragment {
-        'ossec.conf_localfile':
+      'ossec.conf_localfile':
         target  => 'ossec.conf',
         order   => 35,
         before  => Service[$agent_service_name],
         content => template($ossec_localfile_template);
     }
   }
-  if ($configure_active_response == true){
+  if ($configure_active_response == true) {
     concat::fragment {
-        'ossec.conf_active_response':
+      'ossec.conf_active_response':
         target  => 'ossec.conf',
         order   => 40,
         before  => Service[$agent_service_name],
         content => template($ossec_active_response_template);
     }
   }
+
   concat::fragment {
-      'ossec.conf_footer':
+    'ossec.conf_footer':
       target  => 'ossec.conf',
       order   => 99,
       before  => Service[$agent_service_name],
       content => '</ossec_config>';
   }
 
-  if ($manage_client_keys == 'yes'){
-
-    if ($::kernel == 'Linux') {
-      # Is this really Linux only?
-
-      file { $::wazuh::params_agent::keys_file:
-        owner => $wazuh::params_agent::keys_owner,
-        group => $wazuh::params_agent::keys_group,
-        mode  => $wazuh::params_agent::keys_mode,
-      }
-
-      # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
-
-      $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${wazuh_register_endpoint}"
-
-      if $wazuh_manager_root_ca_pem != undef {
-        validate_string($wazuh_manager_root_ca_pem)
-        file { '/var/ossec/etc/rootCA.pem':
-          owner   => $wazuh::params::keys_owner,
-          group   => $wazuh::params::keys_group,
-          mode    => $wazuh::params::keys_mode,
-          content => $wazuh_manager_root_ca_pem,
-          require => Package[$agent_package_name],
+  # Agent registration and service setup
+  if ($manage_client_keys == 'yes') {
+    case $::kernel {
+      'Linux': {
+        file { $::wazuh::params_agent::keys_file:
+          owner => $wazuh::params_agent::keys_owner,
+          group => $wazuh::params_agent::keys_group,
+          mode  => $wazuh::params_agent::keys_mode,
         }
-        $agent_auth_option_manager = '-v /var/ossec/etc/rootCA.pem'
-      }elsif $wazuh_manager_root_ca_pem_path != undef {
-        validate_string($wazuh_manager_root_ca_pem)
-        $agent_auth_option_manager = "-v ${wazuh_manager_root_ca_pem_path}"
-      } else {
-        $agent_auth_option_manager = ''  # Avoid errors when compounding final command
-      }
 
-      if $agent_name != undef {
-        validate_string($agent_name)
-        $agent_auth_option_name = "-A \"${agent_name}\""
-      }else{
-        $agent_auth_option_name = ''
-      }
+        # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
 
-      if $agent_group != undef {
-        validate_string($agent_group)
-        $agent_auth_option_group = "-G \"${agent_group}\""
-      }else{
-        $agent_auth_option_group = ''
-      }
+        $agent_auth_base_command = "/var/ossec/bin/agent-auth -m ${wazuh_register_endpoint}"
 
-    # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-agents-via-ssl
-    if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
-      validate_string($wazuh_agent_cert)
-      validate_string($wazuh_agent_key)
-      file { '/var/ossec/etc/sslagent.cert':
-        owner   => $wazuh::params_agent::keys_owner,
-        group   => $wazuh::params_agent::keys_group,
-        mode    => $wazuh::params_agent::keys_mode,
-        content => $wazuh_agent_cert,
-        require => Package[$agent_package_name],
-      }
-      file { '/var/ossec/etc/sslagent.key':
-        owner   => $wazuh::params_agent::keys_owner,
-        group   => $wazuh::params_agent::keys_group,
-        mode    => $wazuh::params_agent::keys_mode,
-        content => $wazuh_agent_key,
-        require => Package[$agent_package_name],
-      }
-
-      $agent_auth_option_agent = '-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key'
-    }
-
-    if ($wazuh_agent_cert_path != undef) and ($wazuh_agent_key_path != undef) {
-      validate_string($wazuh_agent_cert_path)
-      validate_string($wazuh_agent_key_path)
-      $agent_auth_option_agent = "-x ${wazuh_agent_cert_path} -k ${wazuh_agent_key_path}"
-    }
-
-    $agent_auth_command = "${agent_auth_base_command} ${agent_auth_option_manager} ${agent_auth_option_name}\
-     ${agent_auth_option_group} ${agent_auth_option_agent}"
-
-      if $agent_auth_password {
-        exec { 'agent-auth-with-pwd':
-          command => "${agent_auth_command} -P '${agent_auth_password}'",
-          unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
-          require => Concat['ossec.conf'],
-          before  => Service[$agent_service_name],
+        if $wazuh_manager_root_ca_pem != undef {
+          validate_string($wazuh_manager_root_ca_pem)
+          file { '/var/ossec/etc/rootCA.pem':
+            owner   => $wazuh::params_agent::keys_owner,
+            group   => $wazuh::params_agent::keys_group,
+            mode    => $wazuh::params_agent::keys_mode,
+            content => $wazuh_manager_root_ca_pem,
+            require => Package[$agent_package_name],
           }
-      } else {
-        exec { 'agent-auth-without-pwd':
-          command => $agent_auth_command,
-          unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
-          require => Concat['ossec.conf'],
-          before  => Service[$agent_service_name],
+          $agent_auth_option_manager = '-v /var/ossec/etc/rootCA.pem'
+        } elsif $wazuh_manager_root_ca_pem_path != undef {
+          validate_string($wazuh_manager_root_ca_pem)
+          $agent_auth_option_manager = "-v ${wazuh_manager_root_ca_pem_path}"
+        } else {
+          $agent_auth_option_manager = ''  # Avoid errors when compounding final command
         }
-      }
-      if $wazuh_reporting_endpoint != undef {
+
+        if $agent_name != undef {
+          validate_string($agent_name)
+          $agent_auth_option_name = "-A \"${agent_name}\""
+        } else {
+          $agent_auth_option_name = ''
+        }
+
+        if $agent_group != undef {
+          validate_string($agent_group)
+          $agent_auth_option_group = "-G \"${agent_group}\""
+        } else {
+          $agent_auth_option_group = ''
+        }
+
+        # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-agents-via-ssl
+        if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
+          validate_string($wazuh_agent_cert)
+          validate_string($wazuh_agent_key)
+          file { '/var/ossec/etc/sslagent.cert':
+            owner   => $wazuh::params_agent::keys_owner,
+            group   => $wazuh::params_agent::keys_group,
+            mode    => $wazuh::params_agent::keys_mode,
+            content => $wazuh_agent_cert,
+            require => Package[$agent_package_name],
+          }
+          file { '/var/ossec/etc/sslagent.key':
+            owner   => $wazuh::params_agent::keys_owner,
+            group   => $wazuh::params_agent::keys_group,
+            mode    => $wazuh::params_agent::keys_mode,
+            content => $wazuh_agent_key,
+            require => Package[$agent_package_name],
+          }
+
+          $agent_auth_option_agent = '-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key'
+        }
+
+        if ($wazuh_agent_cert_path != undef) and ($wazuh_agent_key_path != undef) {
+          validate_string($wazuh_agent_cert_path)
+          validate_string($wazuh_agent_key_path)
+          $agent_auth_option_agent = "-x ${wazuh_agent_cert_path} -k ${wazuh_agent_key_path}"
+        }
+
+        $agent_auth_command = "${agent_auth_base_command} ${agent_auth_option_manager} ${agent_auth_option_name}\
+         ${agent_auth_option_group} ${agent_auth_option_agent}"
+
+        if $agent_auth_password {
+          exec { 'agent-auth-with-pwd':
+            command => "${agent_auth_command} -P '${agent_auth_password}'",
+            unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
+            require => Concat['ossec.conf'],
+            before  => Service[$agent_service_name],
+          }
+        } else {
+          exec { 'agent-auth-without-pwd':
+            command => $agent_auth_command,
+            unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
+            require => Concat['ossec.conf'],
+            before  => Service[$agent_service_name],
+          }
+        }
+
         service { $agent_service_name:
-          ensure    => running,
+          ensure    => $agent_service_ensure,
           enable    => true,
           hasstatus => $wazuh::params_agent::service_has_status,
           pattern   => $wazuh::params_agent::agent_service_name,
@@ -442,17 +468,28 @@ class wazuh::agent(
           require   => Package[$agent_package_name],
         }
       }
-    }
-  }
-
-  if ( ( $manage_client_keys != 'yes') or ( $wazuh_reporting_endpoint == undef ) ){
-    service { $agent_service_name:
-          ensure    => stopped,
-          enable    => false,
+      'windows': {
+        # Since the Wazuh agent registration is made by the MSI file on Windows,
+        # we don't need to register the agent and we simply start the service.
+        service { $agent_service_name:
+          ensure    => $agent_service_ensure,
+          enable    => true,
           hasstatus => $wazuh::params_agent::service_has_status,
-          pattern   => $agent_service_name,
+          pattern   => $wazuh::params_agent::agent_service_name,
           provider  => $wazuh::params_agent::ossec_service_provider,
           require   => Package[$agent_package_name],
+        }
+      }
+      default: { fail('OS not supported') }
+    }
+  } else {
+    service { $agent_service_name:
+      ensure    => stopped,
+      enable    => false,
+      hasstatus => $wazuh::params_agent::service_has_status,
+      pattern   => $agent_service_name,
+      provider  => $wazuh::params_agent::ossec_service_provider,
+      require   => Package[$agent_package_name],
     }
   }
 
@@ -464,6 +501,7 @@ class wazuh::agent(
       source_te => 'puppet:///modules/wazuh/ossec-logrotate.te',
     }
   }
+
   # Manage firewall
   if $manage_firewall {
     include firewall
@@ -474,8 +512,8 @@ class wazuh::agent(
       state  => [
         'NEW',
         'RELATED',
-        'ESTABLISHED'],
+        'ESTABLISHED',
+      ],
     }
   }
 }
-

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -1,229 +1,211 @@
 # Wazuh App Copyright (C) 2019 Wazuh Inc. (License GPLv2)
 # Wazuh-Agent configuration parameters
 class wazuh::params_agent {
+  $agent_package_version = '3.10.2-1'
+  $agent_service_ensure = 'running'
+
+  $agent_name = undef
+  $agent_group = undef
+
+  # Enable/Disable agent registration
+  $manage_client_keys = 'yes'
+
+  # Agents registration parameters
+  $wazuh_agent_cert = undef
+  $wazuh_agent_key = undef
+  $wazuh_agent_cert_path = undef
+  $wazuh_agent_key_path = undef
+  $agent_auth_password = undef
+  $wazuh_manager_root_ca_pem = undef
+  $wazuh_manager_root_ca_pem_path = undef
+
+  # ossec.conf generation variables
+  $configure_rootcheck = true
+  $configure_wodle_openscap = false
+  $configure_wodle_cis_cat = true
+  $configure_wodle_osquery = true
+  $configure_wodle_syscollector = true
+  $configure_sca = true
+  $configure_syscheck = true
+  $configure_localfile = true
+  $configure_active_response = true
+
+  # ossec.conf templates paths
+  $ossec_conf_template = 'wazuh/wazuh_agent.conf.erb'
+  $ossec_rootcheck_template = 'wazuh/fragments/_rootcheck.erb'
+  $ossec_wodle_openscap_template = 'wazuh/fragments/_wodle_openscap.erb'
+  $ossec_wodle_cis_cat_template = 'wazuh/fragments/_wodle_cis_cat.erb'
+  $ossec_wodle_osquery_template = 'wazuh/fragments/_wodle_osquery.erb'
+  $ossec_wodle_syscollector_template = 'wazuh/fragments/_wodle_syscollector.erb'
+  $ossec_sca_template = 'wazuh/fragments/_sca.erb'
+  $ossec_syscheck_template = 'wazuh/fragments/_syscheck.erb'
+  $ossec_localfile_template = 'wazuh/fragments/_localfile.erb'
+  $ossec_ruleset = 'wazuh/fragments/_ruleset.erb'
+  $ossec_auth = 'wazuh/fragments/_auth.erb'
+  $ossec_cluster = 'wazuh/fragments/_cluster.erb'
+  $ossec_active_response_template = 'wazuh/fragments/_default_activeresponse.erb'
+
+  # ossec.conf blocks
+
+  ## Server block configuration
+  $wazuh_register_endpoint = undef
+  $wazuh_reporting_endpoint = undef
+  $ossec_port = '1514'
+  $ossec_protocol = 'udp'
+  $ossec_notify_time = 10
+  $ossec_time_reconnect = 60
+  $ossec_auto_restart = 'yes'
+  $ossec_crypto_method = 'aes'
+
+  ## Buffers
+  $client_buffer_queue_size = 5000
+  $client_buffer_events_per_second = 500
+
+  ## localfile
+  $ossec_local_files = $::wazuh::params_agent::default_local_files
+
+  # OS specific configurations
   case $::kernel {
     'Linux': {
+      $agent_package_name = 'wazuh-agent'
+      $agent_service_name = 'wazuh-agent'
 
-# Versions  
+      # Wazuh config folders and modes
+      $config_file = '/var/ossec/etc/ossec.conf'
+      $shared_agent_config_file = '/var/ossec/etc/shared/agent.conf'
 
-      $agent_package_version             = '3.10.2-1'
-      $agent_package_name                = 'wazuh-agent'
-      $agent_service_name                = 'wazuh-agent'
+      $config_mode = '0640'
+      $config_owner = 'root'
+      $config_group = 'ossec'
 
-    # Authd Registration options
+      $keys_file = '/var/ossec/etc/client.keys'
+      $keys_mode = '0640'
+      $keys_owner = 'root'
+      $keys_group = 'ossec'
 
-      $manage_client_keys                = 'yes'  # Enable/Disable agent registration
-      $agent_name                        = undef
-      $agent_group                       = undef
-      $wazuh_agent_cert                  = undef
-      $wazuh_agent_key                   = undef
-      $wazuh_agent_cert_path             = undef
-      $wazuh_agent_key_path              = undef
-      $agent_auth_password               = undef
-      $wazuh_manager_root_ca_pem         = undef
+      $authd_pass_file = '/var/ossec/etc/authd.pass'
 
-      $wazuh_manager_root_ca_pem_path    = undef
+      $validate_cmd_conf = '/var/ossec/bin/verify-agent-conf -f %'
 
-    ## Wazuh config folders and modes
+      $processlist_file = '/var/ossec/bin/.process_list'
+      $processlist_mode = '0640'
+      $processlist_owner = 'root'
+      $processlist_group = 'ossec'
 
-      $config_file                       = '/var/ossec/etc/ossec.conf'
-      $shared_agent_config_file          = '/var/ossec/etc/shared/agent.conf'
+      # ossec.conf blocks
 
-      $config_mode                       = '0640'
-      $config_owner                      = 'root'
-      $config_group                      = 'ossec'
+      ## Rootcheck
+      $ossec_rootcheck_disabled = 'no'
+      $ossec_rootcheck_check_files = 'yes'
+      $ossec_rootcheck_check_trojans = 'yes'
+      $ossec_rootcheck_check_dev = 'yes'
+      $ossec_rootcheck_check_sys = 'yes'
+      $ossec_rootcheck_check_pids = 'yes'
+      $ossec_rootcheck_check_ports = 'yes'
+      $ossec_rootcheck_check_if = 'yes'
+      $ossec_rootcheck_frequency = 43200
+      $ossec_rootcheck_rootkit_files = '/var/ossec/etc/shared/rootkit_files.txt'
+      $ossec_rootcheck_rootkit_trojans = '/var/ossec/etc/shared/rootkit_trojans.txt'
+      $ossec_rootcheck_skip_nfs = 'yes'
 
-      $keys_file                         = '/var/ossec/etc/client.keys'
-      $keys_mode                         = '0640'
-      $keys_owner                        = 'root'
-      $keys_group                        = 'ossec'
+      # Wodles
 
-      $manage_firewall                   = false
-      $authd_pass_file                   = '/var/ossec/etc/authd.pass'
+      ## openscap
+      $wodle_openscap_disabled = 'no'
+      $wodle_openscap_timeout = '1800'
+      $wodle_openscap_interval = '1d'
+      $wodle_openscap_scan_on_start = 'yes'
 
-      $validate_cmd_conf                 = '/var/ossec/bin/verify-agent-conf -f %'
+      ## cis-cat
+      $wodle_ciscat_disabled = 'yes'
+      $wodle_ciscat_timeout = '1800'
+      $wodle_ciscat_interval = '1d'
+      $wodle_ciscat_scan_on_start = 'yes'
+      $wodle_ciscat_java_path = 'wodles/java'
+      $wodle_ciscat_ciscat_path = 'wodles/ciscat'
 
-      $processlist_file                  = '/var/ossec/bin/.process_list'
-      $processlist_mode                  = '0640'
-      $processlist_owner                 = 'root'
-      $processlist_group                 = 'ossec'
+      ## osquery
+      $wodle_osquery_disabled = 'yes'
+      $wodle_osquery_run_daemon = 'yes'
+      $wodle_osquery_log_path = '/var/log/osquery/osqueryd.results.log'
+      $wodle_osquery_config_path = '/etc/osquery/osquery.conf'
+      $wodle_osquery_add_labels = 'yes'
 
-    # ossec.conf generation parameters
+      ## syscollector
+      $wodle_syscollector_disabled = true
+      $wodle_syscollector_interval = '1d'
+      $wodle_syscollector_scan_on_start = 'yes'
+      $wodle_syscollector_hardware = 'yes'
+      $wodle_syscollector_os = 'yes'
+      $wodle_syscollector_network = 'yes'
+      $wodle_syscollector_packages = 'yes'
+      $wodle_syscollector_ports = 'yes'
+      $wodle_syscollector_processes = 'yes'
 
-      ## Ossec.conf generation variables
+      ## syscheck
+      $ossec_syscheck_disabled = 'no'
+      $ossec_syscheck_frequency = '43200'
+      $ossec_syscheck_scan_on_start = 'yes'
+      $ossec_syscheck_alert_new_files = undef
+      $ossec_syscheck_auto_ignore = undef
+      $ossec_syscheck_directories_1 = '/etc,/usr/bin,/usr/sbin'
+      $ossec_syscheck_directories_2 = '/bin,/sbin,/boot'
+      $ossec_syscheck_ignore_list = ['/etc/mtab',
+        '/etc/hosts.deny',
+        '/etc/mail/statistics',
+        '/etc/random-seed',
+        '/etc/random.seed',
+        '/etc/adjtime',
+        '/etc/httpd/logs',
+        '/etc/utmpx',
+        '/etc/wtmpx',
+        '/etc/cups/certs',
+        '/etc/dumpdates',
+        '/etc/svc/volatile',
+        '/sys/kernel/security',
+        '/sys/kernel/debug',
+        '/dev/core',
+      ]
+      $ossec_syscheck_ignore_type_1 = '^/proc'
+      $ossec_syscheck_ignore_type_2 = ".log$|.swp$"
 
-      $configure_rootcheck               = true
-      $configure_wodle_openscap          = true
-      $configure_wodle_cis_cat           = true
-      $configure_wodle_osquery           = true
-      $configure_wodle_syscollector      = true
-      $configure_sca                     = true
-      $configure_syscheck                = true
-      $configure_localfile               = true
-      $configure_active_response         = true
-
-
-    # ossec.conf templates paths
-      $ossec_conf_template               = 'wazuh/wazuh_agent.conf.erb'
-      $ossec_rootcheck_template          = 'wazuh/fragments/_rootcheck.erb'
-      $ossec_wodle_openscap_template     = 'wazuh/fragments/_wodle_openscap.erb'
-      $ossec_wodle_cis_cat_template      = 'wazuh/fragments/_wodle_cis_cat.erb'
-      $ossec_wodle_osquery_template      = 'wazuh/fragments/_wodle_osquery.erb'
-      $ossec_wodle_syscollector_template = 'wazuh/fragments/_wodle_syscollector.erb'
-      $ossec_sca_template                = 'wazuh/fragments/_sca.erb'
-      $ossec_syscheck_template           = 'wazuh/fragments/_syscheck.erb'
-      $ossec_localfile_template          = 'wazuh/fragments/_localfile.erb'
-      $ossec_ruleset                     = 'wazuh/fragments/_ruleset.erb'
-      $ossec_auth                        = 'wazuh/fragments/_auth.erb'
-      $ossec_cluster                     = 'wazuh/fragments/_cluster.erb'
-      $ossec_active_response_template    = 'wazuh/fragments/_default_activeresponse.erb'
-
-      ### Ossec.conf blocks
-
-      ## Server block configuration
-
-      $wazuh_register_endpoint           = undef
-      $wazuh_reporting_endpoint          = undef
-      $ossec_port                        = '1514'
-      $ossec_protocol                    = 'udp'
-      $ossec_notify_time                 = 10
-      $ossec_time_reconnect              = 60
-      $ossec_auto_restart                = 'yes'
-      $ossec_crypto_method               = 'aes'
-
-      $client_buffer_queue_size          = 5000
-      $client_buffer_events_per_second   = 500
-
-      # Rootcheck
-
-      $ossec_rootcheck_disabled          = 'no'
-      $ossec_rootcheck_check_files       = 'yes'
-      $ossec_rootcheck_check_trojans     = 'yes'
-      $ossec_rootcheck_check_dev         = 'yes'
-      $ossec_rootcheck_check_sys         = 'yes'
-      $ossec_rootcheck_check_pids        = 'yes'
-      $ossec_rootcheck_check_ports       = 'yes'
-      $ossec_rootcheck_check_if          = 'yes'
-      $ossec_rootcheck_frequency         = 43200
-      $ossec_rootcheck_rootkit_files     = '/var/ossec/etc/shared/rootkit_files.txt'
-      $ossec_rootcheck_rootkit_trojans   = '/var/ossec/etc/shared/rootkit_trojans.txt'
-      $ossec_rootcheck_skip_nfs          = 'yes'
-
-    ## Wodles
-
-      #openscap
-      $wodle_openscap_disabled           = 'no'
-      $wodle_openscap_timeout            = '1800'
-      $wodle_openscap_interval           = '1d'
-      $wodle_openscap_scan_on_start      = 'yes'
-
-      #cis-cat
-      $wodle_ciscat_disabled             = 'yes'
-      $wodle_ciscat_timeout              = '1800'
-      $wodle_ciscat_interval             = '1d'
-      $wodle_ciscat_scan_on_start        = 'yes'
-      $wodle_ciscat_java_path            = 'wodles/java'
-      $wodle_ciscat_ciscat_path          = 'wodles/ciscat'
-
-      #osquery
-
-      $wodle_osquery_disabled            = 'yes'
-      $wodle_osquery_run_daemon          = 'yes'
-      $wodle_osquery_log_path            = '/var/log/osquery/osqueryd.results.log'
-      $wodle_osquery_config_path         = '/etc/osquery/osquery.conf'
-      $wodle_osquery_add_labels          = 'yes'
-
-      #syscollector
-      $wodle_syscollector_disabled       = true
-      $wodle_syscollector_interval       = '1d'
-      $wodle_syscollector_scan_on_start  = 'yes'
-      $wodle_syscollector_hardware       = 'yes'
-      $wodle_syscollector_os             = 'yes'
-      $wodle_syscollector_network        = 'yes'
-      $wodle_syscollector_packages       = 'yes'
-      $wodle_syscollector_ports          = 'yes'
-      $wodle_syscollector_processes      = 'yes'
-
-      # localfile
-      $ossec_local_files                 = $::wazuh::params_agent::default_local_files
-
-      #syscheck
-      $ossec_syscheck_disabled           = 'no'
-      $ossec_syscheck_frequency          = '43200'
-      $ossec_syscheck_scan_on_start      = 'yes'
-      $ossec_syscheck_alert_new_files    = undef
-      $ossec_syscheck_auto_ignore        = undef
-      $ossec_syscheck_directories_1      = '/etc,/usr/bin,/usr/sbin'
-      $ossec_syscheck_directories_2      = '/bin,/sbin,/boot'
-      $ossec_syscheck_ignore_list        = ['/etc/mtab',
-                                              '/etc/hosts.deny',
-                                              '/etc/mail/statistics',
-                                              '/etc/random-seed',
-                                              '/etc/random.seed',
-                                              '/etc/adjtime',
-                                              '/etc/httpd/logs',
-                                              '/etc/utmpx',
-                                              '/etc/wtmpx',
-                                              '/etc/cups/certs',
-                                              '/etc/dumpdates',
-                                              '/etc/svc/volatile',
-                                              '/sys/kernel/security',
-                                              '/sys/kernel/debug',
-                                              '/dev/core',
-                                            ]
-      $ossec_syscheck_ignore_type_1      = '^/proc'
-      $ossec_syscheck_ignore_type_2      = ".log$|.swp$"
-
-
-      $ossec_syscheck_nodiff             = '/etc/ssl/private.key'
-      $ossec_syscheck_skip_nfs           = 'yes'
-
+      $ossec_syscheck_nodiff = '/etc/ssl/private.key'
+      $ossec_syscheck_skip_nfs = 'yes'
 
       # others
+      $manage_firewall = false
+      $selinux = false
 
-      $selinux                         = false
-
-      $manage_repo                     = true
+      $manage_repo = true
 
       case $::osfamily {
         'Debian': {
-
-          $agent_service  = 'wazuh-agent'
-          $agent_package  = 'wazuh-agent'
-          $service_has_status  = false
+          $service_has_status = false
           $ossec_service_provider = undef
-          $api_service_provider = undef
+
           $default_local_files = [
-            {  'location' => '/var/log/syslog' , 'log_format' => 'syslog'},
-            {  'location' => '/var/log/kern.log' , 'log_format' => 'syslog'},
-            {  'location' => '/var/log/auth.log' , 'log_format' => 'syslog'},
-            {  'location' => '/var/log/dpkg.log', 'log_format' => 'syslog'},
-            {  'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog'},
-            {  'location' => '/var/log/messages' , 'log_format' => 'syslog'},
+            { 'location' => '/var/log/syslog', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/kern.log', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/auth.log', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/dpkg.log', 'log_format' => 'syslog' },
+            { 'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/messages', 'log_format' => 'syslog' },
           ]
           case $::lsbdistcodename {
             'xenial': {
-              $server_service = 'wazuh-manager'
-              $server_package = 'wazuh-manager'
-              $api_service = 'wazuh-api'
-              $api_package = 'wazuh-api'
               $wodle_openscap_content = {
-                'ssg-ubuntu-1604-ds.xml' => {
-                  'type' => 'xccdf',
+                'ssg-ubuntu-1604-ds.xml'        => {
+                  'type'   => 'xccdf',
                   profiles => ['xccdf_org.ssgproject.content_profile_common'],
-                },'cve-ubuntu-xenial-oval.xml' => {
+                }, 'cve-ubuntu-xenial-oval.xml' => {
                   'type' => 'oval'
                 }
               }
             }
             'jessie': {
-              $server_service = 'wazuh-manager'
-              $server_package = 'wazuh-manager'
-              $api_service = 'wazuh-api'
-              $api_package = 'wazuh-api'
               $wodle_openscap_content = {
-                'ssg-debian-8-ds.xml' => {
-                  'type' => 'xccdf',
+                'ssg-debian-8-ds.xml'   => {
+                  'type'   => 'xccdf',
                   profiles => ['xccdf_org.ssgproject.content_profile_common'],
                 },
                 'cve-debian-8-oval.xml' => {
@@ -232,34 +214,23 @@ class wazuh::params_agent {
               }
             }
             /^(wheezy|stretch|sid|precise|trusty|vivid|wily|xenial|bionic)$/: {
-              $server_service = 'wazuh-manager'
-              $server_package = 'wazuh-manager'
-              $api_service = 'wazuh-api'
-              $api_package = 'wazuh-api'
               $wodle_openscap_content = undef
             }
-        default: {
-          fail("Module ${module_name} is not supported on ${::operatingsystem}")
-        }
+            default: {
+              fail("Module ${module_name} is not supported on ${::operatingsystem}")
+            }
           }
 
         }
         'RedHat': {
+          $service_has_status = true
 
-          $agent_service  = 'wazuh-agent'
-          $agent_package  = 'wazuh-agent'
-          $server_service = 'wazuh-manager'
-          $server_package = 'wazuh-manager'
-          $api_service = 'wazuh-api'
-          $api_package = 'wazuh-api'
-          $service_has_status  = true
-
-          $default_local_files =[
-              {  'location' => '/var/log/audit/audit.log' , 'log_format' => 'audit'},
-              {  'location' => '/var/ossec/logs/active-responses.log' , 'log_format' => 'syslog'},
-              {  'location' => '/var/log/messages', 'log_format' => 'syslog'},
-              {  'location' => '/var/log/secure' , 'log_format' => 'syslog'},
-              {  'location' => '/var/log/maillog' , 'log_format' => 'syslog'},
+          $default_local_files = [
+            { 'location' => '/var/log/audit/audit.log', 'log_format' => 'audit' },
+            { 'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/messages', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/secure', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/maillog', 'log_format' => 'syslog' },
           ]
           case $::operatingsystem {
             'Amazon': {
@@ -273,21 +244,27 @@ class wazuh::params_agent {
 
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
                 $ossec_service_provider = 'redhat'
-                $api_service_provider = 'redhat'
+
                 $wodle_openscap_content = {
                   'ssg-centos-6-ds.xml' => {
-                    'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
+                    'type'   => 'xccdf',
+                    profiles => [
+                      'xccdf_org.ssgproject.content_profile_pci-dss',
+                      'xccdf_org.ssgproject.content_profile_server',
+                    ]
                   }
                 }
               }
               if ( $::operatingsystemrelease =~ /^7.*/ ) {
                 $ossec_service_provider = 'systemd'
-                $api_service_provider = 'systemd'
+
                 $wodle_openscap_content = {
                   'ssg-centos-7-ds.xml' => {
-                    'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
+                    'type'   => 'xccdf',
+                    profiles => [
+                      'xccdf_org.ssgproject.content_profile_pci-dss',
+                      'xccdf_org.ssgproject.content_profile_common',
+                    ]
                   }
                 }
               }
@@ -295,11 +272,14 @@ class wazuh::params_agent {
             /^(RedHat|OracleLinux)$/: {
               if ( $::operatingsystemrelease =~ /^6.*/ ) {
                 $ossec_service_provider = 'redhat'
-                $api_service_provider = 'redhat'
+
                 $wodle_openscap_content = {
-                  'ssg-rhel-6-ds.xml' => {
-                    'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
+                  'ssg-rhel-6-ds.xml'   => {
+                    'type'   => 'xccdf',
+                    profiles => [
+                      'xccdf_org.ssgproject.content_profile_pci-dss',
+                      'xccdf_org.ssgproject.content_profile_server',
+                    ]
                   },
                   'cve-redhat-6-ds.xml' => {
                     'type' => 'xccdf',
@@ -308,11 +288,14 @@ class wazuh::params_agent {
               }
               if ( $::operatingsystemrelease =~ /^7.*/ ) {
                 $ossec_service_provider = 'systemd'
-                $api_service_provider = 'systemd'
+
                 $wodle_openscap_content = {
-                  'ssg-rhel-7-ds.xml' => {
-                    'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
+                  'ssg-rhel-7-ds.xml'   => {
+                    'type'   => 'xccdf',
+                    profiles => [
+                      'xccdf_org.ssgproject.content_profile_pci-dss',
+                      'xccdf_org.ssgproject.content_profile_common',
+                    ]
                   },
                   'cve-redhat-7-ds.xml' => {
                     'type' => 'xccdf',
@@ -323,11 +306,14 @@ class wazuh::params_agent {
             'Fedora': {
               if ( $::operatingsystemrelease =~ /^(23|24|25).*/ ) {
                 $ossec_service_provider = 'redhat'
-                $api_service_provider = 'redhat'
+
                 $wodle_openscap_content = {
                   'ssg-fedora-ds.xml' => {
-                    'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',]
+                    'type'   => 'xccdf',
+                    profiles => [
+                      'xccdf_org.ssgproject.content_profile_standard',
+                      'xccdf_org.ssgproject.content_profile_common',
+                    ]
                   },
                 }
               }
@@ -343,7 +329,7 @@ class wazuh::params_agent {
       $shared_agent_config_file = regsubst(sprintf('c:/Program Files (x86)/ossec-agent/shared/agent.conf'), '\\\\', '/')
       $config_owner = 'Administrator'
       $config_group = 'Administrators'
-      $download_path = 'C:/'
+      $download_path = 'C:\\Temp'
       $manage_firewall = false
 
       $keys_file = regsubst(sprintf('c:/Program Files (x86)/ossec-agent/client.keys'), '\\\\', '/')
@@ -351,26 +337,45 @@ class wazuh::params_agent {
       $keys_owner = 'Administrator'
       $keys_group = 'Administrators'
 
-      $agent_service  = 'OssecSvc'
-      $agent_package  = 'Wazuh Agent 3.10.2'
-      $server_service = ''
-      $server_package = ''
-      $api_service = ''
-      $api_package = ''
-      $service_has_status  = true
+      $agent_package_name = 'Wazuh Agent'
+      $agent_service_name = 'OssecSvc'
+      $service_has_status = true
+      $ossec_service_provider = undef
 
       # TODO
       $validate_cmd_conf = undef
-      # Pushed by shared agent config now
-      $default_local_files =  [
-        {'location' => 'Security' , 'log_format' => 'eventchannel',
-        'query' => 'Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and EventID != 4656 and EventID != 4658\
-        and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID!= 4703 and EventID != 4907]'},
-        {'location' => 'System' , 'log_format' =>  'eventlog'  },
-        {'location' => 'active-response\active-responses.log' , 'log_format' =>  'syslog'  },
-      ]
 
+      # Wodles
+
+      ## openscap
+      $wodle_openscap_disabled = 'yes'
+
+      ## cis-cat
+      $wodle_ciscat_disabled = 'yes'
+
+      ## osquery
+      $wodle_osquery_disabled = 'yes'
+
+      ## syscollector
+      $wodle_syscollector_disabled = true
+
+      # Pushed by shared agent config now
+      $default_local_files = [
+        {
+          'location'   => 'Security',
+          'log_format' => 'eventchannel',
+          'query'      => 'Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and EventID != 4656 and EventID != 4658 and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID!= 4703 and EventID != 4907]'
+        },
+        {
+          'location'   => 'System',
+          'log_format' => 'eventlog'
+        },
+        {
+          'location'   => 'active-response\active-responses.log',
+          'log_format' => 'syslog'
+        },
+      ]
     }
-  default: { fail('This ossec module has not been tested on your distribution') }
+    default: { fail('This ossec module has not been tested on your distribution') }
   }
 }


### PR DESCRIPTION
# Wazuh agent on Windows

## Why do I open this PR
I need to deploy Wazuh agents on Windows instances. I rapidly figured out that this Puppet module was not ready for Windows, so I fixed it!

## Changes
\+ Add an optional agent_service_ensure parameter to control the service status
\+ Download the Wazuh Windows agent MSI file to `C:\Temp` (fixes #73)
\! Use the right parameters for the Windows agent MSI (based on the official documentation)
\+ Add the support for a registration password for the Windows agent
\! Fix the agent package ensure loop on Windows (Windows sais 3.10.2 is installed, but Puppet wants 3.10.2-1, so Puppet was re-installing it at every run)
\+ Add the support for Windows in `ossec.conf generation concats`
\* Make sure we generate the `ossec.conf` file before starting the Wazuh service (a `before` was missing, causing the service to start before the `ossec.conf` setup)
\+ Setup the Wazuh service on Windows (was only called on Linux, I replaced the faulty `if` by a swith case)
\* Extract agent parameters common to both Linux and Windows out of the Linux case
\+ Add the missing parameters for the Windows agent
\- Remove all the parameters that are not relevant for agents from the params_agent.pp file
\* Format the agent.pp file
\* Format the params_agent.pp file

## Disclamer
I'm not a Puppet expert! Feel free to request any changes 🙂