### PR TITLE
Permission for filebeat.yml with credentials in it

### DIFF
--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -34,7 +34,7 @@ class wazuh::filebeat_oss (
   file { '/etc/filebeat/filebeat.yml':
     owner   => 'root',
     group   => 'root',
-    mode    => '0644',
+    mode    => '0640',
     notify  => Service['filebeat'], ## Restarts the service
     content => template('wazuh/filebeat_oss_yml.erb'),
     require => Package['filebeat'],


### PR DESCRIPTION
As the credentials for filebeat are stored in the config file and not the keystore, it should be better to at least hide them from non privileged users.

This PR removes read permission for other users to the filebeat.yml config file.

Fixes #540 