### PR TITLE
Add more options for filebeat to support ES Cloud

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,16 @@
---- {}
+--- 
+
+lookup_options:
+  wazuh::agent::ossec_config_centos_profiles:
+    merge:
+      strategy: deep
+      knockout_prefix: ABSENT
+  wazuh::agent::ossec_syscheck_ignore_list:
+    merge:
+      strategy: deep
+      knockout_prefix: ABSENT
+  wazuh::agent::ossec_local_files:
+    merge:
+      strategy: deep
+      knockout_prefix: ABSENT
+

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -55,13 +55,13 @@ class wazuh::filebeat (
     path    => '/usr/bin',
     command => "curl -o /root/${wazuh_filebeat_module} https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
     creates => "/root/${wazuh_filebeat_module}",
-  }  ~>
+  }  ->
 
   exec { 'Unpackaging':
     command => '/bin/tar -xzvf /root/${wazuh_filebeat_module} -C /usr/share/filebeat/module',
     notify  => Service['filebeat'],
     require => Package['filebeat'],
-    refreshonly => true
+    creates => "/usr/share/filebeat/module/wazuh/module.yml"
   } 
 
   file { '/usr/share/filebeat/module/wazuh':

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -1,16 +1,23 @@
 # Wazuh App Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 # Setup for Filebeat
 class wazuh::filebeat (
-  $filebeat_elasticsearch_ip = 'localhost',
-  $filebeat_elasticsearch_port = '9200',
-  $elasticsearch_server_ip = "\"${filebeat_elasticsearch_ip}:${filebeat_elasticsearch_port}\"",
+  String $filebeat_elasticsearch_ip = 'localhost',
+  Variant[String,Integer] $filebeat_elasticsearch_port = 9200,
+  Optional[String] $filebeat_elasticsearch_proto = 'https',
+  String $elasticsearch_server_ip = "\"${filebeat_elasticsearch_ip}:${filebeat_elasticsearch_port}\"",
 
-  $filebeat_package = 'filebeat',
-  $filebeat_service = 'filebeat',
-  $filebeat_version = '7.10.0',
-  $wazuh_app_version = '4.3.0_7.10.0',
-  $wazuh_extensions_version = 'v4.3.0',
-  $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
+  String $filebeat_package = 'filebeat',
+  String $filebeat_service = 'filebeat',
+  String $filebeat_version = '7.10.0',
+  Optional[String] $filebeat_elastic_user = undef,
+  Optional[String] $filebeat_elastic_password = undef,
+  Optional[String] $filebeat_elastic_api_key = undef,
+  String $filebeat_ssl_verification = 'full',
+  Integer $filebeat_elastic_worker = 1,
+  Optional[Boolean] $filebeat_setup_ilm_enabled = undef,
+  String $wazuh_app_version = '4.3.0_7.10.0',
+  String $wazuh_extensions_version = 'v4.3.0',
+  String $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){
 
   class {'wazuh::repo_elastic':}
@@ -40,19 +47,22 @@ class wazuh::filebeat (
     path    => '/usr/bin',
     command => "curl -so /etc/filebeat/wazuh-template.json 'https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_extensions_version}/extensions/elasticsearch/7.x/wazuh-template.json'",
     notify  => Service['filebeat'],
-    require => Package['filebeat']
-  }
+    require => Package['filebeat'],
+    creates => '/etc/filebeat/wazuh-template.json'
+  } 
 
   exec { 'Installing filebeat module ... Downloading package':
     path    => '/usr/bin',
-    command => "curl -o /root/${$wazuh_filebeat_module} https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
-  }
+    command => "curl -o /root/${wazuh_filebeat_module} https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
+    creates => "/root/${wazuh_filebeat_module}",
+  }  ~>
 
