### PR TITLE
Integrations: Use manager ossec conf as render target.

### DIFF
--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -14,7 +14,7 @@ define wazuh::integration(
   require wazuh::params_manager
 
   concat::fragment { $name:
-    target  => 'ossec.conf',
+    target  => 'manager_ossec.conf',
     order   => 60,
     content => template('wazuh/fragments/_integration.erb')
   }

--- a/templates/fragments/_integration.erb
+++ b/templates/fragments/_integration.erb
@@ -18,7 +18,9 @@
     <% if @in_location != '' -%>
       <event_location><%= @in_location %></event_location>
     <% end %>
+    <% if @in_format != '' -%>
     <alert_format><%= @in_format %></alert_format>
+    <% end %>
     <% if @in_max_log != '' -%>
       <max_log><%= @in_max_log %></max_log>
     <% end %>


### PR DESCRIPTION
Hi team,

This PR sets manager `ossec.conf` file as `_integration.erb` fragment render target. It also adds a conditional statement to logs format option.


Greetings,

JP