### PR TITLE
Rename daemons from ossec-* to wazuh-*

### DIFF
--- a/kitchen/README.md
+++ b/kitchen/README.md
@@ -215,7 +215,7 @@ collecting ... collected 8 items
 test/base/test_wazuh_agent.py::test_wazuh_agent_package SKIPPED          [ 12%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-agentd-ossec] SKIPPED [ 25%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-execd-root] SKIPPED [ 37%]
-test/base/test_wazuh_agent.py::test_wazuh_processes_running[ossec-syscheckd-root] SKIPPED [ 50%]
+test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-syscheckd-root] SKIPPED [ 50%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-modulesd-root] SKIPPED [ 62%]
 test/base/test_wazuh_manager.py::test_wazuh_agent_package PASSED         [ 75%]
 test/base/test_wazuh_manager.py::test_wazuh_packages_are_installed PASSED [ 87%]

--- a/kitchen/README.md
+++ b/kitchen/README.md
@@ -213,7 +213,7 @@ plugins: testinfra-3.0.5
 collecting ... collected 8 items
 
 test/base/test_wazuh_agent.py::test_wazuh_agent_package SKIPPED          [ 12%]
-test/base/test_wazuh_agent.py::test_wazuh_processes_running[ossec-agentd-ossec] SKIPPED [ 25%]
+test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-agentd-ossec] SKIPPED [ 25%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[ossec-execd-root] SKIPPED [ 37%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[ossec-syscheckd-root] SKIPPED [ 50%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-modulesd-root] SKIPPED [ 62%]

--- a/kitchen/README.md
+++ b/kitchen/README.md
@@ -214,7 +214,7 @@ collecting ... collected 8 items
 
 test/base/test_wazuh_agent.py::test_wazuh_agent_package SKIPPED          [ 12%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-agentd-ossec] SKIPPED [ 25%]
-test/base/test_wazuh_agent.py::test_wazuh_processes_running[ossec-execd-root] SKIPPED [ 37%]
+test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-execd-root] SKIPPED [ 37%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[ossec-syscheckd-root] SKIPPED [ 50%]
 test/base/test_wazuh_agent.py::test_wazuh_processes_running[wazuh-modulesd-root] SKIPPED [ 62%]
 test/base/test_wazuh_manager.py::test_wazuh_agent_package PASSED         [ 75%]

--- a/kitchen/test/integration/agent/agent_spec.rb
+++ b/kitchen/test/integration/agent/agent_spec.rb
@@ -17,7 +17,7 @@ control 'wazuh-agent' do
   wazuh_daemons = {
     # 'wazuh-agentd' => 'ossec',
     'wazuh-execd' => 'root',
-    # 'ossec-syscheckd' => 'root',
+    # 'wazuh-syscheckd' => 'root',
     # 'wazuh-modulesd' => 'root',
   }
 

--- a/kitchen/test/integration/agent/agent_spec.rb
+++ b/kitchen/test/integration/agent/agent_spec.rb
@@ -15,7 +15,7 @@ control 'wazuh-agent' do
 
   # Verifying daemons
   wazuh_daemons = {
-    # 'ossec-agentd' => 'ossec',
+    # 'wazuh-agentd' => 'ossec',
     'ossec-execd' => 'root',
     # 'ossec-syscheckd' => 'root',
     # 'wazuh-modulesd' => 'root',

--- a/kitchen/test/integration/agent/agent_spec.rb
+++ b/kitchen/test/integration/agent/agent_spec.rb
@@ -16,7 +16,7 @@ control 'wazuh-agent' do
   # Verifying daemons
   wazuh_daemons = {
     # 'wazuh-agentd' => 'ossec',
-    'ossec-execd' => 'root',
+    'wazuh-execd' => 'root',
     # 'ossec-syscheckd' => 'root',
     # 'wazuh-modulesd' => 'root',
   }

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -18,7 +18,7 @@ control 'wazuh-manager' do
   wazuh_daemons = {
     'ossec-authd' => 'root',
     'ossec-execd' => 'root',
-    'ossec-analysisd' => 'ossec',
+    'wazuh-analysisd' => 'ossec',
     'ossec-syscheckd' => 'root',
     'ossec-remoted' => 'ossecr',
     'ossec-logcollector' => 'root',

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -20,7 +20,7 @@ control 'wazuh-manager' do
     'wazuh-execd' => 'root',
     'wazuh-analysisd' => 'ossec',
     'ossec-syscheckd' => 'root',
-    'ossec-remoted' => 'ossecr',
+    'wazuh-remoted' => 'ossecr',
     'wazuh-logcollector' => 'root',
     'wazuh-monitord' => 'ossec',
     'wazuh-db' => 'ossec',

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -17,7 +17,7 @@ control 'wazuh-manager' do
   # Verifying daemons
   wazuh_daemons = {
     'ossec-authd' => 'root',
-    'ossec-execd' => 'root',
+    'wazuh-execd' => 'root',
     'wazuh-analysisd' => 'ossec',
     'ossec-syscheckd' => 'root',
     'ossec-remoted' => 'ossecr',

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -16,7 +16,7 @@ control 'wazuh-manager' do
 
   # Verifying daemons
   wazuh_daemons = {
-    'ossec-authd' => 'root',
+    'wazuh-authd' => 'root',
     'wazuh-execd' => 'root',
     'wazuh-analysisd' => 'ossec',
     'wazuh-syscheckd' => 'root',

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -21,7 +21,7 @@ control 'wazuh-manager' do
     'wazuh-analysisd' => 'ossec',
     'ossec-syscheckd' => 'root',
     'ossec-remoted' => 'ossecr',
-    'ossec-logcollector' => 'root',
+    'wazuh-logcollector' => 'root',
     'ossec-monitord' => 'ossec',
     'wazuh-db' => 'ossec',
     'wazuh-modulesd' => 'root',

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -19,7 +19,7 @@ control 'wazuh-manager' do
     'ossec-authd' => 'root',
     'wazuh-execd' => 'root',
     'wazuh-analysisd' => 'ossec',
-    'ossec-syscheckd' => 'root',
+    'wazuh-syscheckd' => 'root',
     'wazuh-remoted' => 'ossecr',
     'wazuh-logcollector' => 'root',
     'wazuh-monitord' => 'ossec',

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -22,7 +22,7 @@ control 'wazuh-manager' do
     'ossec-syscheckd' => 'root',
     'ossec-remoted' => 'ossecr',
     'wazuh-logcollector' => 'root',
-    'ossec-monitord' => 'ossec',
+    'wazuh-monitord' => 'ossec',
     'wazuh-db' => 'ossec',
     'wazuh-modulesd' => 'root',
   }

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -436,7 +436,7 @@ class wazuh::params_agent {
       $keys_file = 'C:\\Program Files (x86)\\ossec-agent\\client.keys'
 
       $agent_package_name = 'Wazuh Agent'
-      $agent_service_name = 'OssecSvc'
+      $agent_service_name = 'WazuhSvc'
       $service_has_status = true
       $ossec_service_provider = undef
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -533,7 +533,7 @@ class wazuh::params_manager {
       $keys_owner = 'Administrator'
       $keys_group = 'Administrators'
 
-      $agent_service  = 'OssecSvc'
+      $agent_service  = 'WazuhSvc'
       $agent_package  = 'Wazuh Agent 4.0.3'
       $server_service = ''
       $server_package = ''

--- a/templates/process_list.erb
+++ b/templates/process_list.erb
@@ -4,5 +4,5 @@
 CSYSLOG_DAEMON=wazuh-csyslogd
 <% end -%>
 <% if @ossec_integratord_enabled -%>
-INTEGRATOR_DAEMON=ossec-integratord
+INTEGRATOR_DAEMON=wazuh-integratord
 <% end -%>

--- a/templates/process_list.erb
+++ b/templates/process_list.erb
@@ -1,7 +1,7 @@
 # This file managed by Puppet.
 # Any changes will be overwritten
 <% if @syslog_output -%>
-CSYSLOG_DAEMON=ossec-csyslogd
+CSYSLOG_DAEMON=wazuh-csyslogd
 <% end -%>
 <% if @ossec_integratord_enabled -%>
 INTEGRATOR_DAEMON=ossec-integratord


### PR DESCRIPTION
For details see issue 324. A quick search for references:

```
rg ossec-agentd
rg ossec-agentlessd
rg ossec-analysisd
rg ossec-authd
rg ossec-csyslogd
rg ossec-dbd
rg ossec-execd
rg ossec-integratord
rg ossec-logcollector
rg ossec-maild
rg ossec-monitord
rg ossec-remoted
rg ossec-reportd
rg ossec-syscheckd
rg ossec-agent.exe
rg ossec-agent-eventchannel.exe
rg ossec-rootcheck.exe
rg OssecSvc
```

Shows no output. A greedier search with `rg ossec-` shows unrelated items.