### PR TITLE
374 issue upgrade agent windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed a bug in the agent.pp manifest that did not upgrade a new version of Wazuh Agent in Windows ([#374](https://github.com/wazuh/wazuh-puppet/issues/374))
+- Fixed a but in the agent.pp manifest that prevented the Wazuh Agent from upgrading in Windows ([#374](https://github.com/wazuh/wazuh-puppet/issues/374))
 
 ## Wazuh Puppet v4.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed a but in the agent.pp manifest that prevented the Wazuh Agent from upgrading in Windows ([#374](https://github.com/wazuh/wazuh-puppet/issues/374))
+- Fixed a bug in the agent.pp manifest that prevented the Wazuh Agent from upgrading in Windows ([#374](https://github.com/wazuh/wazuh-puppet/issues/374))
 
 ## Wazuh Puppet v4.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 
 - Support to 4.2.2 Wazuh release.
 
+### Fixed
+
+- Fixed a bug in the agent.pp manifest that did not upgrade a new version of Wazuh Agent in Windows ([#374](https://github.com/wazuh/wazuh-puppet/issues/374))
+
 ## Wazuh Puppet v4.2.1
 
 ### Added

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -293,7 +293,7 @@ class wazuh::agent (
 
       # We dont need to pin the package version on Windows since we install if from the right MSI.
       -> package { $agent_package_name:
-        ensure          => 'installed',
+        ensure          => "${agent_package_version}",
         provider        => 'windows',
         source          => "${download_path}\\wazuh-agent-${agent_package_version}.msi",
         install_options => [


### PR DESCRIPTION
Closes  https://github.com/wazuh/wazuh-puppet/issues/374
This PR fix a bug in the agent.pp manifest that did not upgrade a new version of Wazuh Agent in Windows