### PR TITLE
Ability to use custom certificates

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -31,6 +31,7 @@ class wazuh::dashboard (
     },
   ],
 
+  $manage_certs = true,
   $use_system_ca = false,
 ) {
 
@@ -50,32 +51,34 @@ class wazuh::dashboard (
     name   => $dashboard_package,
   }
 
-  exec { "ensure full path of ${dashboard_path_certs}":
-    path    => '/usr/bin:/bin',
-    command => "mkdir -p ${dashboard_path_certs}",
-    creates => $dashboard_path_certs,
-    require => Package['wazuh-dashboard'],
-  }
-  -> file { $dashboard_path_certs:
-    ensure => directory,
-    owner  => $dashboard_fileuser,
-    group  => $dashboard_filegroup,
-    mode   => '0500',
-  }
+  if $manage_certs {
+    exec { "ensure full path of ${dashboard_path_certs}":
+      path    => '/usr/bin:/bin',
+      command => "mkdir -p ${dashboard_path_certs}",
+      creates => $dashboard_path_certs,
+      require => Package['wazuh-dashboard'],
+    }
+    -> file { $dashboard_path_certs:
+      ensure => directory,
+      owner  => $dashboard_fileuser,
+      group  => $dashboard_filegroup,
+      mode   => '0500',
+    }
 
-  [
-    'dashboard.pem',
-    'dashboard-key.pem',
-    'root-ca.pem',
-  ].each |String $certfile| {
-    file { "${dashboard_path_certs}/${certfile}":
-      ensure  => file,
-      owner   => $dashboard_fileuser,
-      group   => $dashboard_filegroup,
-      mode    => '0400',
-      replace => true,
-      recurse => remote,
-      source  => "puppet:///modules/archive/${certfile}",
+    [
+      'dashboard.pem',
+      'dashboard-key.pem',
+      'root-ca.pem',
+    ].each |String $certfile| {
+      file { "${dashboard_path_certs}/${certfile}":
+        ensure  => file,
+        owner   => $dashboard_fileuser,
+        group   => $dashboard_filegroup,
+        mode    => '0400',
+        replace => true,
+        recurse => remote,
+        source  => "puppet:///modules/archive/${certfile}",
+      }
     }
   }
 

--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -31,6 +31,7 @@ class wazuh::dashboard (
     },
   ],
 
+  $use_system_ca = false,
 ) {
 
   # assign version according to the package manager

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -19,6 +19,8 @@ class wazuh::filebeat_oss (
   $filebeat_fileuser = 'root',
   $filebeat_filegroup = 'root',
   $filebeat_path_certs = '/etc/filebeat/certs',
+
+  $use_system_ca = false,
 ) {
 
   package { 'filebeat':

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -23,6 +23,7 @@ class wazuh::indexer (
   $indexer_discovery_hosts = [], # Empty array for single-node configuration
   $indexer_cluster_initial_master_nodes = ['node-1'],
   $indexer_cluster_CN = ['node-1'],
+  $manage_certs = true,
 
   # JVM options
   $jvm_options_memory = '1g',
@@ -44,38 +45,38 @@ class wazuh::indexer (
     name   => $indexer_package,
   }
 
-  exec { "ensure full path of ${indexer_path_certs}":
-    path    => '/usr/bin:/bin',
-    command => "mkdir -p ${indexer_path_certs}",
-    creates => $indexer_path_certs,
-    require => Package['wazuh-indexer'],
-  }
-  -> file { $indexer_path_certs:
-    ensure => directory,
-    owner  => $indexer_fileuser,
-    group  => $indexer_filegroup,
-    mode   => '0500',
-  }
+  if $manage_certs {
+    exec { "ensure full path of ${indexer_path_certs}":
+      path    => '/usr/bin:/bin',
+      command => "mkdir -p ${indexer_path_certs}",
+      creates => $indexer_path_certs,
+      require => Package['wazuh-indexer'],
+    }
+    -> file { $indexer_path_certs:
+      ensure => directory,
+      owner  => $indexer_fileuser,
+      group  => $indexer_filegroup,
+      mode   => '0500',
+    }
 
-  [
-   "indexer-$indexer_node_name.pem",
-   "indexer-$indexer_node_name-key.pem",
-   'root-ca.pem',
-   'admin.pem',
-   'admin-key.pem',
-  ].each |String $certfile| {
-    file { "${indexer_path_certs}/${certfile}":
-      ensure  => file,
-      owner   => $indexer_fileuser,
-      group   => $indexer_filegroup,
-      mode    => '0400',
-      replace => true,
-      recurse => remote,
-      source  => "puppet:///modules/archive/${certfile}",
+    [
+     "indexer-$indexer_node_name.pem",
+     "indexer-$indexer_node_name-key.pem",
+     'root-ca.pem',
+     'admin.pem',
+     'admin-key.pem',
+    ].each |String $certfile| {
+      file { "${indexer_path_certs}/${certfile}":
+        ensure  => file,
+        owner   => $indexer_fileuser,
+        group   => $indexer_filegroup,
+        mode    => '0400',
+        replace => true,
+        recurse => remote,
+        source  => "puppet:///modules/archive/${certfile}",
+      }
     }
   }
-
-
 
   file { 'configuration file':
     path    => '/etc/wazuh-indexer/opensearch.yml',

--- a/templates/filebeat_oss_yml.erb
+++ b/templates/filebeat_oss_yml.erb
@@ -17,8 +17,10 @@ output.elasticsearch:
   username: <%= @filebeat_oss_elastic_user %>
   password: <%= @filebeat_oss_elastic_password %>
   protocol: https
+<% if not @use_system_ca -%>
   ssl.certificate_authorities:
     - /etc/filebeat/certs/root-ca.pem
+<% end -%>
   ssl.certificate: "/etc/filebeat/certs/filebeat.pem"
   ssl.key: "/etc/filebeat/certs/filebeat-key.pem"
 

--- a/templates/wazuh_dashboard_yml.erb
+++ b/templates/wazuh_dashboard_yml.erb
@@ -12,5 +12,7 @@ opensearch_security.readonly_mode.roles: ["kibana_read_only"]
 server.ssl.enabled: true
 server.ssl.key: "<%= @dashboard_path_certs %>/dashboard-key.pem"
 server.ssl.certificate: "<%= @dashboard_path_certs %>/dashboard.pem"
+<% if not @use_system_ca -%>
 opensearch.ssl.certificateAuthorities: ["<%= @dashboard_path_certs %>/root-ca.pem"]
+<% end -%>
 uiSettings.overrides.defaultRoute: /app/wz-home

--- a/templates/wazuh_indexer_yml.erb
+++ b/templates/wazuh_indexer_yml.erb
@@ -30,6 +30,11 @@ plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
 <% @indexer_cluster_CN.each do |cn| -%>
 - "CN=indexer-<%= cn %>,OU=Wazuh,O=Wazuh,L=California,C=US"
+<% if @manage_certs -%>
+- "CN=indexer-<%= cn %>,OU=Wazuh,O=Wazuh,L=California,C=US"
+<% else -%>
+- "CN=<%= cn %>"
+<% end -%>
 <% end -%>
 plugins.security.restapi.roles_enabled:
 - "all_access"


### PR DESCRIPTION
This PR allows the user to use custom certificates signed by other CA than the one created in the wazuh::certificates class.

- Add an option to manage or not the certificates.
- Add an option to configure the dashboard and filebeat with system default CA.

Closes #538 
~~Depends on #537~~
~~Depends on #531~~