-  exec { 'Unpackaging ...':
-    command => '/bin/tar -xzvf /root/wazuh-filebeat-0.1.tar.gz -C /usr/share/filebeat/module',
+  exec { 'Unpackaging':
+    command => '/bin/tar -xzvf /root/${wazuh_filebeat_module} -C /usr/share/filebeat/module',
     notify  => Service['filebeat'],
-    require => Package['filebeat']
-  }
+    require => Package['filebeat'],
+    refreshonly => true
+  } 
 
   file { '/usr/share/filebeat/module/wazuh':
     ensure  => 'directory',

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -18,6 +18,9 @@ class wazuh::filebeat (
   String $wazuh_app_version = '4.3.0_7.10.0',
   String $wazuh_extensions_version = 'v4.3.0',
   String $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
+  Optional[String] $filebeat_log_level = undef,
+  Integer $filebeat_log_keep = 7,
+  String $filebeat_log_interval = '1d',
 ){
 
   class {'wazuh::repo_elastic':}

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -56,13 +56,13 @@ class wazuh::filebeat_oss (
     path    => '/usr/bin',
     command => "curl -o /root/${wazuh_filebeat_module} https://packages.wazuh.com/4.x/filebeat/${wazuh_filebeat_module}",
     creates => "/root/${wazuh_filebeat_module}",
-  } ~>
+  } ->
 
   exec { 'Unpackaging ...':
     command => '/bin/tar -xzvf /root/${wazuh_filebeat_module} -C /usr/share/filebeat/module',
     notify  => Service[$filebeat_oss_service],
-    require => Package[$filebeat_oss_package]
-    refreshonly => true
+    require => Package[$filebeat_oss_package],
+    creates => "/usr/share/filebeat/module/wazuh/module.yml"
   } 
 
   file { '/usr/share/filebeat/module/wazuh':

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -1,18 +1,24 @@
 # Wazuh App Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 # Setup for Filebeat_oss
 class wazuh::filebeat_oss (
-  $filebeat_oss_elasticsearch_ip = 'localhost',
-  $filebeat_oss_elasticsearch_port = '9200',
+  String $filebeat_oss_elasticsearch_ip = 'localhost',
+  Variant[String,Integer] $filebeat_oss_elasticsearch_port = 9200,
+  Optional[String] $filebeat_oss_elasticsearch_proto = 'https',
   $elasticsearch_server_ip = "\"${filebeat_oss_elasticsearch_ip}:${filebeat_oss_elasticsearch_port}\"",
 
-  $filebeat_oss_package = 'filebeat',
-  $filebeat_oss_service = 'filebeat',
-  $filebeat_oss_elastic_user = 'admin',
-  $filebeat_oss_elastic_password = 'admin',
-  $filebeat_oss_version = '7.10.0',
-  $wazuh_app_version = '4.3.0_7.10.0',
-  $wazuh_extensions_version = 'v4.3.0',
-  $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
+  String $filebeat_oss_package = 'filebeat',
+  String $filebeat_oss_service = 'filebeat',
+  Optional[String] $filebeat_oss_elastic_user = undef,
+  Optional[String] $filebeat_oss_elastic_password = undef,
+  Optional[String] $filebeat_oss_elastic_api_key = undef,
+  String $filebeat_oss_ssl_verification = 'none',
+  Integer $filebeat_oss_elastic_worker = 1,
+  Optional[Boolean] $filebeat_oss_setup_ilm_enabled = false,
+
+  String $filebeat_oss_version = '7.10.0',
+  String $wazuh_app_version = '4.3.0_7.10.0',
+  String $wazuh_extensions_version = 'v4.3.0',
+  String $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){
 
   class {'wazuh::repo_elastic_oss':}
@@ -42,19 +48,22 @@ class wazuh::filebeat_oss (
     path    => '/usr/bin',
     command => "curl -so /etc/filebeat/wazuh-template.json 'https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_extensions_version}/extensions/elasticsearch/7.x/wazuh-template.json'",
     notify  => Service[$filebeat_oss_service],
-    require => Package[$filebeat_oss_package]
+    require => Package[$filebeat_oss_package],
+    creates => '/etc/filebeat/wazuh-template.json'
   }
 
   exec { 'Installing filebeat module ... Downloading package':
     path    => '/usr/bin',
-    command => "curl -o /root/${$wazuh_filebeat_module} https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
-  }
+    command => "curl -o /root/${wazuh_filebeat_module} https://packages.wazuh.com/4.x/filebeat/${wazuh_filebeat_module}",
+    creates => "/root/${wazuh_filebeat_module}",
+  } ~>
 
   exec { 'Unpackaging ...':
-    command => '/bin/tar -xzvf /root/wazuh-filebeat-0.1.tar.gz -C /usr/share/filebeat/module',
+    command => '/bin/tar -xzvf /root/${wazuh_filebeat_module} -C /usr/share/filebeat/module',
     notify  => Service[$filebeat_oss_service],
     require => Package[$filebeat_oss_package]
-  }
+    refreshonly => true
+  } 
 
   file { '/usr/share/filebeat/module/wazuh':
     ensure  => 'directory',

--- a/manifests/kibana.pp
+++ b/manifests/kibana.pp
@@ -52,6 +52,9 @@ class wazuh::kibana (
   # kibana paths
   $kibana_path_home = '/usr/share/kibana',
   $kibana_path_config = '/etc/kibana',
+
+  $kibana_settings = {},
+  $saml_realm = undef,
 ) {
 
   # install package

--- a/manifests/kibana.pp
+++ b/manifests/kibana.pp
@@ -17,10 +17,18 @@ class wazuh::kibana (
   $kibana_elasticsearch_ip = $kibana_elasticsearch_hosts[0]['host'],
   $kibana_elasticsearch_port = $kibana_elasticsearch_hosts[0]['port'],
   $kibana_elasticsearch_proto = $kibana_elasticsearch_hosts[0]['proto'],
+  
+  $elasticsearch_username = undef,
+  $elasticsearch_password = undef,
+  $elasticsearch_ssl_verificationmode = undef,
 
   $kibana_server_port = '5601',
   $kibana_server_host = '0.0.0.0',
   $kibana_wazuh_version = '4.3.0',
+
+  $server_ssl = false,
+  $server_ssl_certificate = undef,
+  $server_ssl_key = undef,
 
   # app variables
   $kibana_app_version = "${kibana_wazuh_version}_${$kibana_version}",

--- a/manifests/kibana.pp
+++ b/manifests/kibana.pp
@@ -80,13 +80,14 @@ class wazuh::kibana (
     ensure     => running,
     enable     => true,
     hasrestart => true,
-  }
+  } 
 
   exec {'Waiting for elasticsearch...':
-    path      => '/usr/bin',
-    command   => "curl -s -XGET ${kibana_elasticsearch_proto}://${kibana_elasticsearch_ip}:${kibana_elasticsearch_port}",
-    tries     => 100,
-    try_sleep => 3,
+    path        => '/usr/bin',
+    command     => "curl -s -XGET ${kibana_elasticsearch_proto}://${kibana_elasticsearch_ip}:${kibana_elasticsearch_port}",
+    tries       => 100,
+    try_sleep   => 3,
+    refreshonly => true,
   }
 
   exec {'kibana-plugin install':

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -64,6 +64,14 @@ class wazuh::manager (
       $ossec_active_response_template               = $wazuh::params_manager::ossec_active_response_template,
       $ossec_syslog_output_template                 = $wazuh::params_manager::ossec_syslog_output_template,
 
+      # rulesets
+      $ossec_ruleset_decoder_dir                    = $wazuh::params_manager::ossec_ruleset_decoder_dir,
+      $ossec_ruleset_rule_dir                       = $wazuh::params_manager::ossec_ruleset_rule_dir,
+      $ossec_ruleset_rule_exclude                   = $wazuh::params_manager::ossec_ruleset_rule_exclude,
+      $ossec_ruleset_list                           = $wazuh::params_manager::ossec_ruleset_list,
+      $ossec_ruleset_user_defined_decoder_dir       = $wazuh::params_manager::ossec_ruleset_user_defined_decoder_dir ,
+      $ossec_ruleset_user_defined_rule_dir          =  $wazuh::params_manager::ossec_ruleset_user_defined_rule_dir,
+
       # active-response
       $ossec_active_response_command                =  $wazuh::params_manager::active_response_command,
       $ossec_active_response_location               =  $wazuh::params_manager::active_response_location,
@@ -251,8 +259,10 @@ class wazuh::manager (
 
       $local_decoder_template               = $wazuh::params_manager::local_decoder_template,
       $decoder_exclude                      = $wazuh::params_manager::decoder_exclude,
+      $local_decoders                       = $wazuh::params_manager::local_decoders,
       $local_rules_template                 = $wazuh::params_manager::local_rules_template,
       $rule_exclude                         = $wazuh::params_manager::rule_exclude,
+      $local_rules                          = $wazuh::params_manager::local_rules,
       $shared_agent_template                = $wazuh::params_manager::shared_agent_template,
 
       $wazuh_manager_verify_manager_ssl     = $wazuh::params_manager::wazuh_manager_verify_manager_ssl,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -290,8 +290,10 @@ class wazuh::params_manager {
 
       $local_decoder_template              = 'wazuh/local_decoder.xml.erb'
       $decoder_exclude                     = []
+      $local_decoders                      = []
       $local_rules_template                = 'wazuh/local_rules.xml.erb'
       $rule_exclude                        = []
+      $local_rules                         = []
       $shared_agent_template               = 'wazuh/ossec_shared_agent.conf.erb'
 
       $wazuh_manager_verify_manager_ssl    = false

--- a/templates/filebeat_oss_yml.erb
+++ b/templates/filebeat_oss_yml.erb
@@ -13,11 +13,23 @@ setup.template.overwrite: true
 
 # Send events directly to Elasticsearch
 output.elasticsearch:
-  hosts: ["https://<%= @filebeat_oss_elasticsearch_ip %>:<%= @filebeat_oss_elasticsearch_port %>"]
+  hosts: ["<%= @filebeat_oss_elasticsearch_proto %>://<%= @filebeat_oss_elasticsearch_ip %>:<%= @filebeat_oss_elasticsearch_port %>"]
+<% if @filebeat_oss_elastic_api_key -%>
+  api_key: <%= @filebeat_oss_elastic_api_key %>
+<% else -%>
+<% if @filebeat_elastic_oss_password -%>
   username: <%= @filebeat_oss_elastic_user %>
   password: <%= @filebeat_oss_elastic_password %>
-  ssl.verification_mode: none
+<% end -%>
+<% end -%>
+<% if @filebeat_oss_ssl_verification -%>
+  ssl.verification_mode: <%= @filebeat_oss_ssl_verification %>
+<% end -%>
+<% if @filebeat_oss_elastic_worker > 1 -%>
+  worker: <%= @filebeat_oss_elastic_worker %>
+<% end -%>
 
-setup.ilm.enabled: false
-
+<% if not @filebeat_oss_setup_ilm_enabled.nil? %>
+setup.ilm.enabled: <%= @filebeat_oss_setup_ilm_enabled %>
+<% end -%>
 

--- a/templates/filebeat_yml.erb
+++ b/templates/filebeat_yml.erb
@@ -12,5 +12,24 @@ setup.template.json.name: "wazuh"
 setup.template.overwrite: true
 
 # Send events directly to Elasticsearch
-output.elasticsearch.hosts: [<%= @elasticsearch_server_ip %>]
+output.elasticsearch:
+  hosts: ["<%= @filebeat_elasticsearch_proto %>://<%= @filebeat_elasticsearch_ip %>:<%= @filebeat_elasticsearch_port %>"]
+<% if @filebeat_elastic_api_key -%>
+  api_key: <%= @filebeat_elastic_api_key %>
+<% else -%>
+<% if @filebeat_elastic_password -%>
+  username: <%= @filebeat_elastic_user %>
+  password: <%= @filebeat_elastic_password %>
+<% end -%>
+<% end -%>
+<% if @filebeat_ssl_verification -%>
+  ssl.verification_mode: <%= @filebeat_ssl_verification %>
+<% end -%>
+<% if @filebeat_elastic_worker > 1 -%>
+  worker: <%= @filebeat_elastic_worker %>
+<% end -%>
+
+<% if not @filebeat_setup_ilm_enabled.nil? %>
+setup.ilm.enabled: <%= @filebeat_setup_ilm_enabled %>
+<% end -%>
 

--- a/templates/filebeat_yml.erb
+++ b/templates/filebeat_yml.erb
@@ -33,3 +33,19 @@ output.elasticsearch:
 setup.ilm.enabled: <%= @filebeat_setup_ilm_enabled %>
 <% end -%>
 
+<% if @filebeat_log_level -%>
+logging.level: <%= @filebeat_log_level %>
+logging.selectors: [ "*" ]
+logging.to_stderr: false
+logging.to_syslog: false
+logging.metrics.enabled: true
+logging.metrics.period: 300s
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  rotateeverybytes: 10485760
+  keepfiles: <%= @filebeat_log_keep %>
+  permissions: 0644
+  interval: <%= @filebeat_log_interval %>
+<% end -%>

--- a/templates/fragments/_ruleset.erb
+++ b/templates/fragments/_ruleset.erb
@@ -4,10 +4,10 @@
 <ruleset>
   <!-- Default ruleset -->
   <% if @ossec_ruleset_decoder_dir -%>
-  <decoder_dir><%= @ossec_ruleset_decoder_dir %></decoder_dir>
+  <decoder_dir pattern=".xml$"><%= @ossec_ruleset_decoder_dir %></decoder_dir>
   <%- end -%>
   <% if @ossec_ruleset_rule_dir -%>
-  <rule_dir><%= @ossec_ruleset_rule_dir %></rule_dir>
+  <rule_dir pattern=".xml$"><%= @ossec_ruleset_rule_dir %></rule_dir>
   <%- end -%>
   <% if @ossec_ruleset_rule_exclude -%>
   <rule_exclude><%= @ossec_ruleset_rule_exclude %></rule_exclude>
@@ -18,10 +18,10 @@
   
   <!-- User-defined ruleset -->
   <% if @ossec_ruleset_user_defined_decoder_dir -%>
-  <decoder_dir><%= @ossec_ruleset_user_defined_decoder_dir %></decoder_dir>
+  <decoder_dir pattern=".xml$"><%= @ossec_ruleset_user_defined_decoder_dir %></decoder_dir>
   <%- end -%>
   <% if @ossec_ruleset_user_defined_rule_dir -%>
-  <rule_dir><%= @ossec_ruleset_user_defined_rule_dir %></rule_dir>
+  <rule_dir pattern=".xml$"><%= @ossec_ruleset_user_defined_rule_dir %></rule_dir>
   <%- end -%>
 </ruleset>
 

--- a/templates/kibana_yml.erb
+++ b/templates/kibana_yml.erb
@@ -138,3 +138,16 @@ elasticsearch.ssl.verificationMode: <%= @elasticsearch_ssl_verificationmode %>
 # Specifies locale to be used for all localizable strings, dates and number formats.
 #i18n.locale: "en"
 
+# Custom settings
+<%- @kibana_settings.each do |k_key,k_value| -%>
+<%= k_key %>: <%= k_value %>
+<%- end -%>
+
+<%- if @saml_realm -%>
+# SAML
+xpack.security.authc.providers:
+  saml.<%= @saml_realm %>:
+    order: 0
+    realm: "<%= @saml_realm %>"
+<%- end -%>
+

--- a/templates/kibana_yml.erb
+++ b/templates/kibana_yml.erb
@@ -54,14 +54,25 @@ elasticsearch.hosts:
 # the username and password that the Kibana server uses to perform maintenance on the Kibana
 # index at startup. Your Kibana users still need to authenticate with Elasticsearch, which
 # is proxied through the Kibana server.
+<%- if @elasticsearch_username -%>
+elasticsearch.username: "<%= @elasticsearch_username %>"
+elasticsearch.password: "<%= @elasticsearch_password %>"
+<%- else -%>
 #elasticsearch.username: "user"
 #elasticsearch.password: "pass"
+<%- end -%>
 
 # Enables SSL and paths to the PEM-format SSL certificate and SSL key files, respectively.
 # These settings enable SSL for outgoing requests from the Kibana server to the browser.
-#server.ssl.enabled: false
+<%- if @server_ssl -%>
+server.ssl.enabled: true
+server.ssl.certificate: <%= @server_ssl_certificate %>
+server.ssl.key: <%= @server_ssl_key %>
+<%- else -%>
+server.ssl.enabled: false
 #server.ssl.certificate: /path/to/your/server.crt
 #server.ssl.key: /path/to/your/server.key
+<%- end -%>
 
 # Optional settings that provide the paths to the PEM-format SSL certificate and key files.
 # These files validate that your Elasticsearch backend uses the same key files.
@@ -73,7 +84,11 @@ elasticsearch.hosts:
 #elasticsearch.ssl.certificateAuthorities: [ "/path/to/your/CA.pem" ]
 
 # To disregard the validity of SSL certificates, change this setting's value to 'none'.
+<%- if @elasticsearch_ssl_verificationmode -%>
+elasticsearch.ssl.verificationMode: <%= @elasticsearch_ssl_verificationmode %>
+<%- else -%>
 #elasticsearch.ssl.verificationMode: full
+<%- end -%>
 
 # Time in milliseconds to wait for Elasticsearch to respond to pings. Defaults to the value of
 # the elasticsearch.requestTimeout setting.
@@ -122,3 +137,4 @@ elasticsearch.hosts:
 
 # Specifies locale to be used for all localizable strings, dates and number formats.
 #i18n.locale: "en"
+

--- a/templates/local_decoder.xml.erb
+++ b/templates/local_decoder.xml.erb
@@ -25,12 +25,14 @@
 </decoder>
 -->
 
-<% @local_decoder.each do |decoder| -%>
+<% if @local_decoders -%>
+<% @local_decoders.each do |decoder| -%>
   <decoder name="<%= decoder['name'] %>">
 <% dkeys = ['parent','prematch','regexp','order','plugin_decoder','program_name'] -%>
 <% dkeys.each do |thiskey| -%>
 <% if decoder[thiskey] %>    <<%= thiskey %>><%= decoder[thiskey] %></<%= thiskey %>><% end -%>
 <% end -%>
   </decoder>
+<% end -%>
 <% end -%>
 

--- a/templates/local_decoder.xml.erb
+++ b/templates/local_decoder.xml.erb
@@ -19,6 +19,18 @@
   - extra_data - Any extra data
 -->
 
+<!--
 <decoder name="local_decoder_example">
     <program_name>local_decoder_example</program_name>
 </decoder>
+-->
+
+<% @local_decoder.each do |decoder| -%>
+  <decoder name="<%= decoder['name'] %>">
+<% dkeys = ['parent','prematch','regexp','order','plugin_decoder','program_name'] -%>
+<% dkeys.each do |thiskey| -%>
+<% if decoder[thiskey] %>    <<%= thiskey %>><%= decoder[thiskey] %></<%= thiskey %>><% end -%>
+<% end -%>
+  </decoder>
+<% end -%>
+

--- a/templates/local_decoder.xml.erb
+++ b/templates/local_decoder.xml.erb
@@ -25,7 +25,7 @@
 </decoder>
 -->
 
-<% if @local_decoders -%>
+<% if ! @local_decoders.nil? and @local_decoders.is_a?(Array) -%>
 <% @local_decoders.each do |decoder| -%>
   <decoder name="<%= decoder['name'] %>">
 <% dkeys = ['parent','prematch','regexp','order','plugin_decoder','program_name'] -%>
@@ -33,6 +33,5 @@
 <% if decoder[thiskey] %>    <<%= thiskey %>><%= decoder[thiskey] %></<%= thiskey %>><% end -%>
 <% end -%>
   </decoder>
-<% end -%>
-<% end -%>
+<% end -%><% end -%>
 

--- a/templates/local_decoder.xml.erb
+++ b/templates/local_decoder.xml.erb
@@ -30,7 +30,8 @@
   <decoder name="<%= decoder['name'] %>">
 <% dkeys = ['parent','prematch','regexp','order','plugin_decoder','program_name'] -%>
 <% dkeys.each do |thiskey| -%>
-<% if decoder[thiskey] %>    <<%= thiskey %>><%= decoder[thiskey] %></<%= thiskey %>><% end -%>
+<% if decoder[thiskey] %>    <<%= thiskey %>><%= decoder[thiskey] %></<%= thiskey %>>
+<% end -%>
 <% end -%>
   </decoder>
 <% end -%><% end -%>

--- a/templates/local_rules.xml.erb
+++ b/templates/local_rules.xml.erb
@@ -1,18 +1,17 @@
-<!-- Modify it at your will. -->
+<!-- This file created by puppet
+     Update by adding local_rules and rule_exclude inthe hiera
+  -->
 
-<group name="local,syslog,sshd,">
+<group name="puppet-controlled">
 
-  <!-- Note that rule id 5711 is defined at the ssh_rules file
-    -  as a ssh failed login. This is just an example
-    -  since ip 1.1.1.1 shouldn't be used anywhere.
-    -  Level 0 means ignore.
-    -->
+  <!--
   <rule id="100001" level="5">
     <if_sid>5716</if_sid>
     <srcip>1.1.1.1</srcip>
     <description>sshd: authentication failed from IP 1.1.1.1.</description>
     <group>authentication_failed,pci_dss_10.2.4,pci_dss_10.2.5,</group>
   </rule>
+  -->
 
 
   <!-- This example will ignore ssh failed logins for the user name XYZABC.
@@ -28,14 +27,24 @@
 
 
   <!-- Specify here a list of rules to ignore. -->
-  <!--
-  <rule id="100030" level="0">
-    <if_sid>12345, 23456, xyz, abc</if_sid>
+<% if @rule_exclude %>
+  <rule id="100000" level="0">
+    <if_sid><%= @rule_exclude.join(",") %></if_sid>
     <description>List of rules to be ignored.</description>
   </rule>
-  -->
+<% end -%>
 
-</group> <!-- SYSLOG,LOCAL -->
+  <!-- Locally defined rule overrides. -->
+<% @local_rules.each do |rule| -%>
+  <rule id="<%= rule['id'] %>" level="<%= rule['level'] %>">
+<% if rule['if_sid'] %>    <if_sid><%= rule['if_sid'] %></if_sid><% end -%>
+<% if rule['srcip'] %>    <srcip><%= rule['srcip'] %></srcip><% end -%>
+<% if rule['user'] %>    <user><%= rule['user'] %></user><% end -%>
+<% if rule['group'] %>    <group><%= rule['group'] %></group><% end -%>
+<% if rule['description'] %>    <description><%= rule['description'] %></description><% end -%>
+  </rule>
+<% end -%>
 
+</group> 
 
 <!-- EOF -->

--- a/templates/local_rules.xml.erb
+++ b/templates/local_rules.xml.erb
@@ -35,6 +35,7 @@
 <% end -%>
 
   <!-- Locally defined rule overrides. -->
+<% if #local_rules -%>
 <% @local_rules.each do |rule| -%>
   <rule id="<%= rule['id'] %>" level="<%= rule['level'] %>">
 <% if rule['if_sid'] %>    <if_sid><%= rule['if_sid'] %></if_sid><% end -%>
@@ -43,6 +44,7 @@
 <% if rule['group'] %>    <group><%= rule['group'] %></group><% end -%>
 <% if rule['description'] %>    <description><%= rule['description'] %></description><% end -%>
   </rule>
+<% end -%>
 <% end -%>
 
 </group> 

--- a/templates/local_rules.xml.erb
+++ b/templates/local_rules.xml.erb
@@ -27,25 +27,29 @@
 
 
   <!-- Specify here a list of rules to ignore. -->
-<% if @rule_exclude %>
+<% if ! @rule_exclude.nil? and @rule_exlude.is_a(Array) and @rule_exclude.length() > 0 %>
   <rule id="100000" level="0">
-    <if_sid><%= @rule_exclude.join(",") %></if_sid>
+    <if_sid><%= @rule_exclude.join(", ") %></if_sid>
     <description>List of rules to be ignored.</description>
   </rule>
 <% end -%>
 
   <!-- Locally defined rule overrides. -->
-<% if #local_rules -%>
+<% if ! @local_rules.nil? and @local_rules.is_a?(Array) -%>
 <% @local_rules.each do |rule| -%>
   <rule id="<%= rule['id'] %>" level="<%= rule['level'] %>">
-<% if rule['if_sid'] %>    <if_sid><%= rule['if_sid'] %></if_sid><% end -%>
-<% if rule['srcip'] %>    <srcip><%= rule['srcip'] %></srcip><% end -%>
-<% if rule['user'] %>    <user><%= rule['user'] %></user><% end -%>
-<% if rule['group'] %>    <group><%= rule['group'] %></group><% end -%>
-<% if rule['description'] %>    <description><%= rule['description'] %></description><% end -%>
+<% if rule['if_sid'] %>    <if_sid><%= rule['if_sid'] %></if_sid>
+<% end -%>
+<% if rule['srcip'] %>    <srcip><%= rule['srcip'] %></srcip>
+<% end -%>
+<% if rule['user'] %>    <user><%= rule['user'] %></user>
+<% end -%>
+<% if rule['group'] %>    <group><%= rule['group'] %></group>
+<% end -%>
+<% if rule['description'] %>    <description><%= rule['description'] %></description>
+<% end -%>
   </rule>
-<% end -%>
-<% end -%>
+<% end -%><% end -%>
 
 </group> 
 

--- a/templates/local_rules.xml.erb
+++ b/templates/local_rules.xml.erb
@@ -27,7 +27,7 @@
 
 
   <!-- Specify here a list of rules to ignore. -->
-<% if ! @rule_exclude.nil? and @rule_exlude.is_a(Array) and @rule_exclude.length() > 0 %>
+<% if ! @rule_exclude.nil? and @rule_exlude.is_a?(Array) and @rule_exclude.length() > 0 %>
   <rule id="100000" level="0">
     <if_sid><%= @rule_exclude.join(", ") %></if_sid>
     <description>List of rules to be ignored.</description>


### PR DESCRIPTION
This change to the filebeat and filebeat_oss classes allows more options to be set. 
Specifically, it allows authentication options to be used with the non-oss class, enabling filebeat to connect to Elasticsearch Cloud with an API key or username/password combination.
There are also options to allow more worker threads and to enable or disable the certificate verification.
Finally, the Exec resources are updated with precedence and 'creates' options, to prevent things from being run more than is required.