### PR TITLE
Parameters for logall and logall_json options

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -13,6 +13,8 @@ class wazuh::manager (
 
       ## Global
 
+      $ossec_logall                     = $wazuh::params_manager::ossec_logall,
+      $ossec_logall_json                = $wazuh::params_manager::ossec_logall_json,
       $ossec_emailnotification          = $wazuh::params_manager::ossec_emailnotification,
       $ossec_emailto                    = $wazuh::params_manager::ossec_emailto,
       $ossec_smtp_server                = $wazuh::params_manager::ossec_smtp_server,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -13,6 +13,8 @@ class wazuh::params_manager {
     ### Ossec.conf blocks
 
       ## Global
+      $ossec_logall                                    = 'no'
+      $ossec_logall_json                               = 'no'
       $ossec_emailnotification                         = false
       $ossec_emailto                                   = ['recipient@example.wazuh.com']
       $ossec_smtp_server                               = 'smtp.example.wazuh.com'

--- a/templates/wazuh_manager.conf.erb
+++ b/templates/wazuh_manager.conf.erb
@@ -1,8 +1,8 @@
   <global>
     <jsonout_output>yes</jsonout_output>
     <alerts_log>yes</alerts_log>
-    <logall>no</logall>
-    <logall_json>no</logall_json>
+    <logall><%= @ossec_logall %></logall>
+    <logall_json><%= @ossec_logall_json %></logall_json>
     <agents_disconnection_time>10m</agents_disconnection_time>
     <agents_disconnection_alert_time>0</agents_disconnection_alert_time>
   <%- if @ossec_emailnotification -%>


### PR DESCRIPTION
This PR allows the user of the module to set `logall` and `logall_json` options in the Wazuh manager configuration.

Tested on a Debian 10 machine with Puppet version 6.27.0.

Closes #532 