### PR TITLE
Add docker-listener wodle section

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -34,6 +34,7 @@ class wazuh::agent (
   $configure_wodle_cis_cat           = $wazuh::params_agent::configure_wodle_cis_cat,
   $configure_wodle_osquery           = $wazuh::params_agent::configure_wodle_osquery,
   $configure_wodle_syscollector      = $wazuh::params_agent::configure_wodle_syscollector,
+  $configure_wodle_docker_listener   = $wazuh::params_agent::configure_wodle_docker_listener,
   $configure_sca                     = $wazuh::params_agent::configure_sca,
   $configure_syscheck                = $wazuh::params_agent::configure_syscheck,
   $configure_localfile               = $wazuh::params_agent::configure_localfile,
@@ -41,19 +42,20 @@ class wazuh::agent (
   $configure_labels                  = $wazuh::params_agent::configure_labels,
 
   # Templates paths
-  $ossec_conf_template               = $wazuh::params_agent::ossec_conf_template,
-  $ossec_rootcheck_template          = $wazuh::params_agent::ossec_rootcheck_template,
-  $ossec_wodle_openscap_template     = $wazuh::params_agent::ossec_wodle_openscap_template,
-  $ossec_wodle_cis_cat_template      = $wazuh::params_agent::ossec_wodle_cis_cat_template,
-  $ossec_wodle_osquery_template      = $wazuh::params_agent::ossec_wodle_osquery_template,
-  $ossec_wodle_syscollector_template = $wazuh::params_agent::ossec_wodle_syscollector_template,
-  $ossec_sca_template                = $wazuh::params_agent::ossec_sca_template,
-  $ossec_syscheck_template           = $wazuh::params_agent::ossec_syscheck_template,
-  $ossec_localfile_template          = $wazuh::params_agent::ossec_localfile_template,
-  $ossec_auth                        = $wazuh::params_agent::ossec_auth,
-  $ossec_cluster                     = $wazuh::params_agent::ossec_cluster,
-  $ossec_active_response_template    = $wazuh::params_agent::ossec_active_response_template,
-  $ossec_labels_template             = $wazuh::params_agent::ossec_labels_template,
+  $ossec_conf_template                  = $wazuh::params_agent::ossec_conf_template,
+  $ossec_rootcheck_template             = $wazuh::params_agent::ossec_rootcheck_template,
+  $ossec_wodle_openscap_template        = $wazuh::params_agent::ossec_wodle_openscap_template,
+  $ossec_wodle_cis_cat_template         = $wazuh::params_agent::ossec_wodle_cis_cat_template,
+  $ossec_wodle_osquery_template         = $wazuh::params_agent::ossec_wodle_osquery_template,
+  $ossec_wodle_syscollector_template    = $wazuh::params_agent::ossec_wodle_syscollector_template,
+  $ossec_wodle_docker_listener_template = $wazuh::params_agent::ossec_wodle_docker_listener_template,
+  $ossec_sca_template                   = $wazuh::params_agent::ossec_sca_template,
+  $ossec_syscheck_template              = $wazuh::params_agent::ossec_syscheck_template,
+  $ossec_localfile_template             = $wazuh::params_agent::ossec_localfile_template,
+  $ossec_auth                           = $wazuh::params_agent::ossec_auth,
+  $ossec_cluster                        = $wazuh::params_agent::ossec_cluster,
+  $ossec_active_response_template       = $wazuh::params_agent::ossec_active_response_template,
+  $ossec_labels_template                = $wazuh::params_agent::ossec_labels_template,
 
   # Server configuration
 
@@ -179,6 +181,9 @@ class wazuh::agent (
   $wodle_syscollector_ports          = $wazuh::params_agent::wodle_syscollector_ports,
   $wodle_syscollector_processes      = $wazuh::params_agent::wodle_syscollector_processes,
   $wodle_syscollector_hotfixes       = $wazuh::params_agent::wodle_syscollector_hotfixes,
+
+  # Docker-listener
+  $wodle_docker_listener_disabled    = $wazuh::params_agent::wodle_docker_listener_disabled,
 
   # Localfile
   $ossec_local_files                 = $wazuh::params_agent::default_local_files,
@@ -406,6 +411,15 @@ class wazuh::agent (
         order   => 19,
         before  => Service[$agent_service_name],
         content => template($ossec_wodle_syscollector_template);
+    }
+  }
+  if ($configure_wodle_docker_listener == true) {
+    concat::fragment {
+      'ossec.conf_docker_listener':
+        target  => 'agent_ossec.conf',
+        order   => 20,
+        before  => Service[$agent_service_name],
+        content => template($ossec_wodle_docker_listener_template);
     }
   }
   if ($configure_sca == true) {

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -36,6 +36,7 @@ class wazuh::manager (
       $configure_wodle_cis_cat              = $wazuh::params_manager::configure_wodle_cis_cat,
       $configure_wodle_osquery              = $wazuh::params_manager::configure_wodle_osquery,
       $configure_wodle_syscollector         = $wazuh::params_manager::configure_wodle_syscollector,
+      $configure_wodle_docker_listener      = $wazuh::params_manager::configure_wodle_docker_listener,
       $configure_vulnerability_detector     = $wazuh::params_manager::configure_vulnerability_detector,
       $configure_sca                        = $wazuh::params_manager::configure_sca,
       $configure_syscheck                   = $wazuh::params_manager::configure_syscheck,
@@ -53,7 +54,8 @@ class wazuh::manager (
       $ossec_wodle_cis_cat_template                 = $wazuh::params_manager::ossec_wodle_cis_cat_template,
       $ossec_wodle_osquery_template                 = $wazuh::params_manager::ossec_wodle_osquery_template,
       $ossec_wodle_syscollector_template            = $wazuh::params_manager::ossec_wodle_syscollector_template,
-      $ossec_vulnerability_detector_template  = $wazuh::params_manager::ossec_vulnerability_detector_template,
+      $ossec_wodle_docker_listener_template         = $wazuh::params_manager::ossec_wodle_docker_listener_template,
+      $ossec_vulnerability_detector_template        = $wazuh::params_manager::ossec_vulnerability_detector_template,
       $ossec_sca_template                           = $wazuh::params_manager::ossec_sca_template,
       $ossec_syscheck_template                      = $wazuh::params_manager::ossec_syscheck_template,
       $ossec_default_commands_template              = $wazuh::params_manager::ossec_default_commands_template,
@@ -148,6 +150,9 @@ class wazuh::manager (
       $wodle_syscollector_packages          = $wazuh::params_manager::wodle_syscollector_packages,
       $wodle_syscollector_ports             = $wazuh::params_manager::wodle_syscollector_ports,
       $wodle_syscollector_processes         = $wazuh::params_manager::wodle_syscollector_processes,
+
+      #docker-listener
+      $wodle_docker_listener_disabled       = $wazuh::params_manager::wodle_docker_listener_disabled,
 
       #vulnerability-detector
       $vulnerability_detector_enabled                            = $wazuh::params_manager::vulnerability_detector_enabled,
@@ -495,6 +500,14 @@ class wazuh::manager (
         order   => 30,
         target  => 'manager_ossec.conf',
         content => template($ossec_wodle_syscollector_template);
+    }
+  }
+  if ($configure_wodle_docker_listener == true){
+    concat::fragment {
+      'ossec.conf_wodle_docker_listener':
+        order   => 30,
+        target  => 'manager_ossec.conf',
+        content => template($ossec_wodle_docker_listener_template);
     }
   }
   if ($configure_sca == true){

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -30,6 +30,7 @@ class wazuh::params_agent {
   $configure_wodle_cis_cat = true
   $configure_wodle_osquery = true
   $configure_wodle_syscollector = true
+  $configure_wodle_docker_listener = false
   $configure_sca = true
   $configure_syscheck = true
   $configure_localfile = true
@@ -42,6 +43,7 @@ class wazuh::params_agent {
   $ossec_wodle_cis_cat_template = 'wazuh/fragments/_wodle_cis_cat.erb'
   $ossec_wodle_osquery_template = 'wazuh/fragments/_wodle_osquery.erb'
   $ossec_wodle_syscollector_template = 'wazuh/fragments/_wodle_syscollector.erb'
+  $ossec_wodle_docker_listener_template = 'wazuh/fragments/_wodle_docker_listener.erb'
   $ossec_sca_template = 'wazuh/fragments/_sca.erb'
   $ossec_syscheck_template = 'wazuh/fragments/_syscheck.erb'
   $ossec_localfile_template = 'wazuh/fragments/_localfile.erb'
@@ -177,6 +179,9 @@ class wazuh::params_agent {
       $sca_else_policies = []
 
       # Wodles
+
+      ## doker-listener
+      $wodle_doker_listener_disabled = 'yes'
 
       ## open-scap
       $wodle_openscap_disabled = 'yes'

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -36,6 +36,7 @@ class wazuh::params_manager {
       $configure_wodle_cis_cat                         = true
       $configure_wodle_osquery                         = true
       $configure_wodle_syscollector                    = true
+      $configure_wodle_docker_listener                 = false
       $configure_vulnerability_detector                = true
       $configure_sca                                   = true
       $configure_syscheck                              = true
@@ -54,6 +55,7 @@ class wazuh::params_manager {
       $ossec_wodle_cis_cat_template                    = 'wazuh/fragments/_wodle_cis_cat.erb'
       $ossec_wodle_osquery_template                    = 'wazuh/fragments/_wodle_osquery.erb'
       $ossec_wodle_syscollector_template               = 'wazuh/fragments/_wodle_syscollector.erb'
+      $ossec_wodle_docker_listener_template            = 'wazuh/fragments/_wodle_docker_listener.erb'
       $ossec_vulnerability_detector_template           = 'wazuh/fragments/_vulnerability_detector.erb'
       $ossec_sca_template                              = 'wazuh/fragments/_sca.erb'
       $ossec_syscheck_template                         = 'wazuh/fragments/_syscheck.erb'
@@ -141,6 +143,8 @@ class wazuh::params_manager {
       $wodle_syscollector_ports                        = 'yes'
       $wodle_syscollector_processes                    = 'yes'
 
+      #docker-listener
+      $wodle_docker_listener_disabled                  = 'no'
 
       #active-response
       $active_response_command                         = 'firewall-drop'

--- a/templates/fragments/_wodle_docker_listener.erb
+++ b/templates/fragments/_wodle_docker_listener.erb
@@ -1,0 +1,6 @@
+
+<wodle name="docker-listener">
+  <% if @wodle_docker_listener_disabled -%>
+  <disabled><%= @wodle_docker_listener_disabled %></disabled>
+  <%- end -%>
+</wodle>


### PR DESCRIPTION
Allow puppet module to configure docker containers activity as described on
https://documentation.wazuh.com/4.0/docker-monitor/monitoring_containers_activity.html

Note: `apt install python-docker` is better than `pip install docker` in Debian Buster.