### PR TITLE
Added configurable MSI download location for offline environments

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -9,6 +9,7 @@ class wazuh::agent (
   $agent_package_name                = $wazuh::params_agent::agent_package_name,
   $agent_service_name                = $wazuh::params_agent::agent_service_name,
   $agent_service_ensure              = $wazuh::params_agent::agent_service_ensure,
+  $agent_msi_download_location       = $wazuh::params_agent::agent_msi_download_location,
 
   # Manage repository
 
@@ -274,7 +275,7 @@ class wazuh::agent (
         owner              => 'Administrator',
         group              => 'Administrators',
         mode               => '0774',
-        source             => "http://packages.wazuh.com/3.x/windows/wazuh-agent-${agent_package_version}.msi",
+        source             => "${agent_msi_download_location}/wazuh-agent-${agent_package_version}.msi",
         source_permissions => ignore
       }
 

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -3,6 +3,7 @@
 class wazuh::params_agent {
   $agent_package_version = '3.13.1-1'
   $agent_service_ensure = 'running'
+  $agent_msi_download_location = 'http://packages.wazuh.com/3.x/windows'
 
   $agent_name = undef
   $agent_group = undef


### PR DESCRIPTION
This PR is to make the download location of the MSI package configurable.

Because we work mainly in Enterprise environments and they tend to have no Internet access on their servers, i would like this merged so that in future version, we can configure our own download location.

It would be even better if their would be (configurable) support for chocolatey. But I believe this is allready a step in the right direction.