### PR TITLE
Fabian1976 fix authkey change

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -562,6 +562,7 @@ class wazuh::agent (
           unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
           require => Concat['agent_ossec.conf'],
           before  => Service[$agent_service_name],
+          notify  => Service[$agent_service_name],
         }
 
         service { $agent_service_name:
@@ -589,6 +590,7 @@ class wazuh::agent (
           onlyif   => "if ((Get-Item '${$::wazuh::params_agent::keys_file}').length -gt 0kb) {exit 1}",
           require  => Concat['agent_ossec.conf'],
           before   => Service[$agent_service_name],
+          notify   => Service[$agent_service_name],
         }
 
         service { $agent_service_name:

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -583,6 +583,7 @@ class wazuh::manager (
       mode    => $wazuh::params_manager::keys_mode,
       content => $agent_auth_password,
       require => Package[$wazuh::params_manager::server_package],
+      notify  => Service[$wazuh::params_manager::server_service],
     }
   }
 


### PR DESCRIPTION
_This PR was [originally](https://github.com/wazuh/wazuh-puppet/pull/265) opened by @Fabian1976_


I found out that when you changed the agent_auth_password, the manager service needs to be restarted for the new key to be used. Otherwise the old key is still begin used.

This fixes that.