### PR TITLE
Fixes #219: Add sca support for Debian

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -105,6 +105,13 @@ class wazuh::agent (
   $sca_rhel_skip_nfs = $wazuh::params_agent::sca_rhel_skip_nfs,
   $sca_rhel_policies = $wazuh::params_agent::sca_rhel_policies,
 
+  ## DEBIAN
+  $sca_debian_enabled = $wazuh::params_agent::sca_debian_enabled,
+  $sca_debian_scan_on_start = $wazuh::params_agent::sca_debian_scan_on_start,
+  $sca_debian_interval = $wazuh::params_agent::sca_debian_interval,
+  $sca_debian_skip_nfs = $wazuh::params_agent::sca_debian_skip_nfs,
+  $sca_debian_policies = $wazuh::params_agent::sca_debian_policies,
+
   ## <Linux else>
   $sca_else_enabled = $wazuh::params_agent::sca_else_enabled,
   $sca_else_scan_on_start = $wazuh::params_agent::sca_else_scan_on_start,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -133,6 +133,13 @@ class wazuh::params_agent {
       $sca_rhel_skip_nfs = 'yes'
       $sca_rhel_policies = []
 
+      ## DEBIAN
+      $sca_debian_enabled = 'yes'
+      $sca_debian_scan_on_start = 'yes'
+      $sca_debian_interval = '12h'
+      $sca_debian_skip_nfs = 'yes'
+      $sca_debian_policies = []
+
       ## <else>
       $sca_else_enabled = 'yes'
       $sca_else_scan_on_start = 'yes'

--- a/templates/fragments/_sca.erb
+++ b/templates/fragments/_sca.erb
@@ -46,6 +46,29 @@
   </policies>
   <%- end -%>
 </sca>
+<%- elsif @apply_template_os =='debian' -%>
+<sca>
+  <% if @sca_debian_enabled -%>
+  <enabled><%= @sca_debian_enabled %></enabled>
+  <%- end -%>
+  <% if @sca_debian_scan_on_start -%>
+  <scan_on_start><%= @sca_debian_scan_on_start %></scan_on_start>
+  <%- end -%>
+  <% if @sca_debian_interval -%>
+  <interval><%= @sca_debian_interval %></interval>
+  <%- end -%>
+  <% if @sca_debian_skip_nfs -%>
+  <skip_nfs><%= @sca_debian_skip_nfs %></skip_nfs>
+  <%- end -%>
+
+  <% if !@sca_debian_policies.empty? -%>
+  <policies>
+  <% @sca_debian_policies.each do |policy| -%>
+      <policy><%= policy %></policy>
+  <%- end -%>
+  </policies>
+  <%- end -%>
+</sca>
 <%- else -%>
 <sca>
   <% if @sca_else_enabled -%>


### PR DESCRIPTION
The PR adds sca support for Debian by introducing the required variables
and changes in the corresponding template.