### PR TITLE
Removed user Administrator for windows deployments to 4.2

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -284,7 +284,6 @@ class wazuh::agent (
 
       -> file { 'wazuh-agent':
         path               => "${download_path}\\wazuh-agent-${agent_package_version}.msi",
-        owner              => 'Administrator',
         group              => 'Administrators',
         mode               => '0774',
         source             => "${agent_msi_download_location}/wazuh-agent-${agent_package_version}.msi",

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -438,9 +438,9 @@ class wazuh::params_agent {
     'windows': {
       $config_file = 'C:\\Program Files (x86)\\ossec-agent\\ossec.conf'
       $shared_agent_config_file = 'C:\\Program Files (x86)\\ossec-agent\\shared\\agent.conf'
-      $config_owner = 'Administrator'
       $config_group = 'Administrators'
       $download_path = 'C:\\Temp'
+      $config_mode = '0664'
       $manage_firewall = false
 
       $keys_file = 'C:\\Program Files (x86)\\ossec-agent\\client.keys'


### PR DESCRIPTION
Close: https://github.com/wazuh/wazuh-puppet/issues/362

Local tests are carried out to simulate the error raised by the community user and it can be replicated, that is, if in a windows machine we do not have the Administrator user, we receive an error due to lack of permissions, so the correction is applied posed by the community user and the installation works correctly

Windows server 2016:
![Screenshot_20211112_161314](https://user-images.githubusercontent.com/64099752/141522271-fadbf086-1dbf-41cb-824f-f7e244b1bb15.png)

Install before fix:
![Screenshot_20211112_161344](https://user-images.githubusercontent.com/64099752/141522324-c1edc280-5b6b-42e4-99d8-c00bf707bd2c.png)

Install after fix:
![Screenshot_20211112_161417](https://user-images.githubusercontent.com/64099752/141522389-cd98180b-bccb-4008-b728-02305bad864c.png)

Wazuh manager agent list:
![Screenshot_20211112_161508](https://user-images.githubusercontent.com/64099752/141522491-4bfe0f53-458c-451e-a1cc-c3fcf5d4b740.png)
