### PR TITLE
Adapt the Puppet deployment to use the new Wazuh indexer default ports

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -8,7 +8,7 @@ class wazuh::dashboard (
   $dashboard_password = 'admin',
   $dashboard_app_version = '4.3.0-1',
   $dashboard_ip = 'localhost',
-  $dashboard_port = '9700',
+  $dashboard_port = '9200',
 
   $dashboard_server_port = '5601',
   $dashboard_server_host = '0.0.0.0',

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -18,7 +18,7 @@ class wazuh::indexer (
 
 
   $indexer_ip = 'localhost',
-  $indexer_port = '9700',
+  $indexer_port = '9200',
   $indexer_discovery_option = 'discovery.type: single-node',
   $indexer_cluster_initial_master_nodes = "#cluster.initial_master_nodes: ['node-1']",
 


### PR DESCRIPTION
This PR modifiy default ports for Indexer
Closes https://github.com/wazuh/wazuh-puppet/issues/447