### PR TITLE
Update 4.2 branch with puppet last changes

### DIFF
--- a/.github/actions/validate_module/Dockerfile
+++ b/.github/actions/validate_module/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="https://github.com/wazuh/wazuh-puppet"
 LABEL "maintainer"="Wazuh"
 
 RUN rpm -Uvh https://yum.puppet.com/puppet-tools-release-el-7.noarch.rpm && \
-    yum install -y --assumeyes pdk
+    yum install -y --assumeyes pdk && \
     yum groupinstall -y --assumeyes "Development tools"
 
 COPY ./entrypoint.sh /entrypoint.sh

--- a/.github/actions/validate_module/Dockerfile
+++ b/.github/actions/validate_module/Dockerfile
@@ -10,6 +10,7 @@ LABEL "maintainer"="Wazuh"
 
 RUN rpm -Uvh https://yum.puppet.com/puppet-tools-release-el-7.noarch.rpm && \
     yum install -y --assumeyes pdk
+    yum groupinstall -y --assumeyes "Development tools"
 
 COPY ./entrypoint.sh /entrypoint.sh
 RUN chmod 755 /entrypoint.sh

--- a/.github/actions/validate_module/entrypoint.sh
+++ b/.github/actions/validate_module/entrypoint.sh
@@ -1,3 +1,2 @@
 #! /usr/bin/env bash
-pdk convert --force
 pdk validate

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ require:
 - rubocop-i18n
 AllCops:
   DisplayCopNames: true
-  TargetRubyVersion: '2.1'
+  TargetRubyVersion: '2.5'
   Include:
   - "./**/*.rb"
   Exclude:
@@ -18,12 +18,12 @@ AllCops:
   - "**/Puppetfile"
   - "**/Vagrantfile"
   - "**/Guardfile"
-Metrics/LineLength:
+Layout/LineLength:
   Description: People have wide screens, use them.
   Max: 200
-GetText:
+I18n/GetText:
   Enabled: false
-GetText/DecorateString:
+I18n/GetText/DecorateString:
   Description: We don't want to decorate test output.
   Exclude:
   - spec/**/*
@@ -40,10 +40,6 @@ Style/BlockDelimiters:
   Description: Prefer braces for chaining. Mostly an aesthetical choice. Better to
     be consistent then.
   EnforcedStyle: braces_for_chaining
-Style/BracesAroundHashParameters:
-  Description: Braces are required by Ruby 2.7. Cop removed from RuboCop v0.80.0.
-    See https://github.com/rubocop-hq/rubocop/pull/7643
-  Enabled: true
 Style/ClassAndModuleChildren:
   Description: Compact style reduces the required amount of indentation.
   EnforcedStyle: compact
@@ -72,7 +68,7 @@ Style/TrailingCommaInArguments:
   Description: Prefer always trailing comma on multiline argument lists. This makes
     diffs, and re-ordering nicer.
   EnforcedStyleForMultiline: comma
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   Description: Prefer always trailing comma on multiline literals. This makes diffs,
     and re-ordering nicer.
   EnforcedStyleForMultiline: comma
@@ -93,15 +89,15 @@ Style/MethodCalledOnDoEndBlock:
   Enabled: true
 Style/StringMethods:
   Enabled: true
-GetText/DecorateFunctionMessage:
+I18n/GetText/DecorateFunctionMessage:
   Enabled: false
-GetText/DecorateStringFormattingUsingInterpolation:
+I18n/GetText/DecorateStringFormattingUsingInterpolation:
   Enabled: false
-GetText/DecorateStringFormattingUsingPercent:
+I18n/GetText/DecorateStringFormattingUsingPercent:
   Enabled: false
 Layout/EndOfLine:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Metrics/AbcSize:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ gem "kitchen-puppet"
 gem "kitchen-vagrant"
 gem 'kitchen-docker', '~> 2.3'
 gem "librarian-puppet"
+gem "rubocop-i18n", require: false
 # vim: syntax=ruby

--- a/kitchen/test/integration/agent/agent_spec.rb
+++ b/kitchen/test/integration/agent/agent_spec.rb
@@ -15,10 +15,9 @@ control 'wazuh-agent' do
 
   # Verifying daemons
   wazuh_daemons = {
-    # 'ossec-agentd' => 'ossec',
-    'ossec-execd' => 'root',
-    # 'ossec-syscheckd' => 'root',
-    # 'wazuh-modulesd' => 'root',
+    'wazuh-agentd' => 'ossec',
+    'wazuh-execd' => 'root',
+    'wazuh-modulesd' => 'root',
   }
 
   wazuh_daemons.each do |key, value|

