### PR TITLE
Add new line before and after email_alerts block

### DIFF
--- a/templates/fragments/_email_alert.erb
+++ b/templates/fragments/_email_alert.erb
@@ -1,3 +1,4 @@
+
   <email_alerts>
     <email_to><%= @alert_email %></email_to>
     <%- if @level -%>


### PR DESCRIPTION
from this:
```
    <email_alerts>
    <email_to>a@b.com</email_to>
    <event_location>test1.b.com|test2.b.com</event_location>
    <do_not_delay />
  </email_alerts>  <email_alerts>
    <email_to>a@b.com</email_to>
    <rule_id>398440,401323,401324,401344</rule_id>
  </email_alerts>
```
to this:
```

  <email_alerts>
    <email_to>a@b.com</email_to>
    <event_location>test1.b.com|test2.b.com</event_location>
    <do_not_delay />
  </email_alerts>

  <email_alerts>
    <email_to>a@b.com</email_to>
    <rule_id>398440,401323,401324,401344</rule_id>
  </email_alerts>

```