### PR TITLE
ossec.conf concat resources rename

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -540,7 +540,7 @@ class wazuh::agent (
         exec { 'agent-auth-linux':
           command => $agent_auth_command,
           unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
-          require => Concat['ossec.conf'],
+          require => Concat['agent_ossec.conf'],
           before  => Service[$agent_service_name],
         }
 
@@ -567,7 +567,7 @@ class wazuh::agent (
           command  => $agent_auth_command,
           provider => 'powershell',
           onlyif   => "if ((Get-Item '${$::wazuh::params_agent::keys_file}').length -gt 0kb) {exit 1}",
-          require  => Concat['ossec.conf'],
+          require  => Concat['agent_ossec.conf'],
           before   => Service[$agent_service_name],
         }
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -327,7 +327,7 @@ class wazuh::agent (
   }
 
 
-  concat { 'ossec.conf':
+  concat { 'agent_ossec.conf':
     path    => $wazuh::params_agent::config_file,
     owner   => $wazuh::params_agent::config_owner,
     group   => $wazuh::params_agent::config_group,
@@ -339,12 +339,12 @@ class wazuh::agent (
 
   concat::fragment {
     'ossec.conf_header':
-      target  => 'ossec.conf',
+      target  => 'agent_ossec.conf',
       order   => 00,
       before  => Service[$agent_service_name],
       content => "<ossec_config>\n";
     'ossec.conf_agent':
-      target  => 'ossec.conf',
+      target  => 'agent_ossec.conf',
       order   => 10,
       before  => Service[$agent_service_name],
       content => template($ossec_conf_template);
@@ -353,7 +353,7 @@ class wazuh::agent (
   if ($configure_rootcheck == true) {
     concat::fragment {
       'ossec.conf_rootcheck':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 15,
         before  => Service[$agent_service_name],
         content => template($ossec_rootcheck_template);
@@ -362,7 +362,7 @@ class wazuh::agent (
   if ($configure_wodle_openscap == true) {
     concat::fragment {
       'ossec.conf_openscap':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 16,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_openscap_template);
@@ -371,7 +371,7 @@ class wazuh::agent (
   if ($configure_wodle_cis_cat == true) {
     concat::fragment {
       'ossec.conf_cis_cat':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 17,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_cis_cat_template);
@@ -380,7 +380,7 @@ class wazuh::agent (
   if ($configure_wodle_osquery == true) {
     concat::fragment {
       'ossec.conf_osquery':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 18,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_osquery_template);
@@ -389,7 +389,7 @@ class wazuh::agent (
   if ($configure_wodle_syscollector == true) {
     concat::fragment {
       'ossec.conf_syscollector':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 19,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_syscollector_template);
@@ -398,7 +398,7 @@ class wazuh::agent (
   if ($configure_sca == true) {
     concat::fragment {
       'ossec.conf_sca':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 25,
         before  => Service[$agent_service_name],
         content => template($ossec_sca_template);
@@ -407,7 +407,7 @@ class wazuh::agent (
   if ($configure_syscheck == true) {
     concat::fragment {
       'ossec.conf_syscheck':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 30,
         before  => Service[$agent_service_name],
         content => template($ossec_syscheck_template);
@@ -416,7 +416,7 @@ class wazuh::agent (
   if ($configure_localfile == true) {
     concat::fragment {
       'ossec.conf_localfile':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 35,
         before  => Service[$agent_service_name],
         content => template($ossec_localfile_template);
@@ -442,7 +442,7 @@ class wazuh::agent (
   if ($configure_labels == true){
     concat::fragment {
         'ossec.conf_labels':
-        target  => 'ossec.conf',
+        target  => 'agent_ossec.conf',
         order   => 45,
         before  => Service[$agent_service_name],
         content => template($ossec_labels_template);
@@ -451,7 +451,7 @@ class wazuh::agent (
 
   concat::fragment {
     'ossec.conf_footer':
-      target  => 'ossec.conf',
+      target  => 'agent_ossec.conf',
       order   => 99,
       before  => Service[$agent_service_name],
       content => '</ossec_config>';

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -383,7 +383,7 @@ class wazuh::manager (
 
 
 
-  concat { 'ossec.conf':
+  concat { 'manager_ossec.conf':
     path    => $wazuh::params_manager::config_file,
     owner   => $wazuh::params_manager::config_owner,
     group   => $wazuh::params_manager::config_group,
@@ -393,11 +393,11 @@ class wazuh::manager (
   }
   concat::fragment {
     'ossec.conf_header':
-      target  => 'ossec.conf',
+      target  => 'manager_ossec.conf',
       order   => 00,
       content => "<ossec_config>\n";
     'ossec.conf_main':
-      target  => 'ossec.conf',
+      target  => 'manager_ossec.conf',
       order   => 01,
       content => template($ossec_manager_template);
   }
@@ -405,7 +405,7 @@ class wazuh::manager (
   if ($syslog_output == true){
     concat::fragment {
       'ossec.conf_syslog_output':
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_syslog_output_template);
     }
   }
@@ -414,7 +414,7 @@ class wazuh::manager (
     concat::fragment {
         'ossec.conf_rootcheck':
           order   => 10,
-          target  => 'ossec.conf',
+          target  => 'manager_ossec.conf',
           content => template($ossec_rootcheck_template);
       }
   }
@@ -423,7 +423,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_wodle_openscap':
         order   => 15,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_wodle_openscap_template);
     }
   }
@@ -431,7 +431,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_wodle_ciscat':
         order   => 20,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_wodle_cis_cat_template);
     }
   }
@@ -439,7 +439,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_wodle_osquery':
         order   => 25,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_wodle_osquery_template);
     }
   }
@@ -447,7 +447,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_wodle_syscollector':
         order   => 30,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_wodle_syscollector_template);
     }
   }
@@ -455,7 +455,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_sca':
         order   => 40,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_sca_template);
       }
   }
@@ -463,7 +463,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_vulnerability_detector':
         order   => 45,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_vulnerability_detector_template);
     }
   }
@@ -471,7 +471,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_syscheck':
         order   => 55,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_syscheck_template);
     }
   }
@@ -479,7 +479,7 @@ class wazuh::manager (
     concat::fragment {
           'ossec.conf_command':
             order   => 60,
-            target  => 'ossec.conf',
+            target  => 'manager_ossec.conf',
             content => template($ossec_default_commands_template);
       }
   }
@@ -487,7 +487,7 @@ class wazuh::manager (
     concat::fragment {
       'ossec.conf_localfile':
         order   => 65,
-        target  => 'ossec.conf',
+        target  => 'manager_ossec.conf',
         content => template($ossec_localfile_template);
     }
   }
@@ -495,7 +495,7 @@ class wazuh::manager (
     concat::fragment {
         'ossec.conf_ruleset':
           order   => 75,
-          target  => 'ossec.conf',
+          target  => 'manager_ossec.conf',
           content => template($ossec_ruleset_template);
       }
   }
@@ -503,7 +503,7 @@ class wazuh::manager (
     concat::fragment {
         'ossec.conf_auth':
           order   => 80,
-          target  => 'ossec.conf',
+          target  => 'manager_ossec.conf',
           content => template($ossec_auth_template);
       }
   }
@@ -511,7 +511,7 @@ class wazuh::manager (
     concat::fragment {
         'ossec.conf_cluster':
           order   => 85,
-          target  => 'ossec.conf',
+          target  => 'manager_ossec.conf',
           content => template($ossec_cluster_template);
       }
   }
@@ -529,7 +529,7 @@ class wazuh::manager (
   }
   concat::fragment {
     'ossec.conf_footer':
-      target  => 'ossec.conf',
+      target  => 'manager_ossec.conf',
       order   => 99,
       content => "</ossec_config>\n";
   }


### PR DESCRIPTION
Hi team,

This PR renames the `concat` resources used to render the `ossec.conf` template in both agent and manager classes.
This PR closes #261. It has been tested locally.

Greetings,

JP