### PR TITLE
4.2.2 release requires an update to the wazuh api yml template. manifest/manager.pp logic

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -277,7 +277,8 @@ class wazuh::manager (
       $wazuh_api_https_ca                       = $wazuh::params_manager::wazuh_api_https_ca,
       $wazuh_api_logs_level                     = $wazuh::params_manager::wazuh_api_logs_level,
       $wazuh_api_logs_path                      = $wazuh::params_manager::wazuh_api_logs_path,
-      $wazuh_api_ssl_cipher                     = $wazuh::params_manager::wazuh_api_ssl_cipher,
+      $wazuh_api_ssl_ciphers                    = $wazuh::params_manager::wazuh_api_ssl_ciphers,
+      $wazuh_api_ssl_protocol                   = $wazuh::params_manager::wazuh_api_ssl_protocol,
 
       $wazuh_api_cors_enabled                   = $wazuh::params_manager::wazuh_api_cors_enabled,
       $wazuh_api_cors_source_route              = $wazuh::params_manager::wazuh_api_cors_source_route,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -336,7 +336,8 @@ class wazuh::params_manager {
       $wazuh_api_https_cert = 'api/configuration/ssl/server.crt'
       $wazuh_api_https_use_ca = 'False'
       $wazuh_api_https_ca = 'api/configuration/ssl/ca.crt'
-      $wazuh_api_ssl_cipher = 'TLSv1.2'
+      $wazuh_api_ssl_protocol = 'TLSv1.2'
+      $wazuh_api_ssl_ciphers  = '""'
 
       # Logging configuration
       # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).

--- a/templates/wazuh_api_yml.erb
+++ b/templates/wazuh_api_yml.erb
@@ -11,7 +11,8 @@ https:
   cert: <%= @wazuh_api_https_cert %>
   use_ca: <%= @wazuh_api_https_use_ca %>
   ca: <%= @wazuh_api_https_ca %>
-  ssl_cipher: <%= @wazuh_api_ssl_cipher %>
+  ssl_protocol: <%= @wazuh_api_ssl_protocol %>
+  ssl_ciphers: <%= @wazuh_api_ssl_ciphers %>
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
 logs:


### PR DESCRIPTION
Updated managers manifests and api yaml template to reflect addition of ssl_ciphers and ssl_protocols to Wazuh api, where ssl_cipher has been removed.