### PR TITLE
Filebeat archives parameter

### DIFF
--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -5,6 +5,7 @@ class wazuh::filebeat_oss (
   $filebeat_oss_indexer_port = '9200',
   $indexer_server_ip = "\"${filebeat_oss_indexer_ip}:${filebeat_oss_indexer_port}\"",
 
+  $filebeat_oss_archives = false,
   $filebeat_oss_package = 'filebeat',
   $filebeat_oss_service = 'filebeat',
   $filebeat_oss_elastic_user = 'admin',

--- a/templates/filebeat_oss_yml.erb
+++ b/templates/filebeat_oss_yml.erb
@@ -4,7 +4,7 @@ filebeat.modules:
     alerts:
       enabled: true
     archives:
-      enabled: false
+      enabled: <%= @filebeat_oss_archives %>
 
 setup.template.json.enabled: true
 setup.template.json.path: "/etc/filebeat/wazuh-template.json"


### PR DESCRIPTION
This PR adds the possibility to enable the collection of archives in the Filebeat configuration.

Fixes #548 

Tested with Puppet 6.27.0 on a Debian 10 machine.