### PR TITLE
Repo management in dashboard class

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -85,16 +85,18 @@ class wazuh::dashboard (
 
   # TODO: Fully manage the opensearch_dashboards.yml and a template file resource
   file_line { 'Setting host for wazuh-dashboard':
-    path   => '/etc/wazuh-dashboard/opensearch_dashboards.yml',
-    line   => "server.host: ${dashboard_server_host}",
-    match  => "^server.host:\s",
-    notify => Service['wazuh-dashboard'],
+    path    => '/etc/wazuh-dashboard/opensearch_dashboards.yml',
+    line    => "server.host: ${dashboard_server_host}",
+    match   => "^server.host:\s",
+    require => Package['wazuh-dashboard'],
+    notify  => Service['wazuh-dashboard'],
   }
   file_line { 'Setting port for wazuh-dashboard':
-    path   => '/etc/wazuh-dashboard/opensearch_dashboards.yml',
-    line   => "server.port: ${dashboard_server_port}",
-    match  => "^server.port:\s",
-    notify => Service['wazuh-dashboard'],
+    path    => '/etc/wazuh-dashboard/opensearch_dashboards.yml',
+    line    => "server.port: ${dashboard_server_port}",
+    match   => "^server.port:\s",
+    require => Package['wazuh-dashboard'],
+    notify  => Service['wazuh-dashboard'],
   }
 
   service { 'wazuh-dashboard':

--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -23,8 +23,20 @@ class wazuh::dashboard (
       'user'     => 'foo',
       'password' => 'bar',
     },
-  ]
+  ],
+
+  $manage_repos = false, # Change to true when manager is not present.
 ) {
+  if $manage_repos {
+    include wazuh::repo
+
+    if $::osfamily == 'Debian' {
+      Class['wazuh::repo'] -> Class['apt::update'] -> Package['wazuh-dashboard']
+    } else {
+      Class['wazuh::repo'] -> Package['wazuh-dashboard']
+    }
+  }
+
   # assign version according to the package manager
   case $facts['os']['family'] {
     'Debian': {


### PR DESCRIPTION
When the Wazuh dashboard is not installed on the same machine as the Wazuh manager or indexer, the Wazuh repository is not configured.

This PR adds a parameter in Wazuh dashboard class to manage the repos as in the Wazuh indexer class.

This PR also fixes the dependencies between the resources in the Wazuh dashboard class to make it possible.

Resolves #528

Tested on a Debian 10 machine.