### PR TITLE
update target name in concat for manager_ossec.conf

### DIFF
--- a/manifests/activeresponse.pp
+++ b/manifests/activeresponse.pp
@@ -13,7 +13,7 @@ define wazuh::activeresponse(
   $active_response_timeout            = undef,
   $active_response_repeated_offenders = [],
 
-  $target_arg                         = 'manager_ossec.conf',
+  $target_arg                         = 'ossec.conf',
   $order_arg                          = undef,
   $before_arg                         = undef,
   $content_arg                        = 'wazuh/fragments/_activeresponse.erb'

--- a/manifests/activeresponse.pp
+++ b/manifests/activeresponse.pp
@@ -13,7 +13,7 @@ define wazuh::activeresponse(
   $active_response_timeout            = undef,
   $active_response_repeated_offenders = [],
 
-  $target_arg                         = 'ossec.conf',
+  $target_arg                         = 'manager_ossec.conf',
   $order_arg                          = undef,
   $before_arg                         = undef,
   $content_arg                        = 'wazuh/fragments/_activeresponse.erb'

--- a/manifests/addlog.pp
+++ b/manifests/addlog.pp
@@ -6,11 +6,12 @@ define wazuh::addlog(
   $logcommand   = undef,
   $commandalias = undef,
   $frequency    = undef,
+  $target_arg   = 'manager_ossec.conf',
 ) {
   require wazuh::params_manager
 
   concat::fragment { "ossec.conf_localfile-${logfile}":
-    target  => 'manager_ossec.conf',
+    target  => $target_arg,
     content => template('wazuh/fragments/_localfile_generation.erb'),
     order   => 21,
   }

--- a/manifests/addlog.pp
+++ b/manifests/addlog.pp
@@ -10,7 +10,7 @@ define wazuh::addlog(
   require wazuh::params_manager
 
   concat::fragment { "ossec.conf_localfile-${logfile}":
-    target  => 'ossec.conf',
+    target  => 'manager_ossec.conf',
     content => template('wazuh/fragments/_localfile_generation.erb'),
     order   => 21,
   }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -435,7 +435,8 @@ class wazuh::agent (
       active_response_timeout            =>  $ossec_active_response_timeout,
       active_response_repeated_offenders =>  $ossec_active_response_repeated_offenders,
       order_arg                          => 40,
-      before_arg                         => Service[$agent_service_name]
+      before_arg                         => Service[$agent_service_name],
+      target_arg                         => 'agent_ossec.conf',
     }
   }
 

--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -10,7 +10,7 @@ define wazuh::command(
 
   if ($timeout_allowed) { $command_timeout_allowed='yes' } else { $command_timeout_allowed='no' }
   concat::fragment { $name:
-    target  => 'ossec.conf',
+    target  => 'manager_ossec.conf',
     order   => 46,
     content => template('wazuh/fragments/_command.erb'),
   }

--- a/manifests/email_alert.pp
+++ b/manifests/email_alert.pp
@@ -7,7 +7,7 @@ define wazuh::email_alert(
   require wazuh::params_manager
 
   concat::fragment { $name:
-    target  => 'ossec.conf',
+    target  => 'manager_ossec.conf',
     order   => 66,
     content => template('wazuh/fragments/_email_alert.erb'),
   }

--- a/manifests/repo_opendistro.pp
+++ b/manifests/repo_opendistro.pp
@@ -20,7 +20,7 @@ class wazuh::repo_opendistro (
             apt::source { 'wazuh_elastic_od':
               ensure   => present,
               comment  => 'This is the Open Distro for Elastic repository',
-              location => 'ttps://d3g5vo6xdbdb9a.cloudfront.net/apt',
+              location => 'https://d3g5vo6xdbdb9a.cloudfront.net/apt',
               release  => 'stable',
               repos    => 'main',
               include  => {


### PR DESCRIPTION
Hello everyone! I think, I fix issue #322 by simple changing concat target in few classes.

Here is working example:

```  
  wazuh::addlog { 'CronLogFile':
    logfile => '/var/log/cron.log',
    logtype => 'syslog'
  }

  wazuh::email_alert { 'mail':
    alert_email => 'mail@example.com',
    alert_group => ['syslog'],
  }

  wazuh::activeresponse { 'blockWebattack':
    active_response_command            => 'firewall-drop',
    active_response_level              => 9,
    active_response_agent_id           => 123,
    active_response_rules_id           => [31153,31151],
    active_response_repeated_offenders => ['30','60','120'],
  }

  wazuh::command { 'firewallblock':
    command_name       => 'firewall-drop',
    command_executable => 'firewall-drop.sh',
    command_expect     => 'srcip'
  }
```

After changing everything work as expected.