### PR TITLE
Allow NVD alternative update source

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -176,6 +176,10 @@ class wazuh::manager (
       $vulnerability_detector_provider_nvd_os                    = $wazuh::params_manager::vulnerability_detector_provider_nvd_os,
       $vulnerability_detector_provider_nvd_update_from_year      = $wazuh::params_manager::vulnerability_detector_provider_nvd_update_from_year,
       $vulnerability_detector_provider_nvd_update_interval       = $wazuh::params_manager::vulnerability_detector_provider_nvd_update_interval,
+      $vulnerability_detector_provider_nvd_path                  = $wazuh::params_manager::vulnerability_detector_provider_nvd_path,
+      $vulnerability_detector_provider_nvd_url                   = $wazuh::params_manager::vulnerability_detector_provider_nvd_url,
+      $vulnerability_detector_provider_nvd_url_start             = $wazuh::params_manager::vulnerability_detector_provider_nvd_url_start,
+      $vulnerability_detector_provider_nvd_url_end               = $wazuh::params_manager::vulnerability_detector_provider_nvd_url_end,
       #lint:endignore
 
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -187,6 +187,10 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_nvd_os                 = []
       $vulnerability_detector_provider_nvd_update_from_year   = '2010'
       $vulnerability_detector_provider_nvd_update_interval    = '1h'
+      $vulnerability_detector_provider_nvd_path               = undef
+      $vulnerability_detector_provider_nvd_url                = undef
+      $vulnerability_detector_provider_nvd_url_start          = undef
+      $vulnerability_detector_provider_nvd_url_end            = undef
 
       $syslog_output                                   = false
       $syslog_output_level                             = 2

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -38,6 +38,8 @@
     <% if @vulnerability_detector_provider_nvd_enabled %><enabled><%= @vulnerability_detector_provider_nvd_enabled %></enabled><% end %>
     <% if @vulnerability_detector_provider_nvd_update_from_year %><update_from_year><%= @vulnerability_detector_provider_nvd_update_from_year %></update_from_year><% end %>
     <% if @vulnerability_detector_provider_nvd_update_interval %><update_interval><%= @vulnerability_detector_provider_nvd_update_interval %></update_interval><% end %>
+    <% if @vulnerability_detector_provider_nvd_path %><path><%= @vulnerability_detector_provider_nvd_path %></path><% end %>
+    <% if @vulnerability_detector_provider_nvd_url && @vulnerability_detector_provider_nvd_url_start && @vulnerability_detector_provider_nvd_url_end %><url start="<%= @vulnerability_detector_provider_nvd_url_start %>" end="<%= @vulnerability_detector_provider_nvd_url_end %>"><%= @vulnerability_detector_provider_nvd_url %></url><% end %>
   </provider>   
 <% end %>
 </vulnerability-detector>


### PR DESCRIPTION
Add parameters to configure `path` or `url` of NVD provider as described on https://documentation.wazuh.com/4.0/user-manual/capabilities/vulnerability-detection/offline_update.html?highlight=feed#national-vulnerability-database
Url will be configure only if both start and end option are defined.