### PR TITLE
syscheck 'report_changes' option requires a blank line

### DIFF
--- a/templates/fragments/_syscheck.erb
+++ b/templates/fragments/_syscheck.erb
@@ -119,10 +119,10 @@
 
 <%- else -%>
   <%- if @ossec_syscheck_directories_1 -%>
-  <directories check_all="yes" <%- if @ossec_syscheck_whodata_directories_1 == 'yes' -%>whodata="<%=@ossec_syscheck_whodata_directories_1%>"<%- end -%> <%- if @ossec_syscheck_realtime_directories_1 == 'yes'  -%> realtime="<%=@ossec_syscheck_realtime_directories_1%>"<%- end -%> <%- if @ossec_syscheck_report_changes_directories_1 == 'yes' -%>report_changes="<%=@ossec_syscheck_report_changes_directories_1%>"<%- end -%>><%=@ossec_syscheck_directories_1%></directories>
+  <directories check_all="yes" <%- if @ossec_syscheck_whodata_directories_1 == 'yes' -%>whodata="<%=@ossec_syscheck_whodata_directories_1%>"<%- end -%> <%- if @ossec_syscheck_realtime_directories_1 == 'yes'  -%> realtime="<%=@ossec_syscheck_realtime_directories_1%>"<%- end -%> <%- if @ossec_syscheck_report_changes_directories_1 == 'yes' -%> report_changes="<%=@ossec_syscheck_report_changes_directories_1%>"<%- end -%>><%=@ossec_syscheck_directories_1%></directories>
   <%- end -%>
   <%- if @ossec_syscheck_directories_2 -%>
-  <directories check_all="yes" <%- if @ossec_syscheck_whodata_directories_2 == 'yes'  -%>whodata="<%=@ossec_syscheck_whodata_directories_2%>"<%- end -%> <%- if @ossec_syscheck_realtime_directories_2 == 'yes' -%> realtime="<%=@ossec_syscheck_realtime_directories_2%>"<%- end -%> <%- if @ossec_syscheck_report_changes_directories_2 == 'yes' -%>report_changes="<%=@ossec_syscheck_report_changes_directories_2%>"<%- end -%>><%=@ossec_syscheck_directories_2%></directories>
+  <directories check_all="yes" <%- if @ossec_syscheck_whodata_directories_2 == 'yes'  -%>whodata="<%=@ossec_syscheck_whodata_directories_2%>"<%- end -%> <%- if @ossec_syscheck_realtime_directories_2 == 'yes' -%> realtime="<%=@ossec_syscheck_realtime_directories_2%>"<%- end -%> <%- if @ossec_syscheck_report_changes_directories_2 == 'yes' -%> report_changes="<%=@ossec_syscheck_report_changes_directories_2%>"<%- end -%>><%=@ossec_syscheck_directories_2%></directories>
   <%- end -%>
   <%- if @ossec_syscheck_ignore_list -%>
     <%- @ossec_syscheck_ignore_list.each do |ignore_element| -%>


### PR DESCRIPTION
This should fix this error I am seeing 'CRITICAL: (1226): Error reading XML file '/var/ossec/etc/ossec.conf':  (line 0).'

Happens whenever I try to enable the ossec_syscheck_report_changes_directories_[1-2] parameters.