--- a/kitchen/test/integration/agent/agent_spec.rb
+++ b/kitchen/test/integration/agent/agent_spec.rb
@@ -18,6 +18,8 @@ control 'wazuh-agent' do
     'wazuh-agentd' => 'ossec',
     'wazuh-execd' => 'root',
     'wazuh-modulesd' => 'root',
+    'wazuh-syscheckd' => 'root',
+    'wazuh-logcollector' => 'root'
   }
 
   wazuh_daemons.each do |key, value|

--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -16,13 +16,13 @@ control 'wazuh-manager' do
 
   # Verifying daemons
   wazuh_daemons = {
-    'ossec-authd' => 'root',
-    'ossec-execd' => 'root',
-    'ossec-analysisd' => 'ossec',
-    'ossec-syscheckd' => 'root',
-    'ossec-remoted' => 'ossecr',
-    'ossec-logcollector' => 'root',
-    'ossec-monitord' => 'ossec',
+    'wazuh-authd' => 'root',
+    'wazuh-execd' => 'root',
+    'wazuh-analysisd' => 'ossec',
+    'wazuh-syscheckd' => 'root',
+    'wazuh-remoted' => 'ossecr',
+    'wazuh-logcollector' => 'root',
+    'wazuh-monitord' => 'ossec',
     'wazuh-db' => 'ossec',
     'wazuh-modulesd' => 'root',
   }

--- a/manifests/audit.pp
+++ b/manifests/audit.pp
@@ -1,6 +1,5 @@
 # Wazuh App Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 # Define an ossec command
