### PR TITLE
Change ossecr user

### DIFF
--- a/kitchen/test/integration/mngr/manager_spec.rb
+++ b/kitchen/test/integration/mngr/manager_spec.rb
@@ -20,7 +20,7 @@ control 'wazuh-manager' do
     'wazuh-execd' => 'root',
     'wazuh-analysisd' => 'wazuh',
     'wazuh-syscheckd' => 'root',
-    'wazuh-remoted' => 'ossecr',
+    'wazuh-remoted' => 'wazuh',
     'wazuh-logcollector' => 'root',
     'wazuh-monitord' => 'wazuh',
     'wazuh-db' => 'wazuh',


### PR DESCRIPTION
This PR fix "ossecr" user in Wazuh Manager installation to wazuh user
Closes #352