### PR TITLE
Allow alternative Debian security feeds

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -163,6 +163,8 @@ class wazuh::manager (
       $vulnerability_detector_provider_debian                    = $wazuh::params_manager::vulnerability_detector_provider_debian,
       $vulnerability_detector_provider_debian_enabled            = $wazuh::params_manager::vulnerability_detector_provider_debian_enabled,
       $vulnerability_detector_provider_debian_os                 = $wazuh::params_manager::vulnerability_detector_provider_debian_os,
+      $vulnerability_detector_provider_debian_path               = $wazuh::params_manager::vulnerability_detector_provider_debian_path,
+      $vulnerability_detector_provider_debian_url                = $wazuh::params_manager::vulnerability_detector_provider_debian_url,
       $vulnerability_detector_provider_debian_update_interval    = $wazuh::params_manager::vulnerability_detector_provider_debian_update_interval,
 
       $vulnerability_detector_provider_redhat                    = $wazuh::params_manager::vulnerability_detector_provider_redhat,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -174,6 +174,8 @@ class wazuh::params_manager {
         'jessie',
         'buster'
       ]
+      $vulnerability_detector_provider_debian_path            = undef
+      $vulnerability_detector_provider_debian_url             = undef
       $vulnerability_detector_provider_debian_update_interval = '1h'
       $vulnerability_detector_provider_redhat                    = 'yes'
       $vulnerability_detector_provider_redhat_enabled            = 'no'

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -20,9 +20,15 @@
     <% if @vulnerability_detector_provider_debian_enabled %><enabled><%= @vulnerability_detector_provider_debian_enabled %></enabled><% end %>
     <% if !@vulnerability_detector_provider_debian_os.empty? %>
     <% @vulnerability_detector_provider_debian_os.each do |os| %>
+    <%- if os.is_a?(String) -%>
     <os><%= os %></os>
+    <%- else -%>
+    <os<% if os.key?('url') %> url="<%= os['url'] %>"<% end %><% if os.key?('path') %> url="<%= os['path'] %>"<% end %>><%= os['release'] %></os>
+    <%- end -%>
     <% end %>
     <% end %>
+    <% if @vulnerability_detector_provider_debian_path %><path><%= @vulnerability_detector_provider_debian_path %></path><% end %>
+    <% if @vulnerability_detector_provider_debian_url %><url><%= @vulnerability_detector_provider_debian_url %></url><% end %>
     <% if @vulnerability_detector_provider_debian_update_interval %><update_interval><%= @vulnerability_detector_provider_debian_update_interval %></update_interval><% end %>
   </provider>
 <% end %>


### PR DESCRIPTION
Add parameters to configure alternative Debian security feeds as described on https://documentation.wazuh.com/4.0/user-manual/capabilities/vulnerability-detection/offline_update.html?highlight=feed#debian.
Path and URL are simple but I had to allow extra optional parameters in the 'os' array.
For backward compatibility it takes array of strings or hashes.
The hash is expected to have `release` and optional `url` or `path`.
Fox example one can now use in Foreman parameter like
`["stretch", {"release":"buster","url":"http://localhost/oval-definitions-buster.xml"}]`