-
 class wazuh::audit (
   $audit_manage_rules = false,
   $audit_buffer_bytes = '8192',

--- a/manifests/elasticsearch.pp
+++ b/manifests/elasticsearch.pp
@@ -11,7 +11,7 @@ class wazuh::elasticsearch (
   $elasticsearch_node_max_local_storage_nodes = '1',
   $elasticsearch_service = 'elasticsearch',
   $elasticsearch_package = 'elasticsearch',
-  $elasticsearch_version = '7.9.3',
+  $elasticsearch_version = '7.10.2',
 
   # user/group elasticsearch processes run as
   $elasticsearch_user = 'elasticsearch',

--- a/manifests/filebeat.pp
+++ b/manifests/filebeat.pp
@@ -7,8 +7,8 @@ class wazuh::filebeat (
 
   $filebeat_package = 'filebeat',
   $filebeat_service = 'filebeat',
-  $filebeat_version = '7.10.0',
-  $wazuh_app_version = '4.2.0_7.10.0',
+  $filebeat_version = '7.10.2',
+  $wazuh_app_version = '4.2.0_7.10.2',
   $wazuh_extensions_version = 'v4.2.0',
   $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -9,8 +9,8 @@ class wazuh::filebeat_oss (
   $filebeat_oss_service = 'filebeat',
   $filebeat_oss_elastic_user = 'admin',
   $filebeat_oss_elastic_password = 'admin',
-  $filebeat_oss_version = '7.10.0',
-  $wazuh_app_version = '4.2.0_7.10.0',
+  $filebeat_oss_version = '7.10.2',
+  $wazuh_app_version = '4.2.0_7.10.2',
   $wazuh_extensions_version = 'v4.2.0',
   $wazuh_filebeat_module = 'wazuh-filebeat-0.1.tar.gz',
 ){

--- a/manifests/kibana.pp
+++ b/manifests/kibana.pp
@@ -3,7 +3,7 @@
 class wazuh::kibana (
   $kibana_package = 'kibana',
   $kibana_service = 'kibana',
-  $kibana_version = '7.9.3',
+  $kibana_version = '7.10.2',
 
   $kibana_elasticsearch_hosts = [
     {

--- a/manifests/kibana_od.pp
+++ b/manifests/kibana_od.pp
@@ -3,10 +3,10 @@
 class wazuh::kibana_od (
   $kibana_od_package = 'opendistroforelasticsearch-kibana',
   $kibana_od_service = 'kibana',
-  $kibana_od_version = '1.12.0',
+  $kibana_od_version = '1.13.2',
   $kibana_od_elastic_user = 'admin',
   $kibana_od_elastic_password = 'admin',
-  $kibana_od_app_version = '4.2.0_7.10.0',
+  $kibana_od_app_version = '4.2.0_7.10.2',
   $kibana_od_elasticsearch_ip = 'localhost',
   $kibana_od_elasticsearch_port = '9200',
 

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -269,7 +269,6 @@ class wazuh::manager (
       $wazuh_api_port                           = $wazuh::params_manager::wazuh_api_port,
       $wazuh_api_file                           = $wazuh::params_manager::wazuh_api_file,
 
-      $wazuh_api_behind_proxy_server            = $wazuh::params_manager::wazuh_api_behind_proxy_server,
       $wazuh_api_https_enabled                  = $wazuh::params_manager::wazuh_api_https_enabled,
       $wazuh_api_https_key                      = $wazuh::params_manager::wazuh_api_https_key,
 

--- a/manifests/opendistro.pp
+++ b/manifests/opendistro.pp
@@ -11,7 +11,7 @@ class wazuh::opendistro (
   $opendistro_node_max_local_storage_nodes = '1',
   $opendistro_service = 'elasticsearch',
   $opendistro_package = 'opendistroforelasticsearch',
-  $opendistro_version = '1.11.0',
+  $opendistro_version = '1.13.2',
 
   $opendistro_path_data = '/var/lib/elasticsearch',
   $opendistro_path_logs = '/var/log/elasticsearch',

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -330,9 +330,6 @@ class wazuh::params_manager {
 
       $wazuh_api_file =  undef
 
-      # Set this option to "yes" in case the API is running behind a proxy server. Values: yes, no
-      $wazuh_api_behind_proxy_server = 'no'
-
       # Advanced configuration
       $wazuh_api_https_enabled = 'yes'
       $wazuh_api_https_key = 'api/configuration/ssl/server.key'

--- a/templates/default_commands.erb
+++ b/templates/default_commands.erb
@@ -1,62 +1,53 @@
   <command>
     <name>disable-account</name>
-    <executable>disable-account.sh</executable>
-    <expect>user</expect>
+    <executable>disable-account</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>restart-ossec</name>
-    <executable>restart-ossec.sh</executable>
-    <expect></expect>
+    <executable>restart-ossec</executable>
   </command>
 
   <command>
     <name>firewall-drop</name>
-    <executable>firewall-drop.sh</executable>
-    <expect>srcip</expect>
+    <executable>firewall-drop</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>host-deny</name>
-    <executable>host-deny.sh</executable>
-    <expect>srcip</expect>
+    <executable>host-deny</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>route-null</name>
-    <executable>route-null.sh</executable>
-    <expect>srcip</expect>
+    <executable>route-null</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>win_route-null</name>
-    <executable>route-null.cmd</executable>
-    <expect>srcip</expect>
+    <executable>route-null</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>win_route-null-2012</name>
-    <executable>route-null-2012.cmd</executable>
-    <expect>srcip</expect>
+    <executable>route-null-2012</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>netsh</name>
-    <executable>netsh.cmd</executable>
-    <expect>srcip</expect>
+    <executable>netsh</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 
   <command>
     <name>netsh-win-2016</name>
-    <executable>netsh-win-2016.cmd</executable>
-    <expect>srcip</expect>
+    <executable>netsh-win-2016</executable>
     <timeout_allowed>yes</timeout_allowed>
   </command>
 

--- a/templates/fragments/_command.erb
+++ b/templates/fragments/_command.erb
@@ -3,7 +3,6 @@
 <command>
   <name><%= @command_name %></name>
   <executable><%= @command_executable %></executable>
-  <expect><%= @command_expect %></expect>
   <timeout_allowed><%= @command_timeout_allowed %></timeout_allowed>
 </command>
 

--- a/templates/wazuh_api_yml.erb
+++ b/templates/wazuh_api_yml.erb
@@ -4,8 +4,6 @@
 #
 host: <%= @wazuh_api_host %>
 port: <%= @wazuh_api_port %>
-# Set this option to "yes" in case the API is running behind a proxy server. Values: yes, no
-behind_proxy_server: <%= @wazuh_api_behind_proxy_server %>
 # Advanced configuration
 https:
   enabled: <%= @wazuh_api_https_enabled %>

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -3,6 +3,8 @@
     <alerts_log>yes</alerts_log>
     <logall>no</logall>
     <logall_json>no</logall_json>
+    <agents_disconnection_time>10m</agents_disconnection_time>
+    <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   <%- if @ossec_emailnotification -%>
     <email_notification>yes</email_notification>
     <%- @ossec_emailto.each do |emailto| -%>


### PR DESCRIPTION
Hello team,

This PR closes #381 we want to update last 4.2 changes into puppet 4.2 main branch.
We have done the following tasks:
- Removed `expect`label config of active-response configuration generator.
- Removed proxy option into API configuration (removed from framework).
- Fixed `pdk` validation tests.
- Updated Rubocop file notation and dependencies.
- Updated automated kitchen tests.
- Updated Elasticseach and OpenDistro versions.

Regards.