### PR TITLE
Dashboard configuration

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -83,18 +83,11 @@ class wazuh::dashboard (
     }
   }
 
-  # TODO: Fully manage the opensearch_dashboards.yml and a template file resource
-  file_line { 'Setting host for wazuh-dashboard':
-    path    => '/etc/wazuh-dashboard/opensearch_dashboards.yml',
-    line    => "server.host: ${dashboard_server_host}",
-    match   => "^server.host:\s",
-    require => Package['wazuh-dashboard'],
-    notify  => Service['wazuh-dashboard'],
-  }
-  file_line { 'Setting port for wazuh-dashboard':
-    path    => '/etc/wazuh-dashboard/opensearch_dashboards.yml',
-    line    => "server.port: ${dashboard_server_port}",
-    match   => "^server.port:\s",
+  file { '/etc/wazuh-dashboard/opensearch_dashboards.yml':
+    content => template('wazuh/wazuh_dashboard_yml.erb'),
+    group   => $dashboard_filegroup,
+    mode    => '0640',
+    owner   => $dashboard_fileuser,
     require => Package['wazuh-dashboard'],
     notify  => Service['wazuh-dashboard'],
   }

--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -92,6 +92,21 @@ class wazuh::dashboard (
     notify  => Service['wazuh-dashboard'],
   }
 
+  file { [ '/usr/share/wazuh-dashboard/data/wazuh/', '/usr/share/wazuh-dashboard/data/wazuh/config' ]:
+    ensure  => 'directory',
+    group   => $dashboard_filegroup,
+    mode    => '0755',
+    owner   => $dashboard_fileuser,
+    require => Package['wazuh-dashboard'],
+  }
+  -> file { '/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml':
+    content => template('wazuh/wazuh_yml.erb'),
+    group   => $dashboard_filegroup,
+    mode    => '0600',
+    owner   => $dashboard_fileuser,
+    notify  => Service['wazuh-dashboard'],
+  }
+
   service { 'wazuh-dashboard':
     ensure     => running,
     enable     => true,

--- a/templates/wazuh_dashboard_yml.erb
+++ b/templates/wazuh_dashboard_yml.erb
@@ -1,0 +1,17 @@
+server.host: <%= @dashboard_server_host %>
+server.port: <%= @dashboard_server_port %>
+opensearch.hosts: <%= @dashboard_server_hosts %>
+opensearch.ssl.verificationMode: certificate
+<% if @dashboard_user and @dashboard_password -%>
+opensearch.username: <%= @dashboard_user %>
+opensearch.password: <%= @dashboard_password %>
+<% end -%>
+opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
+opensearch_security.multitenancy.enabled: false
+opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+server.ssl.enabled: true
+server.ssl.key: "<%= @dashboard_path_certs %>/dashboard-key.pem"
+server.ssl.certificate: "<%= @dashboard_path_certs %>/dashboard.pem"
+opensearch.ssl.certificateAuthorities: ["<%= @dashboard_path_certs %>/root-ca.pem"]
+uiSettings.overrides.defaultRoute: /app/wazuh
+

--- a/templates/wazuh_yml.erb
+++ b/templates/wazuh_yml.erb
@@ -124,7 +124,7 @@
 #     user: <user>
 #     password: <password>
 hosts:
-<% @kibana_wazuh_api_credentials.each do |api_profile| -%>
+<% @dashboard_wazuh_api_credentials.each do |api_profile| -%>
   - <%= api_profile['id'] %>:
       url: <%= api_profile['url'] %>
       port: <%= api_profile['port'] %>


### PR DESCRIPTION
This PR allows the user to configure the Wazuh dashboard with class parameters.

The files `/etc/wazuh-dashboard/opensearch_dashboards.yml` and `/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml` are modified accordingly.

Tested on Debian 10 machine with Puppet version 6.27.0

Closes #534 