### PR TITLE
Use https in default server API URL parameter

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -18,7 +18,7 @@ class wazuh::dashboard (
   $dashboard_wazuh_api_credentials = [
     {
       'id'       => 'default',
-      'url'      => 'http://localhost',
+      'url'      => 'https://localhost',
       'port'     => '55000',
       'user'     => 'foo',
       'password' => 'bar',


### PR DESCRIPTION
Closes #568 

@see https://documentation.wazuh.com/4.3/installation-guide/wazuh-dashboard/step-by-step.html#starting-the-wazuh-dashboard-service