### PR TITLE
Add unless for exec that import elastic rpm key

### DIFF
--- a/manifests/repo_elastic_oss.pp
+++ b/manifests/repo_elastic_oss.pp
@@ -50,8 +50,9 @@ class wazuh::repo_elastic_oss (
         # Import GPG key
 
         exec { 'Install Elasticsearch GPG key':
-          path    => '/usr/bin',
+          path    => ['/bin', '/usr/bin'],
           command => 'rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch',
+          unless  => 'test $(rpm -qa gpg-pubkey | grep -i "D88E42B4" | wc -l) -eq 1',
         }
 
         # Adding repo by Puppet yumrepo resource


### PR DESCRIPTION
### Pull Request (PR) description
> https://puppet.com/docs/puppet/7/types/exec.html#exec-description
> 
> exec resource
> 
> Any command in an exec resource must be able to run multiple times without causing harm --- that is, it must be idempotent.

That is why this PR fixes a missing exec conditions for the rpm key import for RedHat based systems. This fixes the continuously import of the key.

### This Pull Request (PR) fixes the following issues
None