### PR TITLE
Audit package name logic updated

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -337,8 +337,17 @@ class wazuh::manager (
 
 
   if ( $ossec_syscheck_whodata_directories_1 == 'yes' ) or ( $ossec_syscheck_whodata_directories_2 == 'yes' ) {
-    package { 'Installing Auditd...':
-      name   => 'auditd',
+    case $::operatingsystem {
+      'Debian', 'debian', 'Ubuntu', 'ubuntu': {
+        package { 'Installing Auditd...':
+          name => 'auditd',
+        }
+      }
+      default: {
+        package { 'Installing Auditd...':
+          name => 'audit'
+        }
+      }
     }
     service { 'auditd':
       ensure => running,

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -344,7 +344,7 @@ class wazuh::manager (
         }
       }
       default: {
-        package { 'Installing Auditd...':
+        package { 'Installing Audit...':
           name => 'audit'
         }
       }


### PR DESCRIPTION
This PR is related to #464 
> As a consequence of the whodata option for Syscheck we need the auditd package installed on Linux systems. The provisioning fails to install that required dependency.
Variable used: ossec_syscheck_whodata_directories_1 => "yes"
![161130741-2a323845-9873-4a8b-b22c-1523ea468917](https://user-images.githubusercontent.com/33964202/164106685-56a52ee5-5901-4175-8d9b-2e0e3be7f405.png)

This was tested in a local Puppet environment with an Ubuntu Bionic and Centos 7.