### PR TITLE
Fixes #250, adds $ossec_remote_local_ip parameter

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -26,6 +26,7 @@ class wazuh::manager (
       $ossec_remote_connection          = $wazuh::params_manager::ossec_remote_connection,
       $ossec_remote_port                = $wazuh::params_manager::ossec_remote_port,
       $ossec_remote_protocol            = $wazuh::params_manager::ossec_remote_protocol,
+      $ossec_remote_local_ip            = $wazuh::params_manager::ossec_remote_local_ip,
       $ossec_remote_queue_size          = $wazuh::params_manager::ossec_remote_queue_size,
 
       # ossec.conf generation parameters

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -26,6 +26,7 @@ class wazuh::params_manager {
       $ossec_remote_connection                         = 'secure'
       $ossec_remote_port                               = 1514
       $ossec_remote_protocol                           = 'udp'
+      $ossec_remote_local_ip                           = undef
       $ossec_remote_queue_size                         = 131072
 
     # ossec.conf generation parameters

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -33,6 +33,9 @@
     <connection><%= @ossec_remote_connection %></connection>
     <port><%= @ossec_remote_port %></port>
     <protocol><%= @ossec_remote_protocol %></protocol>
+  <%- if @ossec_remote_local_ip -%>
+    <local_ip><%= @ossec_remote_local_ip %></local_ip>
+  <%- end -%>
     <queue_size><%= @ossec_remote_queue_size %></queue_size>
   </remote>
 


### PR DESCRIPTION
The default is `undef` and the template only includes the <local_ip/>
tag if $ossec_remote_local_ip is NOT `undef`.  This prevents
interference with the current behavior for those users who do not need
to alter $ossec_remote_local_ip.