### PR TITLE
Fix stdlib deprecation warnings 

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -250,8 +250,8 @@ class wazuh::agent (
   # )
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)
-  validate_string($agent_package_name)
-  validate_string($agent_service_name)
+  validate_legacy(String, 'validate_string', $agent_package_name)
+  validate_legacy(String, 'validate_string', $agent_service_name)
 
   if (( $ossec_syscheck_whodata_directories_1 == 'yes' ) or ( $ossec_syscheck_whodata_directories_2 == 'yes' )) {
     class { 'wazuh::audit':
@@ -480,14 +480,14 @@ class wazuh::agent (
   # Agent registration and service setup
   if ($manage_client_keys == 'yes') {
     if $agent_name {
-      validate_string($agent_name)
+      validate_legacy(String, 'validate_string', $agent_name)
       $agent_auth_option_name = "-A \"${agent_name}\""
     } else {
       $agent_auth_option_name = ''
     }
 
     if $agent_group {
-      validate_string($agent_group)
+      validate_legacy(String, 'validate_string', $agent_group)
       $agent_auth_option_group = "-G \"${agent_group}\""
     } else {
       $agent_auth_option_group = ''
@@ -512,7 +512,7 @@ class wazuh::agent (
 
         # https://documentation.wazuh.com/4.0/user-manual/registering/manager-verification/manager-verification-registration.html
         if $wazuh_manager_root_ca_pem != undef {
-          validate_string($wazuh_manager_root_ca_pem)
+          validate_legacy(String, 'validate_string', $wazuh_manager_root_ca_pem)
           file { '/var/ossec/etc/rootCA.pem':
             owner   => $wazuh::params_agent::keys_owner,
             group   => $wazuh::params_agent::keys_group,
@@ -522,7 +522,7 @@ class wazuh::agent (
           }
           $agent_auth_option_manager = '-v /var/ossec/etc/rootCA.pem'
         } elsif $wazuh_manager_root_ca_pem_path != undef {
-          validate_string($wazuh_manager_root_ca_pem)
+          validate_legacy(String, 'validate_string', $wazuh_manager_root_ca_pem)
           $agent_auth_option_manager = "-v ${wazuh_manager_root_ca_pem_path}"
         } else {
           $agent_auth_option_manager = ''  # Avoid errors when compounding final command
@@ -530,8 +530,8 @@ class wazuh::agent (
 
         # https://documentation.wazuh.com/4.0/user-manual/registering/manager-verification/agent-verification-registration.html
         if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
-          validate_string($wazuh_agent_cert)
-          validate_string($wazuh_agent_key)
+          validate_legacy(String, 'validate_string', $wazuh_agent_cert)
+          validate_legacy(String, 'validate_string', $wazuh_agent_key)
           file { '/var/ossec/etc/sslagent.cert':
             owner   => $wazuh::params_agent::keys_owner,
             group   => $wazuh::params_agent::keys_group,
@@ -549,8 +549,8 @@ class wazuh::agent (
 
           $agent_auth_option_agent = '-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key'
         } elsif ($wazuh_agent_cert_path != undef) and ($wazuh_agent_key_path != undef) {
-          validate_string($wazuh_agent_cert_path)
-          validate_string($wazuh_agent_key_path)
+          validate_legacy(String, 'validate_string', $wazuh_agent_cert_path)
+          validate_legacy(String, 'validate_string', $wazuh_agent_key_path)
           $agent_auth_option_agent = "-x ${wazuh_agent_cert_path} -k ${wazuh_agent_key_path}"
         } else {
           $agent_auth_option_agent = ''

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -301,11 +301,11 @@ class wazuh::manager (
 
 
 ) inherits wazuh::params_manager {
-  validate_bool(
-    $manage_repos, $syslog_output,$wazuh_manager_verify_manager_ssl
+  validate_legacy(
+    Boolean, 'validate_bool', $manage_repos, $syslog_output,$wazuh_manager_verify_manager_ssl
   )
-  validate_array(
-    $decoder_exclude, $rule_exclude
+  validate_legacy(
+    Array, 'validate_array', $decoder_exclude, $rule_exclude
   )
 
   ## Determine which kernel and family puppet is running on. Will be used on _localfile, _rootcheck, _syscheck & _sca
@@ -335,14 +335,14 @@ class wazuh::manager (
 
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)
-  validate_bool($ossec_emailnotification)
+  validate_legacy(Boolean, 'validate_bool', $ossec_emailnotification)
   if ($ossec_emailnotification) {
     if $ossec_smtp_server == undef {
       fail('$ossec_emailnotification is enabled but $smtp_server was not set')
     }
-    validate_string($ossec_smtp_server)
-    validate_string($ossec_emailfrom)
-    validate_array($ossec_emailto)
+    validate_legacy(String, 'validate_string', $ossec_smtp_server)
+    validate_legacy(String, 'validate_string', $ossec_emailfrom)
+    validate_legacy(Array, 'validate_array', $ossec_emailto)
   }
 
   if $::osfamily == 'windows' {
@@ -591,8 +591,8 @@ class wazuh::manager (
   if $wazuh_manager_verify_manager_ssl {
 
     if ($wazuh_manager_server_crt != undef) and ($wazuh_manager_server_key != undef) {
-      validate_string(
-        $wazuh_manager_server_crt, $wazuh_manager_server_key
+      validate_legacy(
+        String, 'validate_string', $wazuh_manager_server_crt, $wazuh_manager_server_key
       )
 
       file { '/var/ossec/etc/sslmanager.key':

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 1.0.0 < 7.0.0"
+      "version_requirement": ">= 3.14.0 < 7.0.0"
     },
     {
       "name": "puppetlabs/concat",


### PR DESCRIPTION
This PR was [originally opened](https://github.com/wazuh/wazuh-puppet/pull/333) by @Hexta.

```
Use validate_legacy function instead of deprecated validate_* functions.
Maybe it is better to use Puppet rich data types instead of validate_* functions.
```

_- JP_ 