### PR TITLE
Use provided value for wazuh_enrollment_auth_pass

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -656,7 +656,7 @@ class wazuh::agent (
       owner   => 'root',
       group   => 'wazuh',
       mode    => '0640',
-      content => $wazuh::params_agent::wazuh_enrollment_auth_pass,
+      content => $wazuh_enrollment_auth_pass,
       require => Package[$wazuh::params_agent::agent_package_name],
     }
   }


### PR DESCRIPTION
Prior to this change, any value provided to this param was ignored and the auth file was never created on disk.