### PR TITLE
Syscheck variables included in _syscheck.erb

### DIFF
--- a/templates/fragments/_syscheck.erb
+++ b/templates/fragments/_syscheck.erb
@@ -12,6 +12,23 @@
   <%- if @ossec_syscheck_auto_ignore -%>
   <auto_ignore frequency="10" timeframe="3600"><%=@ossec_syscheck_auto_ignore%></auto_ignore>
   <%- end -%>
+  <%- if @ossec_syscheck_process_priority -%>
+  <process_priority><%=@ossec_syscheck_process_priority%></process_priority>
+  <%- end -%>
+  <synchronization>
+    <%- if @ossec_syscheck_synchronization_enabled -%>
+    <enabled><%= @ossec_syscheck_synchronization_enabled %></enabled>
+    <%- end -%>
+    <%- if @ossec_syscheck_synchronization_interval -%>
+    <interval><%= @ossec_syscheck_synchronization_interval %></interval>
+    <%- end -%>
+    <%- if @ossec_syscheck_synchronization_max_interval -%>
+    <max_interval><%= @ossec_syscheck_synchronization_max_interval %></max_interval>
+    <%- end -%>
+    <%- if @ossec_syscheck_synchronization_max_eps -%>
+    <max_eps><%= @ossec_syscheck_synchronization_max_eps %></max_eps>
+    <%- end -%>
+  </synchronization>
 
 <%- if @kernel == 'windows' -%>
 


### PR DESCRIPTION
This PR is related to #464
- [x] Variables have no effect. 
Deleting the following variables from `wazuh-manager.pp` doesn't change anything.
```
ossec_syscheck_process_priority
ossec_syscheck_synchronization_enabled
ossec_syscheck_synchronization_interval
ossec_syscheck_synchronization_max_eps
ossec_syscheck_synchronization_max_interval
```