### PR TITLE
VD Redhat OS logic updated

### DIFF
--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -183,7 +183,7 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_debian_update_interval = '1h'
       $vulnerability_detector_provider_redhat                    = 'yes'
       $vulnerability_detector_provider_redhat_enabled            = 'no'
-      $vulnerability_detector_provider_redhat_os                 = []
+      $vulnerability_detector_provider_redhat_os                 = ['5','6','7','8']
       $vulnerability_detector_provider_redhat_update_from_year   = '2010'
       $vulnerability_detector_provider_redhat_update_interval    = '1h'      # syslog
 

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -31,7 +31,12 @@
     <% if @vulnerability_detector_provider_redhat_enabled %><enabled><%= @vulnerability_detector_provider_redhat_enabled %></enabled><% end %>
     <% if @vulnerability_detector_provider_redhat_update_from_year %><update_from_year><%= @vulnerability_detector_provider_redhat_update_from_year %></update_from_year><% end %>
     <% if @vulnerability_detector_provider_redhat_update_interval %><update_interval><%= @vulnerability_detector_provider_redhat_update_interval %></update_interval><% end %>
-  </provider>
+    <% if !@vulnerability_detector_provider_redhat_os.empty? %>
+    <% @vulnerability_detector_provider_redhat_os.each do |os| %>
+    <os><%= os %></os>
+    <% end %>
+    <% end %>
+    </provider>
 <% end %>
 <% if @vulnerability_detector_provider_nvd %>
   <provider name="nvd">

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -36,7 +36,7 @@
     <os><%= os %></os>
     <% end %>
     <% end %>
-    </provider>
+  </provider>
 <% end %>
 <% if @vulnerability_detector_provider_nvd %>
   <provider name="nvd">


### PR DESCRIPTION
This PR is related to #465 and updates the default value for `vulnerability_detector_provider_redhat_os` and updates the logic for its usage.
