### PR TITLE
Close the SCA policies tag

### DIFF
--- a/templates/fragments/_sca.erb
+++ b/templates/fragments/_sca.erb
@@ -66,6 +66,7 @@
   <% @sca_else_policies.each do |policy| -%>
       <policy><%= policy %></policy>
   <%- end -%>
+  </policies>
   <policies>
   <%- if @debian_additional_templates == 'yes' -%>
     <policy>cis_debianlinux7-8_L1_rcl.yml</policy>


### PR DESCRIPTION
`policies` tag is not closed and the XML cannot be parsed. This fix closes the tag.