### PR TITLE
Adding support for ES and OD on Github Action tests

### DIFF
--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -28,3 +28,36 @@ wazuh_daemons.each do |key, value|
     its('users') { is_expected.to eq [value] }
   end
 end
+
+describe package('elasticsearch') do
+  it { is_expected.to be_installed }
+  its('version') { is_expected.to eq '7.8.1-1' }
+end
+
+describe service('elasticsearch') do
+  it { is_expected.to be_installed }
+  it { is_expected.to be_enabled }
+  it { is_expected.to be_running }
+end
+
+describe package('filebeat') do
+  it { is_expected.to be_installed }
+  its('version') { is_expected.to eq '7.8.1-1' }
+end
+
+describe service('filebeat') do
+  it { is_expected.to be_installed }
+  it { is_expected.to be_enabled }
+  it { is_expected.to be_running }
+end
+
+describe package('kibana') do
+  it { is_expected.to be_installed }
+  its('version') { is_expected.to eq '7.8.1-1' }
+end
+
+describe service('kibana') do
+  it { is_expected.to be_installed }
+  it { is_expected.to be_enabled }
+  it { is_expected.to be_running }
+end


### PR DESCRIPTION
Hi team,

This PR enables support for ES and OD for our `wazuh-puppet` Github Action tests.
This PR closes #288.

Greetings,

JP