### PR TITLE
Change order for active response concat

### DIFF
--- a/manifests/activeresponse.pp
+++ b/manifests/activeresponse.pp
@@ -13,7 +13,7 @@ define wazuh::activeresponse(
   $active_response_timeout            = undef,
   $active_response_repeated_offenders = [],
   $target_arg                         = 'manager_ossec.conf',
-  $order_arg                          = undef,
+  $order_arg                          = 80,
   $before_arg                         = undef,
   $content_arg                        = 'wazuh/fragments/_activeresponse.erb'
 ) {


### PR DESCRIPTION
This PR fixes an error when trying to deploy Wazuh Manager and configure an active response with a command, causing an error because the deploy first concat the active response and then the command