### PR TITLE
param agent: use systemd for supported debian/ubuntu distro

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -190,8 +190,6 @@ class wazuh::params_agent {
 
           $agent_service  = 'wazuh-agent'
           $agent_package  = 'wazuh-agent'
-          $service_has_status  = false
-          $ossec_service_provider = undef
           $api_service_provider = undef
           $default_local_files = [
             {  'location' => '/var/log/syslog' , 'log_format' => 'syslog'},
@@ -203,6 +201,8 @@ class wazuh::params_agent {
           ]
           case $::lsbdistcodename {
             'xenial': {
+              $service_has_status  = true
+              $ossec_service_provider = systemd
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $api_service = 'wazuh-api'
@@ -217,6 +217,8 @@ class wazuh::params_agent {
               }
             }
             'jessie': {
+              $service_has_status  = true
+              $ossec_service_provider = systemd
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $api_service = 'wazuh-api'
@@ -231,7 +233,18 @@ class wazuh::params_agent {
                 }
               }
             }
-            /^(wheezy|stretch|sid|precise|trusty|vivid|wily|bionic)$/: {
+            /^(wheezy|precise|trusty|vivid|wily)$/: {
+              $service_has_status  = false
+              $ossec_service_provider = undef
+              $server_service = 'wazuh-manager'
+              $server_package = 'wazuh-manager'
+              $api_service = 'wazuh-api'
+              $api_package = 'wazuh-api'
+              $wodle_openscap_content = undef
+            }
+            /^(stretch|buster|sid|bionic)$/: {
+              $service_has_status  = true
+              $ossec_service_provider = systemd
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $api_service = 'wazuh-api'

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -231,7 +231,7 @@ class wazuh::params_agent {
                 }
               }
             }
-            /^(wheezy|stretch|sid|precise|trusty|vivid|wily|xenial|bionic)$/: {
+            /^(wheezy|stretch|sid|precise|trusty|vivid|wily|bionic)$/: {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $api_service = 'wazuh-api'


### PR DESCRIPTION
currently we can't restart wazuh-agent service on configuration change because no service provider is defined