### PR TITLE
Updating the wazuh-agent service name for Windows

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -454,7 +454,7 @@ class wazuh::params_agent {
       $keys_file = 'C:\\Program Files (x86)\\ossec-agent\\client.keys'
 
       $agent_package_name = 'Wazuh Agent'
-      $agent_service_name = 'OssecSvc'
+      $agent_service_name = 'WazuhSvc'
       $service_has_status = true
       $ossec_service_provider = undef
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -542,7 +542,7 @@ class wazuh::params_manager {
       $keys_owner = 'Administrator'
       $keys_group = 'Administrators'
 
-      $agent_service  = 'OssecSvc'
+      $agent_service  = 'WazuhSvc'
       $agent_package  = 'Wazuh Agent 4.3.0'
       $server_service = ''
       $server_package = ''


### PR DESCRIPTION
The wazuh-agent service name for Windows agents changed from 'OssecSvc' to 'WazuhSvc' in the wazuh/wazuh repo tag version 4.2.0. This change needs to be reflected in the params files. 

Error message seen on the Windows agents:
`Error: Cannot enable OssecSvc, error was: Failed to open a handle to the service:  The specified service does not exist as an installed service.
Wrapped exception:
Failed to open a handle to the service:  The specified service does not exist as an installed service.
Error: /Stage[main]/Wazuh::Agent/Service[OssecSvc]/ensure: change from 'stopped' to 'running' failed: Cannot enable OssecSvc, error was: Failed to open a handle to the service:  The specified service does not exist as an installed service.`