### PR TITLE
missing config-profiles values.

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -61,6 +61,7 @@ class wazuh::agent (
   $wazuh_reporting_endpoint          = $wazuh::params_agent::wazuh_reporting_endpoint,
   $ossec_port                        = $wazuh::params_agent::ossec_port,
   $ossec_protocol                    = $wazuh::params_agent::ossec_protocol,
+  $ossec_config_profiles             = $wazuh::params_agent::ossec_config_profiles,
   $ossec_notify_time                 = $wazuh::params_agent::ossec_notify_time,
   $ossec_time_reconnect              = $wazuh::params_agent::ossec_time_reconnect,
   $ossec_auto_restart                = $wazuh::params_agent::ossec_auto_restart,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -52,6 +52,7 @@ class wazuh::params_agent {
   $wazuh_reporting_endpoint = undef
   $ossec_port = '1514'
   $ossec_protocol = 'udp'
+  $ossec_config_profiles = undef
   $ossec_notify_time = 10
   $ossec_time_reconnect = 60
   $ossec_auto_restart = 'yes'


### PR DESCRIPTION
I could manage `<config-profiles>` values in wazuh-wazuh (3.8.2) modules previously but now I can't

There are missing params that manage `<config-profiles>` values.