### PR TITLE
Fixes #225 : Option to configure audit rules from this module itself

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -177,6 +177,12 @@ class wazuh::agent (
   $ossec_syscheck_skip_nfs           = $wazuh::params_agent::ossec_syscheck_skip_nfs,
   $ossec_syscheck_windows_audit_interval      = $wazuh::params_agent::windows_audit_interval,
 
+  # Audit
+  $audit_manage_rules                = $wazuh::params_agent::audit_manage_rules,
+  $audit_buffer_bytes                = $wazuh::params_agent::audit_buffer_bytes,
+  $audit_backlog_wait_time           = $wazuh::params_agent::audit_backlog_wait_time,
+  $audit_rules                       = $wazuh::params_agent::audit_rules,
+
   # active-response
   $ossec_active_response_disabled          =  $wazuh::params_agent::active_response_disabled,
   $ossec_active_response_linux_ca_store    =  $wazuh::params_agent::active_response_linux_ca_store,
@@ -208,12 +214,11 @@ class wazuh::agent (
   validate_string($agent_service_name)
 
   if (( $ossec_syscheck_whodata_directories_1 == 'yes' ) or ( $ossec_syscheck_whodata_directories_2 == 'yes' )) {
-    package { 'Installing Audit...':
-      name   => 'audit',
-    }
-    service { 'auditd':
-      ensure => running,
-      enable => true,
+     class { "wazuh::audit":
+      audit_manage_rules => $audit_manage_rules,
+      audit_backlog_wait_time => $audit_backlog_wait_time,
+      audit_buffer_bytes => $audit_buffer_bytes,
+      audit_rules => $audit_rules,
     }
   }
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -167,12 +167,8 @@ class wazuh::agent (
   $ossec_syscheck_auto_ignore        = $wazuh::params_agent::ossec_syscheck_auto_ignore,
   $ossec_syscheck_directories_1      = $wazuh::params_agent::ossec_syscheck_directories_1,
   $ossec_syscheck_directories_2      = $wazuh::params_agent::ossec_syscheck_directories_2,
-  $ossec_syscheck_
-  
-  
-  
-  
-  _directories_1            = $wazuh::params_agent::ossec_syscheck_whodata_directories_1,
+   
+  $ossec_syscheck_whodata_directories_1            = $wazuh::params_agent::ossec_syscheck_whodata_directories_1,
   $ossec_syscheck_realtime_directories_1           = $wazuh::params_agent::ossec_syscheck_realtime_directories_1,
   $ossec_syscheck_whodata_directories_2            = $wazuh::params_agent::ossec_syscheck_whodata_directories_2,
   $ossec_syscheck_realtime_directories_2           = $wazuh::params_agent::ossec_syscheck_realtime_directories_2,

--- a/manifests/audit.pp
+++ b/manifests/audit.pp
@@ -1,0 +1,41 @@
+class wazuh::audit (
+  $audit_manage_rules = false,
+  $audit_buffer_bytes = "8192",
+  $audit_backlog_wait_time = "0",
+  $audit_rules = [],
+) {
+
+  case $::kernel {
+    'Linux': {
+      case $::operatingsystem {
+        'Debian', 'debian', 'Ubuntu', 'ubuntu': {
+          package { 'Installing Audit...':
+            name => 'auditd',
+          }
+        }
+        default: {
+          package { 'Installing Audit...':
+            name => 'audit'
+          }
+        }
+      }
+
+      service { 'auditd':
+        ensure => running,
+        enable => true,
+      }
+
+      if $audit_manage_rules == true {
+
+        file { 'Configure audit.rules':
+          owner   => 'root',
+          group   => 'root',
+          path    => '/etc/audit/rules.d/audit.rules',
+          mode    => '0644',
+          notify  => Service['auditd'], ## Restarts the service
+          content => template('wazuh/audit_rules.erb')
+        }
+      }
+    }
+  }
+}

--- a/manifests/audit.pp
+++ b/manifests/audit.pp
@@ -26,14 +26,16 @@ class wazuh::audit (
       }
 
       if $audit_manage_rules == true {
+        file { '/etc/audit/rules.d/audit.rules':
+          ensure => present
+        }
 
-        file { 'Configure audit.rules':
-          owner   => 'root',
-          group   => 'root',
-          path    => '/etc/audit/rules.d/audit.rules',
-          mode    => '0644',
-          notify  => Service['auditd'], ## Restarts the service
-          content => template('wazuh/audit_rules.erb')
+        $audit_rules.each |String $rule| {
+          file_line { "Append rule ${rule} to /etc/audit/rules.d/audit.rules":
+            path    => '/etc/audit/rules.d/audit.rules',
+            line    => $rule,
+            require => File['/etc/audit/rules.d/audit.rules']
+          }
         }
       }
     }

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -228,7 +228,12 @@ class wazuh::params_agent {
       $audit_manage_rules                = false
       $audit_buffer_bytes                = "8192"
       $audit_backlog_wait_time           = "0"
-      $audit_rules                       = []
+      $audit_rules                       = [
+        '-D',
+        "-b ${audit_buffer_bytes}",
+        "--backlog_wait_time ${audit_backlog_wait_time}",
+        "-f 1"
+      ]
 
       # active-response
       $active_response_linux_ca_store = '/var/ossec/etc/wpk_root.pem'

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -224,6 +224,12 @@ class wazuh::params_agent {
       $ossec_syscheck_nodiff = '/etc/ssl/private.key'
       $ossec_syscheck_skip_nfs = 'yes'
 
+      # Audit
+      $audit_manage_rules                = false
+      $audit_buffer_bytes                = "8192"
+      $audit_backlog_wait_time           = "0"
+      $audit_rules                       = []
+
       # active-response
       $active_response_linux_ca_store = '/var/ossec/etc/wpk_root.pem'
 

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -229,7 +229,6 @@ class wazuh::params_agent {
       $audit_buffer_bytes                = "8192"
       $audit_backlog_wait_time           = "0"
       $audit_rules                       = [
-        '-D',
         "-b ${audit_buffer_bytes}",
         "--backlog_wait_time ${audit_backlog_wait_time}",
         "-f 1"

--- a/templates/audit_rules.erb
+++ b/templates/audit_rules.erb
@@ -1,18 +1,5 @@
-## First rule - delete all
--D
-
-## Increase the buffers to survive stress events.
-## Make this bigger for busy systems
--b <%= @audit_buffer_bytes %>
-
-## This determine how long to wait in burst of events
---backlog_wait_time <%= @audit_backlog_wait_time %>
-
-## Set failure mode to syslog
--f 1
-
 <% if !@audit_rules.empty? -%>
-  <% @audit_rules.each do |audit_rule| -%>
-    <%= audit_rule %>
-  <%- end -%>
+<% @audit_rules.each do |audit_rule| -%>
+<%= audit_rule %>
+<%- end -%>
 <%- end -%>

--- a/templates/audit_rules.erb
+++ b/templates/audit_rules.erb
@@ -1,5 +1,0 @@
-<% if !@audit_rules.empty? -%>
-<% @audit_rules.each do |audit_rule| -%>
-<%= audit_rule %>
-<%- end -%>
-<%- end -%>

--- a/templates/audit_rules.erb
+++ b/templates/audit_rules.erb
@@ -1,0 +1,18 @@
+## First rule - delete all
+-D
+
+## Increase the buffers to survive stress events.
+## Make this bigger for busy systems
+-b <%= @audit_buffer_bytes %>
+
+## This determine how long to wait in burst of events
+--backlog_wait_time <%= @audit_backlog_wait_time %>
+
+## Set failure mode to syslog
+-f 1
+
+<% if !@audit_rules.empty? -%>
+  <% @audit_rules.each do |audit_rule| -%>
+    <%= audit_rule %>
+  <%- end -%>
+<%- end -%>


### PR DESCRIPTION
The PR implements the option to configure audit rules from the Wazuh module
it self. This also moves audit configuration and installation to a separate
pp file for better management.