### PR TITLE
Default dashboard listening port

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -12,7 +12,7 @@ class wazuh::dashboard (
   $dashboard_fileuser = 'wazuh-dashboard',
   $dashboard_filegroup = 'wazuh-dashboard',
 
-  $dashboard_server_port = '5601',
+  $dashboard_server_port = '443',
   $dashboard_server_host = '0.0.0.0',
   $dashboard_server_hosts = "https://${indexer_server_ip}:${indexer_server_port}",
   $dashboard_wazuh_api_credentials = [


### PR DESCRIPTION
This PR replace the default Wazuh Dashboard listening port with 443, as it is in Wazuh documentation :
@see https://documentation.wazuh.com/4.3/installation-guide/wazuh-dashboard/step-by-step.html
@see https://documentation.wazuh.com/4.3/getting-started/architecture.html#required-ports

Closes #564 