### PR TITLE
Fix puppetserver messages about unkown variables

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -145,6 +145,13 @@ class wazuh::params_agent {
   $sca_rhel_skip_nfs = 'yes'
   $sca_rhel_policies = []
 
+  ## Windows
+  $sca_windows_enabled = 'yes'
+  $sca_windows_scan_on_start = 'yes'
+  $sca_windows_interval = '12h'
+  $sca_windows_skip_nfs = 'yes'
+  $sca_windows_policies = []
+
   ## <else>
   $sca_else_enabled = 'yes'
   $sca_else_scan_on_start = 'yes'
@@ -213,6 +220,7 @@ class wazuh::params_agent {
     '-f 1'
   ]
 
+  $windows_audit_interval = 300
 
   # active-response
   $active_response_linux_ca_store = '/var/ossec/etc/wpk_root.pem'
@@ -250,8 +258,8 @@ class wazuh::params_agent {
 
       # Wodles
 
-      ## doker-listener
-      $wodle_doker_listener_disabled = 'yes'
+      ## docker-listener
+      $wodle_docker_listener_disabled = 'yes'
 
       ## cis-cat
       $wodle_ciscat_disabled = 'yes'
@@ -474,14 +482,6 @@ class wazuh::params_agent {
       $service_has_status = true
       $ossec_service_provider = undef
 
-      # sca
-      $sca_windows_enabled = 'yes'
-      $sca_windows_scan_on_start = 'yes'
-      $sca_windows_interval = '12h'
-      $sca_windows_skip_nfs = 'yes'
-      $sca_windows_policies = []
-
-
       # Wodles
 
       ## syscollector
@@ -540,7 +540,6 @@ and EventID != 5152 and EventID != 5157]'
           'log_format' => 'syslog'
         },
       ]
-      $windows_audit_interval = 300
     }
     default: { fail('This ossec module has not been tested on your distribution') }
   }


### PR DESCRIPTION
### Pull Request (PR) description
As described in #554 the puppetserver warns about multiple variables that can not be found.

This PR fixes the reported messages by
 - fixing a typo of `wodle_docker_listener_disabled`
 - moving multiples variables to right global space inside the `params_agent.pp`

### This Pull Request (PR) fixes the following issues
Closes #554 