### PR TITLE
JVM option memory

### DIFF
--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -26,7 +26,7 @@ class wazuh::indexer (
   $manage_repos = false, # Change to true when manager is not present.
 
   # JVM options
-  $jvm_options_memmory = '1g',
+  $jvm_options_memory = '1g',
 ) {
   if $manage_repos {
     include wazuh::repo
@@ -77,7 +77,7 @@ class wazuh::indexer (
 
   file_line { 'Insert line initial size of total heap space':
     path    => '/etc/wazuh-indexer/jvm.options',
-    line    => "-Xms${jvm_options_memmory}",
+    line    => "-Xms${jvm_options_memory}",
     match   => '^-Xms',
     require => Package['wazuh-indexer'],
     notify  => Service['wazuh-indexer'],
@@ -85,7 +85,7 @@ class wazuh::indexer (
 
   file_line { 'Insert line maximum size of total heap space':
     path    => '/etc/wazuh-indexer/jvm.options',
-    line    => "-Xmx${jvm_options_memmory}",
+    line    => "-Xmx${jvm_options_memory}",
     match   => '^-Xmx',
     require => Package['wazuh-indexer'],
     notify  => Service['wazuh-indexer'],

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -75,6 +75,22 @@ class wazuh::indexer (
     }
   }
 
+  file_line { 'Insert line initial size of total heap space':
+    path    => '/etc/wazuh-indexer/jvm.options',
+    line    => "-Xms${jvm_options_memmory}",
+    match   => '^-Xms',
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
+  file_line { 'Insert line maximum size of total heap space':
+    path    => '/etc/wazuh-indexer/jvm.options',
+    line    => "-Xmx${jvm_options_memmory}",
+    match   => '^-Xmx',
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
   service { 'wazuh-indexer':
     ensure  => running,
     enable  => true,


### PR DESCRIPTION
Fixes #546 .

This PR use file_lines resources to change the -Xms and -Xmx values in the `jvm.options` files.

Before, the parameter jvm_options_memmory in wazuh::indexer class had no effect to the JVM.

Tested with Puppet 6.27.0 on a Debian 10 machine.