### PR TITLE
Updated config.yml template

### DIFF
--- a/templates/wazuh_config_yml.erb
+++ b/templates/wazuh_config_yml.erb
@@ -1,10 +1,10 @@
 nodes:
   indexer:
-    name: indexer
-    ip: 127.0.0.1
+    - name: indexer
+      ip: 127.0.0.1
   server:
-    name: server
-    ip: 127.0.0.1
+    - name: server
+      ip: 127.0.0.1
   dashboard:
-    name: dashboard
-    ip: 127.0.0.1
+    - name: dashboard
+      ip: 127.0.0.1


### PR DESCRIPTION
closes https://github.com/wazuh/wazuh-puppet/issues/475
The template is updated based on the new format that the config.yml must have

```
[root@centos72 tmp]# cat config.yml 
nodes:
  indexer:
    - name: indexer
      ip: 127.0.0.1
  server:
    - name: server
      ip: 127.0.0.1
  dashboard:
    - name: dashboard
      ip: 127.0.0.1[root@centos72 tmp]# ls -la wazuh-certificates/
total 44
dr-x------.  2 root root  210 Apr  8 14:01 .
drwxrwxrwt. 14 root root 4096 Apr  8 14:07 ..
-r--------.  1 root root 1704 Apr  8 14:01 admin-key.pem
-r--------.  1 root root 1107 Apr  8 14:01 admin.pem
-r--------.  1 root root 1704 Apr  8 14:01 dashboard-key.pem
-r--------.  1 root root 1224 Apr  8 14:01 dashboard.pem
-r--------.  1 root root 1704 Apr  8 14:01 indexer-key.pem
-r--------.  1 root root 1220 Apr  8 14:01 indexer.pem
-r--------.  1 root root 1704 Apr  8 14:01 root-ca.key
-r--------.  1 root root 1184 Apr  8 14:01 root-ca.pem
-r--------.  1 root root 1704 Apr  8 14:01 server-key.pem
-r--------.  1 root root 1220 Apr  8 14:01 server.pem

```