### PR TITLE
Improve the agent configurability and fix minor issues

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -49,7 +49,6 @@ class wazuh::agent (
   $ossec_sca_template                = $wazuh::params_agent::ossec_sca_template,
   $ossec_syscheck_template           = $wazuh::params_agent::ossec_syscheck_template,
   $ossec_localfile_template          = $wazuh::params_agent::ossec_localfile_template,
-  $ossec_ruleset                     = $wazuh::params_agent::ossec_ruleset,
   $ossec_auth                        = $wazuh::params_agent::ossec_auth,
   $ossec_cluster                     = $wazuh::params_agent::ossec_cluster,
   $ossec_active_response_template    = $wazuh::params_agent::ossec_active_response_template,
@@ -149,6 +148,9 @@ class wazuh::agent (
   ## Windows
 
   $download_path                     = $wazuh::params_agent::download_path,
+
+  # Logging
+  $logging_log_format                = $wazuh::params_agent::logging_log_format,
 ) inherits wazuh::params_agent {
   # validate_bool(
   #   $ossec_active_response, $ossec_rootcheck,

--- a/templates/fragments/_default_activeresponse.erb
+++ b/templates/fragments/_default_activeresponse.erb
@@ -1,7 +1,6 @@
- <active-response> 
-  <disabled>no</disabled>
-  <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
-  <ca_verification>yes</ca_verification>
- </active-response>
+  <active-response> 
+    <disabled>no</disabled>
+    <ca_store>/var/ossec/etc/wpk_root.pem</ca_store>
+    <ca_verification>yes</ca_verification>
+  </active-response>
 
- 

--- a/templates/fragments/_rootcheck.erb
+++ b/templates/fragments/_rootcheck.erb
@@ -38,7 +38,7 @@
   <%- end -%>  
   </rootcheck>
 <%- else -%>
-    <!-- Rootcheck files (static) -->
+  <!-- Rootcheck files (static) -->
   <rootcheck>
     <windows_audit>./shared/win_audit_rcl.txt</windows_audit>
     <windows_apps>./shared/win_applications_rcl.txt</windows_apps>

--- a/templates/fragments/_sca.erb
+++ b/templates/fragments/_sca.erb
@@ -1,39 +1,27 @@
-<%- if @kernel == 'Linux' -%>
-  <%- if @apply_template_os == 'centos' -%>
-    <sca>
-      <enabled>yes</enabled>
-      <scan_on_start>yes</scan_on_start>
-      <interval>12h</interval>
-      <skip_nfs>yes</skip_nfs>
+  <sca>
+    <enabled><%= @sca_enabled %></enabled>
+    <scan_on_start><%= @sca_scan_on_start %></scan_on_start>
+    <interval><%= @sca_interval %></interval>
+    <skip_nfs><%= @sca_skip_nfs %></skip_nfs>
 
-      <policies>
-        <policy>cis_rhel7_linux_rcl.yml</policy>
-        <policy>system_audit_rcl.yml</policy>
-        <policy>system_audit_ssh.yml</policy>
-        <policy>system_audit_pw.yml</policy>
-      </policies>
-    </sca>
-  <%- elsif @apply_template_os =='amazon' -%> 
-    <sca>
-      <enabled>yes</enabled>
-      <scan_on_start>yes</scan_on_start>
-      <interval>12h</interval>
-      <skip_nfs>yes</skip_nfs>
-
-      <policies>
+    <%- if @kernel == 'Linux' -%>
+    <%- if @apply_template_os == 'centos' -%>
+    <policies>
+      <policy>cis_rhel7_linux_rcl.yml</policy>
       <policy>system_audit_rcl.yml</policy>
       <policy>system_audit_ssh.yml</policy>
       <policy>system_audit_pw.yml</policy>
-      </policies>
-    </sca>
-  <%- elsif @apply_template_os =='rhel' -%> 
-    <sca>
-      <enabled>yes</enabled>
-      <scan_on_start>yes</scan_on_start>
-      <interval>12h</interval>
-      <skip_nfs>yes</skip_nfs>
+    </policies>
 
-      <policies>
+    <%- elsif @apply_template_os =='amazon' -%>
+    <policies>
+      <policy>system_audit_rcl.yml</policy>
+      <policy>system_audit_ssh.yml</policy>
+      <policy>system_audit_pw.yml</policy>
+    </policies>
+
+    <%- elsif @apply_template_os =='rhel' -%>
+    <policies>
       <%- if @rhel_version == '7' -%>
       <policy>cis_rhel7_linux_rcl.yml</policy>
       <%- elsif @rhel_version =='6' -%>
@@ -44,16 +32,10 @@
       <policy>system_audit_rcl.yml</policy>
       <policy>system_audit_ssh.yml</policy>
       <policy>system_audit_pw.yml</policy>
-      </policies>
-    </sca>
-  <%- else -%>
-      <sca>
-      <enabled>yes</enabled>
-      <scan_on_start>yes</scan_on_start>
-      <interval>12h</interval>
-      <skip_nfs>yes</skip_nfs>
+    </policies>
 
-      <policies>
+    <%- else -%>
+    <policies>
       <policy>cis_debian_linux_rcl.yml</policy>
       <%- if @debian_additional_templates == 'yes' -%>
       <policy>cis_debianlinux7-8_L1_rcl.yml</policy>
@@ -62,9 +44,7 @@
       <policy>system_audit_rcl.yml</policy>
       <policy>system_audit_ssh.yml</policy>
       <policy>system_audit_pw.yml</policy>
-      </policies>
-    </sca>
-  <%- end -%>
-<%- end -%>
-    
-  
+    </policies>
+    <%- end -%>
+    <%- end -%>
+  </sca>

--- a/templates/fragments/_syscheck.erb
+++ b/templates/fragments/_syscheck.erb
@@ -1,128 +1,141 @@
-<%- if @kernel == 'windows' -%>
-<syscheck> <!-- Default files to be monitored - system32 only. -->
-  <directories check_all="yes">%WINDIR%/win.ini</directories>
-  <directories check_all="yes">%WINDIR%/system.ini</directories>
-  <directories check_all="yes">C:\autoexec.bat</directories>
-  <directories check_all="yes">C:\config.sys</directories>
-  <directories check_all="yes">C:\boot.ini</directories>
-  <directories check_all="yes">%WINDIR%/System32/CONFIG.NT</directories>
-  <directories check_all="yes">%WINDIR%/System32/AUTOEXEC.NT</directories>
-  <directories check_all="yes">%WINDIR%/System32/at.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/attrib.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/cacls.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/debug.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/drwatson.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/drwtsn32.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/edlin.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/eventcreate.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/eventtriggers.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/ftp.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/net.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/net1.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/netsh.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/rcp.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/reg.exe</directories>
-  <directories check_all="yes">%WINDIR%/regedit.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/regedt32.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/regsvr32.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/rexec.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/rsh.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/runas.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/sc.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/subst.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/telnet.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/tftp.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/tlntsvr.exe</directories>
-  <directories check_all="yes">%WINDIR%/System32/drivers/etc</directories>
-  <directories check_all="yes" realtime="yes">C:\Documents and Settings/All Users/Start Menu/Programs/Startup</directories>
-  <directories check_all="yes" realtime="yes">C:\Users/Public/All Users/Microsoft/Windows/Start Menu/Startup</directories>
-  <ignore type="sregex">.log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$</ignore>
+  <%- if @kernel == 'windows' -%>
+  <syscheck>
+    <%- if @ossec_syscheck_disabled -%>
+    <disabled><%= @ossec_syscheck_disabled %></disabled>
+    <%- end -%>
+    <%- if @ossec_syscheck_frequency -%>
+    <frequency><%=@ossec_syscheck_frequency%></frequency>
+    <%- end -%>
+    <%- if @ossec_syscheck_scan_on_start -%>
+    <scan_on_start><%=@ossec_syscheck_scan_on_start%></scan_on_start>
+    <%- end -%>
+    <%- if @ossec_syscheck_alert_new_files -%>
+    <alert_new_files><%=@ossec_syscheck_alert_new_files%></alert_new_files>
+    <%- end -%>
+    <%- if @ossec_syscheck_auto_ignore -%>
+    <auto_ignore frequency="10" timeframe="3600"><%=@ossec_syscheck_auto_ignore%></auto_ignore>
+    <%- end -%>
 
-  <!-- Windows registry entries to monitor. -->
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\batfile</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\cmdfile</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\comfile</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\exefile</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\piffile</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\AllFilesystemObjects</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Directory</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Folder</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Protocols</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Security</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\KnownDLLs</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\winreg</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon</windows_registry>
-  <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components</windows_registry>
+    <!-- Default files to be monitored. -->
+    <directories check_all="yes">%WINDIR%\regedit.exe</directories>
+    <directories check_all="yes">%WINDIR%\system.ini</directories>
+    <directories check_all="yes">%WINDIR%\win.ini</directories>
 
-  <!-- Windows files to ignore (static) -->
-  <ignore>%WINDIR%/System32/LogFiles</ignore>
-  <ignore>%WINDIR%/Debug</ignore>
-  <ignore>%WINDIR%/WindowsUpdate.log</ignore>
-  <ignore>%WINDIR%/iis6.log</ignore>
-  <ignore>%WINDIR%/system32/wbem/Logs</ignore>
-  <ignore>%WINDIR%/system32/wbem/Repository</ignore>
-  <ignore>%WINDIR%/Prefetch</ignore>
-  <ignore>%WINDIR%/PCHEALTH/HELPCTR/DataColl</ignore>
-  <ignore>%WINDIR%/SoftwareDistribution</ignore>
-  <ignore>%WINDIR%/Temp</ignore>
-  <ignore>%WINDIR%/system32/config</ignore>
-  <ignore>%WINDIR%/system32/spool</ignore>
-  <ignore>%WINDIR%/system32/CatRoot</ignore>
+    <!-- 32-bit programs. -->
+    <directories check_all="yes">%WINDIR%\System32\at.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\attrib.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\cacls.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\cmd.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\drivers\etc</directories>
+    <directories check_all="yes">%WINDIR%\System32\eventcreate.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\ftp.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\net.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\net1.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\netsh.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\reg.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\regedit.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\regedt32.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\regsvr32.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\runas.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\sc.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\schtasks.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\sethc.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\subst.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\wbem\WMIC.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe</directories>
+    <directories check_all="yes">%WINDIR%\System32\winrm.vbs</directories>
 
-  <!-- Windows registry entries to ignore. -->
-  <registry_ignore>HKEY_LOCAL_MACHINE\Security\Policy\Secrets</registry_ignore>
-  <registry_ignore>HKEY_LOCAL_MACHINE\Security\SAM\Domains\Account\Users</registry_ignore>
-  <registry_ignore type="sregex">\Enum$</registry_ignore>
-</syscheck>
+    <directories check_all="yes" realtime="yes">%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs\Startup</directories>
+    <ignore>%PROGRAMDATA%\Microsoft\Windows\Start Menu\Programs\Startup\desktop.ini</ignore>
 
-<%- else -%>
-<syscheck>
-  <%- if @ossec_syscheck_disabled -%>
-  <disabled><%= @ossec_syscheck_disabled %></disabled>
-  <%- end -%>
-  <%- if @ossec_syscheck_frequency -%>
-  <frequency><%=@ossec_syscheck_frequency%></frequency>
-  <%- end -%>
-  <%- if @ossec_syscheck_scan_on_start -%>
-  <scan_on_start><%=@ossec_syscheck_scan_on_start%></scan_on_start>
-  <%- end -%>
-  <%- if @ossec_syscheck_alert_new_files -%>
-  <alert_new_files><%=@ossec_syscheck_alert_new_files%></alert_new_files>
-  <%- end -%>
-  <%- if @ossec_syscheck_auto_ignore -%>
-  <auto_ignore frequency="10" timeframe="3600"><%=@ossec_syscheck_auto_ignore%></auto_ignore>
-  <%- end -%>
-  <%- if @ossec_syscheck_directories_1 -%>
-  <directories check_all="yes" whodata=<%=@ossec_syscheck_whodata%> realtime=<%=@ossec_syscheck_realtime%>><%=@ossec_syscheck_directories_1%></directories>
-  <%- end -%>
-  <%- if @ossec_syscheck_directories_2 -%>
-  <directories check_all="yes" whodata=<%=@ossec_syscheck_whodata%> realtime=<%=@ossec_syscheck_realtime%>><%=@ossec_syscheck_directories_2%></directories>
-  <%- end -%>
-  <%- if @ossec_syscheck_ignore_list -%>
-    <%- @ossec_syscheck_ignore_list.each do |ignore_element| -%>
-  <ignore><%= ignore_element %></ignore>
-    <%- end -%>  
-  <%- end -%>
-  <%- if @ossec_syscheck_ignore_type_1 -%>
-  <ignore type="sregex"><%=@ossec_syscheck_ignore_type_1%></ignore>
-  <%- end -%>
-  <%- if @ossec_syscheck_ignore_type_2 -%>
-  <ignore type="sregex"><%=@ossec_syscheck_ignore_type_2%></ignore>
-  <%- end -%>
-  <%- if @ossec_syscheck_nodiff -%>
-  <nodiff><%=@ossec_syscheck_nodiff%></nodiff>
-  <%- end -%>
-  <%- if @ossec_syscheck_skip_nfs -%>
-  <skip_nfs><%=@ossec_syscheck_skip_nfs%></skip_nfs>
-  <%- end -%>
+    <ignore type="sregex">.log$|.htm$|.jpg$|.png$|.chm$|.pnf$|.evtx$</ignore>
+
+    <!-- Windows registry entries to monitor. -->
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\batfile</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\cmdfile</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\comfile</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\exefile</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\piffile</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\AllFilesystemObjects</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Directory</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Classes\Folder</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Classes\Protocols</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Policies</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Security</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Internet Explorer</windows_registry>
+
+    <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\KnownDLLs</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\SecurePipeServers\winreg</windows_registry>
+
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Run</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnce</windows_registry>
+    <windows_registry>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\URL</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Windows</windows_registry>
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Windows NT\CurrentVersion\Winlogon</windows_registry>
+
+    <windows_registry arch="both">HKEY_LOCAL_MACHINE\Software\Microsoft\Active Setup\Installed Components</windows_registry>
+
+    <!-- Windows registry entries to ignore. -->
+    <registry_ignore>HKEY_LOCAL_MACHINE\Security\Policy\Secrets</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\Security\SAM\Domains\Account\Users</registry_ignore>
+    <registry_ignore type="sregex">\Enum$</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\AppCs</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\DHCP</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\IPTLSIn</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\IPTLSOut</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\RPC-EPMap</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\MpsSvc\Parameters\PortKeywords\Teredo</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\PolicyAgent\Parameters\Cache</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\RunOnceEx</registry_ignore>
+    <registry_ignore>HKEY_LOCAL_MACHINE\System\CurrentControlSet\Services\ADOVMPPackage\Final</registry_ignore>
+
+    <%- if @ossec_syscheck_skip_nfs -%>
+    <skip_nfs><%=@ossec_syscheck_skip_nfs%></skip_nfs>
+    <%- end -%>
   </syscheck>
-<%- end -%>
+
+  <%- else -%>
+  <syscheck>
+    <%- if @ossec_syscheck_disabled -%>
+    <disabled><%= @ossec_syscheck_disabled %></disabled>
+    <%- end -%>
+    <%- if @ossec_syscheck_frequency -%>
+    <frequency><%=@ossec_syscheck_frequency%></frequency>
+    <%- end -%>
+    <%- if @ossec_syscheck_scan_on_start -%>
+    <scan_on_start><%=@ossec_syscheck_scan_on_start%></scan_on_start>
+    <%- end -%>
+    <%- if @ossec_syscheck_alert_new_files -%>
+    <alert_new_files><%=@ossec_syscheck_alert_new_files%></alert_new_files>
+    <%- end -%>
+    <%- if @ossec_syscheck_auto_ignore -%>
+    <auto_ignore frequency="10" timeframe="3600"><%=@ossec_syscheck_auto_ignore%></auto_ignore>
+    <%- end -%>
+    <%- if @ossec_syscheck_directories_1 -%>
+    <directories check_all="yes"><%=@ossec_syscheck_directories_1%></directories>
+    <%- end -%>
+    <%- if @ossec_syscheck_directories_2 -%>
+    <directories check_all="yes"><%=@ossec_syscheck_directories_2%></directories>
+    <%- end -%>
+    <%- if @ossec_syscheck_ignore_list -%>
+      <%- @ossec_syscheck_ignore_list.each do |ignore_element| -%>
+    <ignore><%= ignore_element %></ignore>
+      <%- end -%>  
+    <%- end -%>
+    <%- if @ossec_syscheck_ignore_type_1 -%>
+    <ignore type="sregex"><%=@ossec_syscheck_ignore_type_1%></ignore>
+    <%- end -%>
+    <%- if @ossec_syscheck_ignore_type_2 -%>
+    <ignore type="sregex"><%=@ossec_syscheck_ignore_type_2%></ignore>
+    <%- end -%>
+    <%- if @ossec_syscheck_nodiff -%>
+    <nodiff><%=@ossec_syscheck_nodiff%></nodiff>
+    <%- end -%>
+    <%- if @ossec_syscheck_skip_nfs -%>
+    <skip_nfs><%=@ossec_syscheck_skip_nfs%></skip_nfs>
+    <%- end -%>
+    </syscheck>
+  <%- end -%>

--- a/templates/fragments/_wodle_cis_cat.erb
+++ b/templates/fragments/_wodle_cis_cat.erb
@@ -1,10 +1,10 @@
-    <wodle name="cis-cat">
-    <disabled>yes</disabled>
-    <timeout>1800</timeout>
-    <interval>1d</interval>
-    <scan-on-start>yes</scan-on-start>
+  <wodle name="cis-cat">
+    <disabled><%= @wodle_ciscat_disabled %></disabled>
+    <timeout><%= @wodle_ciscat_timeout %></timeout>
+    <interval><%= @wodle_ciscat_interval %></interval>
+    <scan-on-start><%= @wodle_ciscat_scan_on_start %></scan-on-start>
 
-    <java_path>wodles/java</java_path>
-    <ciscat_path>wodles/ciscat</ciscat_path>
-    </wodle>
-    
+    <java_path><%= @wodle_ciscat_java_path %></java_path>
+    <ciscat_path><%= @wodle_ciscat_ciscat_path %></ciscat_path>
+  </wodle>
+

--- a/templates/fragments/_wodle_openscap.erb
+++ b/templates/fragments/_wodle_openscap.erb
@@ -1,9 +1,9 @@
   <wodle name="open-scap">
-    <disabled>yes</disabled>
-    <timeout>1800</timeout>
-    <interval>1d</interval>
-    <scan-on-start>yes</scan-on-start>
-  
+    <disabled><%= @wodle_openscap_disabled %></disabled>
+    <timeout><%= @wodle_openscap_timeout %></timeout>
+    <interval><%= @wodle_openscap_interval %></interval>
+    <scan-on-start><%= @wodle_openscap_scan_on_start %></scan-on-start>
+
     <%- @wodle_openscap_content.each do |path, value| -%>
     <content type="<%= value['type'] %>" path="<%= path %>">
       <%- if value['profiles'] then -%>
@@ -15,4 +15,3 @@
     <%- end -%>
   </wodle>
 
-  

--- a/templates/fragments/_wodle_osquery.erb
+++ b/templates/fragments/_wodle_osquery.erb
@@ -1,9 +1,8 @@
   <wodle name="osquery">
-    <disabled>yes</disabled>
-    <run_daemon>yes</run_daemon>
-    <log_path>/var/log/osquery/osqueryd.results.log</log_path>
-    <config_path>/etc/osquery/osquery.conf</config_path>
-    <add_labels>yes</add_labels>
+    <disabled><%= @wodle_osquery_disabled %></disabled>
+    <run_daemon><%= @wodle_osquery_run_daemon %></run_daemon>
+    <log_path><%= @wodle_osquery_log_path %></log_path>
+    <config_path><%= @wodle_osquery_config_path %></config_path>
+    <add_labels><%= @wodle_osquery_add_labels %></add_labels>
   </wodle>
 
-  

--- a/templates/fragments/_wodle_syscollector.erb
+++ b/templates/fragments/_wodle_syscollector.erb
@@ -1,12 +1,12 @@
   <wodle name="syscollector">
-    <disabled>no</disabled>
-    <interval>1h</interval>
-    <scan_on_start>yes</scan_on_start>
-    <hardware>yes</hardware>
-    <os>yes</os>
-    <network>yes</network>
-    <packages>yes</packages>
-    <ports all="no">yes</ports>
-    <processes>yes</processes>
+    <disabled><%= @wodle_syscollector_disabled %></disabled>
+    <interval><%= @wodle_syscollector_interval %></interval>
+    <scan_on_start><%= @wodle_syscollector_scan_on_start %></scan_on_start>
+    <hardware><%= @wodle_syscollector_hardware %></hardware>
+    <os><%= @wodle_syscollector_os %></os>
+    <network><%= @wodle_syscollector_network %></network>
+    <packages><%= @wodle_syscollector_packages %></packages>
+    <ports all="no"><%= @wodle_syscollector_ports %></ports>
+    <processes><%= @wodle_syscollector_processes %></processes>
   </wodle>
 

--- a/templates/wazuh_agent.conf.erb
+++ b/templates/wazuh_agent.conf.erb
@@ -1,32 +1,32 @@
   <client>
-  <server>
-  <%- if @wazuh_reporting_endpoint then -%>
-    <address><%= @wazuh_reporting_endpoint %></address>
-  <%- end -%>
-  <%- if @ossec_protocol then -%>
-    <protocol><%= @ossec_protocol %></protocol>
-  <%- end -%>
-    <port><%= @ossec_port %></port>
-  </server>
-  <%- if @ossec_config_profiles then -%>
+    <server>
+    <%- if @wazuh_reporting_endpoint then -%>
+      <address><%= @wazuh_reporting_endpoint %></address>
+    <%- end -%>
+    <%- if @ossec_protocol then -%>
+      <protocol><%= @ossec_protocol %></protocol>
+    <%- end -%>
+      <port><%= @ossec_port %></port>
+    </server>
+    <%- if @ossec_config_profiles then -%>
     <config-profile><%= @ossec_config_profiles.join(',') %></config-profile>
-  <%- end -%>
-  <%- if @ossec_notify_time then -%>
+    <%- end -%>
+    <%- if @ossec_notify_time then -%>
     <notify_time><%= @ossec_notify_time %></notify_time>
-  <%- end -%>
-  <%- if @ossec_time_reconnect then -%>
+    <%- end -%>
+    <%- if @ossec_time_reconnect then -%>
     <time-reconnect><%= @ossec_time_reconnect %></time-reconnect>
-  <%- end -%>
-  <%- if @ossec_crypto_method then -%>
+    <%- end -%>
+    <%- if @ossec_crypto_method then -%>
     <crypto_method><%= @ossec_crypto_method %></crypto_method>
-  <%- end -%>
-  <%- if @ossec_auto_restart then -%>
+    <%- end -%>
+    <%- if @ossec_auto_restart then -%>
     <auto_restart><%= @ossec_auto_restart %></auto_restart>
-  <%- end -%>
+    <%- end -%>
   </client>
   
   <logging>
-    <log_format>plain</log_format>
+    <log_format><%= @logging_log_format %></log_format>
   </logging>
 
   <client_buffer>


### PR DESCRIPTION
Hello!

I was browsing the Wazuh repository and I figured out that the Wazuh Windows agent configuration generated by Puppet was off compared to https://github.com/wazuh/wazuh/blob/v3.10.2/src/win32/ossec.conf. So here is the fix!

Then I identified some other minor issues and decided to fix them as well. In the end, those are my changes:
* Remove unused parameters in params_agent.pp
* Make the logging log_format configurable
* Remove some duplication between the agent configuration on Linux and Windows
* Improve the Windows agent configuration based on https://github.com/wazuh/wazuh/blob/v3.10.2/src/win32/ossec.conf
* Make the generated ossec.conf file a little bit more readable by fixing ident in fragments
* Remove the duplication in fragments/_sca.erb
* The SCA config now applies for Windows agents too
* Improve the Windows agent syscheck configuration based on https://github.com/wazuh/wazuh/blob/v3.10.2/src/win32/ossec.conf
* Make the cis cat wodle use variable from params_agent.pp
* Make the open-scap wodle use variable from params_agent.pp
* Make the osquery wodle use variable from params_agent.pp
* Make the syscollector wodle use variable from params_agent.pp

Enjoy!