### PR TITLE
Add more directories for syscheck module

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -162,7 +162,7 @@ class wazuh::agent (
   $wodle_ciscat_scan_on_start        = $wazuh::params_agent::wodle_ciscat_scan_on_start,
   $wodle_ciscat_java_path            = $wazuh::params_agent::wodle_ciscat_java_path,
   $wodle_ciscat_ciscat_path          = $wazuh::params_agent::wodle_ciscat_ciscat_path,
-  wodle_ciscat_content               = $wazuh::params_agent::wodle_ciscat_content,
+  $wodle_ciscat_content              = $wazuh::params_agent::wodle_ciscat_content,
 
   #Osquery
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -197,6 +197,7 @@ class wazuh::agent (
   $ossec_syscheck_frequency          = $wazuh::params_agent::ossec_syscheck_frequency,
   $ossec_syscheck_scan_on_start      = $wazuh::params_agent::ossec_syscheck_scan_on_start,
   $ossec_syscheck_auto_ignore        = $wazuh::params_agent::ossec_syscheck_auto_ignore,
+  $ossec_syscheck_directories        = $wazuh::params_agent::ossec_syscheck_directories,
   $ossec_syscheck_directories_1      = $wazuh::params_agent::ossec_syscheck_directories_1,
   $ossec_syscheck_directories_2      = $wazuh::params_agent::ossec_syscheck_directories_2,
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -162,6 +162,7 @@ class wazuh::agent (
   $wodle_ciscat_scan_on_start        = $wazuh::params_agent::wodle_ciscat_scan_on_start,
   $wodle_ciscat_java_path            = $wazuh::params_agent::wodle_ciscat_java_path,
   $wodle_ciscat_ciscat_path          = $wazuh::params_agent::wodle_ciscat_ciscat_path,
+  wodle_ciscat_content               = $wazuh::params_agent::wodle_ciscat_content,
 
   #Osquery
 

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -133,6 +133,8 @@ class wazuh::manager (
       $wodle_ciscat_scan_on_start           = $wazuh::params_manager::wodle_ciscat_scan_on_start,
       $wodle_ciscat_java_path               = $wazuh::params_manager::wodle_ciscat_java_path,
       $wodle_ciscat_ciscat_path             = $wazuh::params_manager::wodle_ciscat_ciscat_path,
+      $wodle_ciscat_content                 = $wazuh::params_manager::wodle_ciscat_content,
+
 
       #osquery
       $wodle_osquery_disabled               = $wazuh::params_manager::wodle_osquery_disabled,

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -215,6 +215,7 @@ class wazuh::manager (
       $ossec_syscheck_frequency             = $wazuh::params_manager::ossec_syscheck_frequency,
       $ossec_syscheck_scan_on_start         = $wazuh::params_manager::ossec_syscheck_scan_on_start,
       $ossec_syscheck_auto_ignore           = $wazuh::params_manager::ossec_syscheck_auto_ignore,
+      $ossec_syscheck_directories           = $wazuh::params_manager::ossec_syscheck_directories,
       $ossec_syscheck_directories_1         = $wazuh::params_manager::ossec_syscheck_directories_1,
       $ossec_syscheck_directories_2         = $wazuh::params_manager::ossec_syscheck_directories_2,
       $ossec_syscheck_whodata_directories_1            = $wazuh::params_manager::ossec_syscheck_whodata_directories_1,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -226,6 +226,7 @@ class wazuh::params_agent {
       $ossec_syscheck_frequency = '43200'
       $ossec_syscheck_scan_on_start = 'yes'
       $ossec_syscheck_auto_ignore = undef
+      $ossec_syscheck_directories = {}
       $ossec_syscheck_directories_1 = '/etc,/usr/bin,/usr/sbin'
       $ossec_syscheck_directories_2 = '/bin,/sbin,/boot'
       $ossec_syscheck_report_changes_directories_1 = 'no'

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -199,6 +199,7 @@ class wazuh::params_agent {
       $wodle_ciscat_scan_on_start = 'yes'
       $wodle_ciscat_java_path = 'wodles/java'
       $wodle_ciscat_ciscat_path = 'wodles/ciscat'
+      $wodle_ciscat_content = {}
 
       ## osquery
       $wodle_osquery_disabled = 'yes'

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -223,6 +223,7 @@ class wazuh::params_manager {
       $ossec_syscheck_frequency                        = '43200'
       $ossec_syscheck_scan_on_start                    = 'yes'
       $ossec_syscheck_auto_ignore                      = 'no'
+      $ossec_syscheck_directories                      = {}
       $ossec_syscheck_directories_1                    = '/etc,/usr/bin,/usr/sbin'
       $ossec_syscheck_directories_2                    = '/bin,/sbin,/boot'
       $ossec_syscheck_whodata_directories_1            = 'no'

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -124,6 +124,7 @@ class wazuh::params_manager {
       $wodle_ciscat_scan_on_start                      = 'yes'
       $wodle_ciscat_java_path                          = 'wodles/java'
       $wodle_ciscat_ciscat_path                        = 'wodles/ciscat'
+      $wodle_ciscat_content                            = {}
 
       #osquery
 

--- a/templates/fragments/_syscheck.erb
+++ b/templates/fragments/_syscheck.erb
@@ -13,6 +13,10 @@
   <auto_ignore frequency="10" timeframe="3600"><%=@ossec_syscheck_auto_ignore%></auto_ignore>
   <%- end -%>
 
+  <%- @ossec_syscheck_directories.each do |scanpath| -%>
+    <directories check_all="yes" report_changes="<%= scanpath["report_changes"] %>" realtime="<%= scanpath['realtime'] %>" whodata="<%= scanpath['whodata'] || 'no' %>"><%= scanpath['path']  %></directories>
+  <%- end -%>
+
 <%- if @kernel == 'windows' -%>
 
   <!-- Default files to be monitored. -->

--- a/templates/fragments/_wodle_cis_cat.erb
+++ b/templates/fragments/_wodle_cis_cat.erb
@@ -18,5 +18,16 @@
   <% if @wodle_ciscat_ciscat_path -%>
   <ciscat_path><%= @wodle_ciscat_ciscat_path %></ciscat_path>
   <%- end -%>
+  <%- if not @wodle_ciscat_content.nil? -%>
+  <%- @wodle_ciscat_content.each do |path, value| -%>
+  <content type="<%= value['type'] %>" path="<%= path %>">
+    <%- if value['profiles'] then -%>
+    <%- value['profiles'].each do |profile| -%>
+    <profile><%= profile %></profile>
+    <%- end -%>
+    <%- end -%>
+  </content>
+  <%- end -%>
+  <%- end -%>
 </wodle>
 


### PR DESCRIPTION
Currently, it is not possible to add custom directories to the syscheck directive.

hiera example:
```
wazuh::agent::ossec_syscheck_directories:
  - path: '/etc/apache2'
    report_changes: 'yes'
    realtime: 'yes'
  - path: '/etc/dir2'
    report_changes: 'yes'
    realtime: 'yes'
  - path: '/etc/nginx'
    report_changes: 'yes'
    realtime: 'yes'
  - path: '/dir4'
    report_changes: 'yes'
    realtime: 'yes'
  - path: '/dir5'
    report_changes: 'yes'
    realtime: 'yes'
  - path: '/dir6
    report_changes: 'yes'
    realtime: 'yes'
```