### PR TITLE
Add path to agent-auth-linux exec

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -559,7 +559,8 @@ class wazuh::agent (
 
         exec { 'agent-auth-linux':
           command => $agent_auth_command,
-          unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
+          path    => ['/usr/bin', '/usr/sbin', '/bin'],
+          unless  => "egrep -q '.' ${::wazuh::params_agent::keys_file}",
           require => Concat['agent_ossec.conf'],
           before  => Service[$agent_service_name],
           notify  => Service[$agent_service_name],


### PR DESCRIPTION
Exec without path cannot evaluate:
`Error: /Stage[main]/Wazuh::Agent/Exec[agent-auth-linux]: Could not evaluate: /bin/egrep: 2: exec: grep: not found`

Changed configuration is working with version 6 (Puppet agent and server) on Debian (8, 9, 10) and CentOS (7, 8).