### PR TITLE
Make syscheck file_limit configurable

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -211,6 +211,8 @@ class wazuh::agent (
   $ossec_syscheck_ignore_type_2      = $wazuh::params_agent::ossec_syscheck_ignore_type_2,
   $ossec_syscheck_max_eps                      = $wazuh::params_agent::ossec_syscheck_max_eps,
   $ossec_syscheck_process_priority             = $wazuh::params_agent::ossec_syscheck_process_priority,
+  Wazuh::Enabled $ossec_syscheck_filelimit_enabled = $wazuh::params_agent::ossec_syscheck_filelimit_enabled,
+  Integer        $ossec_syscheck_filelimit_entries = $wazuh::params_agent::ossec_syscheck_filelimit_entries,
   $ossec_syscheck_synchronization_enabled      = $wazuh::params_agent::ossec_syscheck_synchronization_enabled,
   $ossec_syscheck_synchronization_interval     = $wazuh::params_agent::ossec_syscheck_synchronization_interval,
   $ossec_syscheck_synchronization_max_eps      = $wazuh::params_agent::ossec_syscheck_synchronization_max_eps,

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -240,6 +240,8 @@ class wazuh::manager (
       $ossec_syscheck_ignore_type_1         = $wazuh::params_manager::ossec_syscheck_ignore_type_1,
       $ossec_syscheck_ignore_type_2         = $wazuh::params_manager::ossec_syscheck_ignore_type_2,
       $ossec_syscheck_process_priority             = $wazuh::params_manager::ossec_syscheck_process_priority,
+      Wazuh::Enabled $ossec_syscheck_filelimit_enabled = $wazuh::params_agent::ossec_syscheck_filelimit_enabled,
+      Integer        $ossec_syscheck_filelimit_entries = $wazuh::params_agent::ossec_syscheck_filelimit_entries,
       $ossec_syscheck_synchronization_enabled      = $wazuh::params_manager::ossec_syscheck_synchronization_enabled,
       $ossec_syscheck_synchronization_interval     = $wazuh::params_manager::ossec_syscheck_synchronization_interval,
       $ossec_syscheck_synchronization_max_eps      = $wazuh::params_manager::ossec_syscheck_synchronization_max_eps,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -195,6 +195,10 @@ class wazuh::params_agent {
 
   $ossec_syscheck_max_eps = '100'
   $ossec_syscheck_process_priority = '10'
+
+  $ossec_syscheck_filelimit_enabled = 'yes'
+  $ossec_syscheck_filelimit_entries = '100000'
+
   $ossec_syscheck_synchronization_enabled = 'yes'
   $ossec_syscheck_synchronization_interval = '5m'
   $ossec_syscheck_synchronization_max_eps = '10'

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -267,6 +267,10 @@ class wazuh::params_manager {
 
       $ossec_syscheck_max_eps = '100'
       $ossec_syscheck_process_priority = '10'
+
+      $ossec_syscheck_filelimit_enabled = 'yes'
+      $ossec_syscheck_filelimit_entries = '100000'
+
       $ossec_syscheck_synchronization_enabled = 'yes'
       $ossec_syscheck_synchronization_interval = '5m'
       $ossec_syscheck_synchronization_max_eps = '10'

--- a/templates/fragments/_syscheck.erb
+++ b/templates/fragments/_syscheck.erb
@@ -15,6 +15,12 @@
   <%- if @ossec_syscheck_process_priority -%>
   <process_priority><%=@ossec_syscheck_process_priority%></process_priority>
   <%- end -%>
+  <file_limit>
+    <%- if @ossec_syscheck_filelimit_enabled -%>
+    <enabled><%= @ossec_syscheck_filelimit_enabled %></enabled>
+    <%- end -%>
+    <entries><%= @ossec_syscheck_filelimit_entries %></entries>
+  </file_limit>
   <synchronization>
     <%- if @ossec_syscheck_synchronization_enabled -%>
     <enabled><%= @ossec_syscheck_synchronization_enabled %></enabled>

--- a/types/enabled.pp
+++ b/types/enabled.pp
@@ -1,2 +1,2 @@
-# Type for allowed values when enabling Wazuh options
+# Type for allowed values when enabling/disabling Wazuh options
 type Wazuh::Enabled = Enum['yes', 'no']

--- a/types/enabled.pp
+++ b/types/enabled.pp
@@ -1,0 +1,2 @@
+# Type for allowed values when enabling Wazuh options
+type Wazuh::Enabled = Enum['yes', 'no']


### PR DESCRIPTION
We sometimes reach the limit of files scanned. So it would be nice if it could be made configurable by merging this PR.