### PR TITLE
Added option to have YUM repo managed by disabled

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,3 +4,6 @@ fixtures:
     stdlib:
       repo: "puppetlabs/stdlib"
       ref: "4.13.0"
+    yumrepo:
+      repo: "puppetlabs/yumrepo_core"
+      ref: "1.1.0"

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -14,6 +14,7 @@ class wazuh::agent (
   # Manage repository
 
   $manage_repo                       = $wazuh::params_agent::manage_repo,
+  $yumrepo_enabled                   = $wazuh::params_agent::yumrepo_enabled,
 
   # Authd registration options
   $manage_client_keys                = $wazuh::params_agent::manage_client_keys,
@@ -274,7 +275,9 @@ class wazuh::agent (
   case $::kernel {
     'Linux': {
       if $manage_repo {
-        class { 'wazuh::repo': }
+        class { 'wazuh::repo':
+          yumrepo_enabled => $yumrepo_enabled,
+        }
         if $::osfamily == 'Debian' {
           Class['wazuh::repo'] -> Class['apt::update'] -> Package[$agent_package_name]
         } else {

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -97,6 +97,7 @@ class wazuh::params_agent {
 
   # Other required to define variables
   $manage_repo = true
+  $yumrepo_enabled = true
   $manage_firewall = false
   $selinux = false
   $configure_labels = false

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,6 +1,7 @@
 # Wazuh App Copyright (C) 2021 Wazuh Inc. (License GPLv2)
 # Wazuh repository installation
 class wazuh::repo (
+  Boolean $yumrepo_enabled = true,
 ) {
 
   case $::osfamily {
@@ -49,7 +50,7 @@ class wazuh::repo (
       # Set up OSSEC repo
       yumrepo { 'wazuh':
         descr    => 'WAZUH OSSEC Repository - www.wazuh.com',
-        enabled  => true,
+        enabled  => $yumrepo_enabled,
         gpgcheck => 1,
         gpgkey   => $gpgkey,
         baseurl  => $baseurl

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,10 @@
     {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 2.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/yumrepo_core",
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -8,7 +8,6 @@ describe 'wazuh::repo' do
       if os_facts[:os]['kernel'] == 'Linux'
         it { is_expected.to compile }
 
-
         if os_facts[:os]['family'] == 'RedHat'
           it {
             is_expected.to contain_yumrepo('wazuh').with(

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe 'wazuh::repo' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      if os_facts[:os]['kernel'] == 'Linux'
+        it { is_expected.to compile }
+
+
+        if os_facts[:os]['family'] == 'RedHat'
+          it {
+            is_expected.to contain_yumrepo('wazuh').with(
+              'descr'    => 'WAZUH OSSEC Repository - www.wazuh.com',
+              'enabled'  => true,
+              'gpgcheck' => '1',
+            )
+          }
+        end
+
+        describe 'Disable yumrepo' do
+         let(:params) do
+           {
+              yumrepo_enabled: false,
+           }
+          end
+
+          it {
+            is_expected.to contain_yumrepo('wazuh').with(
+              'descr'    => 'WAZUH OSSEC Repository - www.wazuh.com',
+              'enabled'  => true,
+              'gpgcheck' => '1',
+            )
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We want to have the YUM repo available, but we don't want it enabled by default. This is so a simple `yum update` doesn't upgrade our Wazuh agent since we pin ours to a specific version.

To do this, I added a `yumrepo_enabled` parameter to the `wazuh::agent` class.

It will default to `true` to not break any current people's configuration.