### PR TITLE
Adding support for Debian 11 (Bullseye)

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -322,7 +322,7 @@ class wazuh::params_agent {
                 }
               }
             }
-            /^(wheezy|stretch|buster|sid|precise|trusty|vivid|wily|xenial|bionic|focal)$/: {
+            /^(wheezy|stretch|buster|bullseye|sid|precise|trusty|vivid|wily|xenial|bionic|focal)$/: {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $wodle_openscap_content = undef

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -419,7 +419,7 @@ class wazuh::params_manager {
                 }
               }
             }
-            /^(wheezy|stretch|buster|sid|precise|trusty|vivid|wily|xenial|bionic|focal)$/: {
+            /^(wheezy|stretch|buster|bullseye|sid|precise|trusty|vivid|wily|xenial|bionic|focal)$/: {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $wodle_openscap_content = undef

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,7 +16,7 @@ class wazuh::repo (
         server => 'pgp.mit.edu'
       }
       case $::lsbdistcodename {
-        /(jessie|wheezy|stretch|buster|sid|precise|trusty|vivid|wily|xenial|yakketi|bionic|focal)/: {
+        /(jessie|wheezy|stretch|buster|bullseye|sid|precise|trusty|vivid|wily|xenial|yakketi|bionic|focal)/: {
 
           apt::source { 'wazuh':
             ensure   => present,


### PR DESCRIPTION
Adding Debian 11 (Bullseye) support for Wazuh version 4.2 as requested by the user in the issue:
https://github.com/wazuh/wazuh-puppet/issues/400