### PR TITLE
update target name in concat for manager_ossec.conf

### DIFF
--- a/manifests/addlog.pp
+++ b/manifests/addlog.pp
@@ -6,11 +6,12 @@ define wazuh::addlog(
   $logcommand   = undef,
   $commandalias = undef,
   $frequency    = undef,
+  $target_arg   = 'manager_ossec.conf',
 ) {
   require wazuh::params_manager
 
   concat::fragment { "ossec.conf_localfile-${logfile}":
-    target  => 'ossec.conf',
+    target  => $target_arg,
     content => template('wazuh/fragments/_localfile_generation.erb'),
     order   => 21,
   }

--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -3,14 +3,15 @@
 define wazuh::command(
   $command_name,
   $command_executable,
-  $command_expect = 'srcip',
+  $command_expect  = 'srcip',
   $timeout_allowed = true,
+  $target_arg      = 'manager_ossec.conf',
 ) {
   require wazuh::params_manager
 
   if ($timeout_allowed) { $command_timeout_allowed='yes' } else { $command_timeout_allowed='no' }
   concat::fragment { $name:
-    target  => 'ossec.conf',
+    target  => $target_arg,
     order   => 46,
     content => template('wazuh/fragments/_command.erb'),
   }

--- a/manifests/email_alert.pp
+++ b/manifests/email_alert.pp
@@ -2,12 +2,13 @@
 # Define an email alert
 define wazuh::email_alert(
   $alert_email,
-  $alert_group = false
+  $alert_group = false,
+  $target_arg  = 'manager_ossec.conf'
 ) {
   require wazuh::params_manager
 
   concat::fragment { $name:
-    target  => 'ossec.conf',
+    target  => $target_arg,
     order   => 66,
     content => template('wazuh/fragments/_email_alert.erb'),
   }

--- a/manifests/repo_opendistro.pp
+++ b/manifests/repo_opendistro.pp
@@ -20,7 +20,7 @@ class wazuh::repo_opendistro (
             apt::source { 'wazuh_elastic_od':
               ensure   => present,
               comment  => 'This is the Open Distro for Elastic repository',
-              location => 'ttps://d3g5vo6xdbdb9a.cloudfront.net/apt',
+              location => 'https://d3g5vo6xdbdb9a.cloudfront.net/apt',
               release  => 'stable',
               repos    => 'main',
               include  => {


### PR DESCRIPTION
_This PR was [originally](https://github.com/wazuh/wazuh-puppet/pull/336) opened by @g3rhard. Below the original description._

Hello everyone! I think, I fix issue #322 by simple changing concat target in few classes.

Here is working example:

``` ruby
  wazuh::addlog { 'CronLogFile':
    logfile => '/var/log/cron.log',
    logtype => 'syslog'
  }

  wazuh::email_alert { 'mail':
    alert_email => 'mail@example.com',
    alert_group => ['syslog'],
  }

  wazuh::activeresponse { 'blockWebattack':
    active_response_command            => 'firewall-drop',
    active_response_level              => 9,
    active_response_agent_id           => 123,
    active_response_rules_id           => [31153,31151],
    active_response_repeated_offenders => ['30','60','120'],
  }

  wazuh::command { 'firewallblock':
    command_name       => 'firewall-drop',
    command_executable => 'firewall-drop.sh',
    command_expect     => 'srcip'
  }
```

After changing everything work as expected.
