### PR TITLE
Add new API logs `format` configuration parameter to Puppet deployment

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -283,6 +283,7 @@ class wazuh::manager (
       $wazuh_api_https_use_ca                   = $wazuh::params_manager::wazuh_api_https_use_ca,
       $wazuh_api_https_ca                       = $wazuh::params_manager::wazuh_api_https_ca,
       $wazuh_api_logs_level                     = $wazuh::params_manager::wazuh_api_logs_level,
+      $wazuh_api_logs_format                    = $wazuh::params_manager::wazuh_api_logs_format,
       $wazuh_api_ssl_ciphers                    = $wazuh::params_manager::wazuh_api_ssl_ciphers,
       $wazuh_api_ssl_protocol                   = $wazuh::params_manager::wazuh_api_ssl_protocol,
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -348,6 +348,8 @@ class wazuh::params_manager {
       # Logging configuration
       # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
       $wazuh_api_logs_level = 'info'
+      # Values for API log format: 'plain', 'json', 'plain,json', 'json,plain'
+      $wazuh_api_logs_format = 'plain'
 
       # Cross-origin resource sharing: https://github.com/aio-libs/aiohttp-cors#usage
       $wazuh_api_cors_enabled = 'no'

--- a/templates/wazuh_api_yml.erb
+++ b/templates/wazuh_api_yml.erb
@@ -17,6 +17,7 @@ https:
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
 logs:
   level: <%= @wazuh_api_logs_level %>
+  format: <%= @wazuh_api_logs_format %>
 # Cross-origin resource sharing: https://github.com/aio-libs/aiohttp-cors#usage
 cors:
   enabled: <%= @wazuh_api_cors_enabled %>


### PR DESCRIPTION
This PR closes #451 

In this PR, I have added the new parameter to `templates/wazuh_api_yml.erb`, `manifests/manager.pp` and `manifests/params_manager.pp`.

To test this, I have deployed Wazuh 4.2.6 with puppet, and I have changed the same files by hand in the Wazuh puppet installation:

`/etc/puppetlabs/code/environments/production/modules/wazuh/manifests/manager.pp
`
`/etc/puppetlabs/code/environments/production/modules/wazuh/manifests/params_manager.pp
`
`/etc/puppetlabs/code/environments/production/modules/wazuh/templates/wazuh_api_yml.erb
`

After that, I have used the new variable in `/etc/puppetlabs/code/environments/production/manifests/wazuh-manager.pp`:

```
...
class { 'wazuh::manager':
    ossec_smtp_server => 'localhost',
    ossec_emailto => ['user@mycompany.com'],
    wazuh_api_logs_format => 'json',
  }

...
```


In the Puppet agent:

`# puppet agent -t`

And the configuration change is done properly:

```
...
Info: Applying configuration version '1649066519'
Notice: /Stage[main]/Wazuh::Manager/File[/var/ossec/api/configuration/api.yaml]/content: 
--- /var/ossec/api/configuration/api.yaml	2022-04-04 09:46:51.022130492 +0000
+++ /tmp/puppet-file20220404-2721-l1p0x0	2022-04-04 10:02:00.617043046 +0000
@@ -16,8 +16,8 @@
 # Logging configuration
 # Values for API log level: disabled, info, warning, error, debug, debug2 (each level includes the previous level).
 logs:
-  level: debug
+  level: info
+  format: json
 # Cross-origin resource sharing: https://github.com/aio-libs/aiohttp-cors#usage
 cors:
   enabled: no

...
```