### PR TITLE
Added Alma Linux deploy support

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -335,7 +335,7 @@ class wazuh::agent (
         }
       }'Amazon':{
         $apply_template_os = 'amazon'
-      }'CentOS','Centos','centos':{
+      }'CentOS','Centos','centos','AlmaLinux':{
         $apply_template_os = 'centos'
       }
       default: { fail('OS not supported') }

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -433,6 +433,11 @@ class wazuh::params_agent {
                 }
               }
             }
+            'AlmaLinux': {
+              if ( $::operatingsystemrelease =~ /^8.*/ ) {
+                $ossec_service_provider = 'redhat'
+              }
+            }
             default: { fail('This ossec module has not been tested on your distribution') }
           }
         }

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -520,6 +520,12 @@ class wazuh::params_manager {
                 }
               }
             }
+            'AlmaLinux': {
+              if ( $::operatingsystemrelease =~ /^8.*/ ) {
+                $ossec_service_provider = 'redhat'
+                $api_service_provider = 'redhat'
+              }
+            }
             default: { fail('This ossec module has not been tested on your distribution') }
           }
         }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,7 +35,7 @@ class wazuh::repo (
     }
     'Linux', 'RedHat' : {
         case $::os[name] {
-          /^(CentOS|RedHat|OracleLinux|Fedora|Amazon)$/: {
+          /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux)$/: {
             if ( $::operatingsystemrelease =~ /^5.*/ ) {
               $baseurl  = 'https://packages.wazuh.com/4.x/yum/5/'
               $gpgkey   = 'http://packages.wazuh.com/key/GPG-KEY-WAZUH'


### PR DESCRIPTION
Hi team,

This PR closes #442 

We have added support to deploy Wazuh agent into AlmaLinux systems.
Remember that some features like vulnerability detector still unsupported by now.

Tested with Puppet server Ubuntu and puppet Agent on AlmaLinux, agent installed, registered and working (Active on manager).

Regards.