### PR TITLE
limit install of apt-transport-https to only occur on older distros

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,7 +5,7 @@ class wazuh::repo (
 
   case $::osfamily {
     'Debian' : {
-      if ! defined(Package['apt-transport-https']) {
+      if $::lsbdistcodename =~ /(jessie|wheezy|stretch|precise|trusty|vivid|wily|xenial|yakketi)/ and ! defined(Package['apt-transport-https']) {
         ensure_packages(['apt-transport-https'], {'ensure' => 'present'})
       }
       # apt-key added by issue #34


### PR DESCRIPTION
Support for https for apt sources has been integrated into the main apt code for recent apt versions.     So on later debian/ubuntu versions the apt-transport-https is a transitional package that doesn't need to be installed.

This merge request limits the install of apt-transport-https to only occur on older debian/ubuntu versions prior to https support being built into apt.    This stops an unneeded transitional package being installed on later distros.

It might also prevent future problems with later debian/ubuntu versions.   Since it's unlikely the apt-transport-https transitional package will be kept forever.


For reference
https://packages.debian.org/search?keywords=apt-transport-https&searchon=names&suite=all&section=all&sourceid=mozilla-search
https://packages.ubuntu.com/search?keywords=apt-transport-https&searchon=names&suite=all&section=all
show (via the package descriptions) current debian/ubuntu versions that still need apt-transport-https vs ones where it's just a transitional package.