### PR TITLE
Notify service when authkey changes. Otherwise old key is still used

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -539,6 +539,7 @@ class wazuh::agent (
           unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
           require => Concat['ossec.conf'],
           before  => Service[$agent_service_name],
+          notify  => Service[$agent_service_name],
         }
 
         service { $agent_service_name:
@@ -566,6 +567,7 @@ class wazuh::agent (
           onlyif   => "if ((Get-Item '${$::wazuh::params_agent::keys_file}').length -gt 0kb) {exit 1}",
           require  => Concat['ossec.conf'],
           before   => Service[$agent_service_name],
+          notify   => Service[$agent_service_name],
         }
 
         service { $agent_service_name:

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -533,6 +533,7 @@ class wazuh::manager (
       mode    => $wazuh::params_manager::keys_mode,
       content => $agent_auth_password,
       require => Package[$wazuh::params_manager::server_package],
+      notify  => Service[$wazuh::params_manager::server_service],
     }
   }
 


### PR DESCRIPTION
I found out that when you changed the agent_auth_password, the manager service needs to be restarted for the new key to be used. Otherwise the old key is still begin used.

This fixes that.