### PR TITLE
Archive Filebeat module

### DIFF
--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -58,18 +58,15 @@ class wazuh::filebeat_oss (
     require => Package['filebeat'],
   }
 
-  # TODO: use archive from puppet-archive module for this task
-  file { "/tmp/${$wazuh_filebeat_module}":
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0440',
-    source => "https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
-  }
-  ~> exec { "Unpackaging /tmp/${$wazuh_filebeat_module}":
-    command     => "/bin/tar -xzvf /tmp/${$wazuh_filebeat_module} -C /usr/share/filebeat/module",
-    notify      => Service['filebeat'],
-    require     => Package['filebeat'],
-    refreshonly => true,
+  archive { "/tmp/${$wazuh_filebeat_module}":
+    ensure       => present,
+    source       => "https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
+    extract      => true,
+    extract_path => '/usr/share/filebeat/module',
+    creates      => '/usr/share/filebeat/module/wazuh',
+    cleanup      => true,
+    notify       => Service['filebeat'],
+    require      => Package['filebeat'],
   }
 
   file { '/usr/share/filebeat/module/wazuh':

--- a/metadata.json
+++ b/metadata.json
@@ -35,6 +35,10 @@
     {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 2.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppet/archive",
+      "version_requirement": ">= 0.4.8 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Fixes #544 .

This PR makes the wazuh::oss_filebeat class use the archive resource to manage the Wazuh Filebeat module.

I'm not sure how to write the dependency for the Puppet archive module.
Also not sure about the version compatibility.

Tested with Puppet 6.27.0 with archive module version 3.0.0 on Debian 10 machines.