### PR TITLE
A validation was added for the case of a full reinstall of Wazuh indexer

### DIFF
--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -136,10 +136,10 @@ class wazuh::indexer (
   }
 
   if $full_indexer_reinstall {
-    exec { "Clean security init lockfile":
-      path    => '/usr/bin:/bin',
-      command => "rm -f ${indexer_security_init_lockfile}",
+    file { $indexer_security_init_lockfile:
+      ensure  => absent,
       require => Package['wazuh-indexer'],
+      before  => Exec['Initialize the Opensearch security index in Wazuh indexer'],
     }
   }
 

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -15,6 +15,7 @@ class wazuh::indexer (
   $indexer_path_logs = '/var/log/wazuh-indexer',
   $indexer_path_certs = '/etc/wazuh-indexer/certs',
   $indexer_security_init_lockfile = '/var/tmp/indexer-security-init.lock',
+  $full_indexer_reinstall = false, # Change to true when whant a full reinstall of Wazuh indexer
 
   $indexer_ip = 'localhost',
   $indexer_port = '9200',
@@ -125,12 +126,20 @@ class wazuh::indexer (
     '/usr/share/wazuh-indexer',
     '/var/lib/wazuh-indexer',
   ].each |String $file| {
-    exec { "set ecusive ownership of ${file}":
+    exec { "set recusive ownership of ${file}":
       path        => '/usr/bin:/bin',
       command     => "chown ${indexer_fileuser}:${indexer_filegroup} -R ${file}",
       refreshonly => true,  # only run when package is installed or updated
       subscribe   => Package['wazuh-indexer'],
       notify      => Service['wazuh-indexer'],
+    }
+  }
+
+  if $full_indexer_reinstall {
+    exec { "Clean security init lockfile":
+      path    => '/usr/bin:/bin',
+      command => "rm -f ${indexer_security_init_lockfile}",
+      require => Package['wazuh-indexer'],
     }
   }
 


### PR DESCRIPTION
I've added a variable to handle the case where you want to do a full reinstall of Wazuh indexer, and this will omit the existence of the /var/tmp/indexer-security-init.lock file.

With this, the user can choose if he wants to perform a complete reinstall, or if the case proposed in this issue https://github.com/wazuh/wazuh-puppet/issues/574 is going to be considered

Tests:
variable in false:
```
root@ubuntu-focal-2:~# systemctl status wazuh-indexer
● wazuh-indexer.service - Wazuh-indexer
     Loaded: loaded (/lib/systemd/system/wazuh-indexer.service; enabled; vendor preset: enabled)
     Active: active (running) since Wed 2022-11-02 15:52:33 UTC; 26min ago
       Docs: https://documentation.wazuh.com
   Main PID: 9105 (java)
      Tasks: 55 (limit: 5930)
     Memory: 1.3G
     CGroup: /system.slice/wazuh-indexer.service
             └─9105 /usr/share/wazuh-indexer/jdk/bin/java -Xshare:auto -Dopensearch.networkaddress.cache.ttl=60 -Dopensearch.networkaddress.cache.negative.ttl=10 -XX:+AlwaysPreTouch -Xss1m -Djava.awt.headless=true -Dfile.encoding=UTF-8 >

Nov 02 15:52:25 ubuntu-focal-2 systemd[1]: Starting Wazuh-indexer...
Nov 02 15:52:32 ubuntu-focal-2 systemd-entrypoint[9105]: WARNING: An illegal reflective access operation has occurred
Nov 02 15:52:32 ubuntu-focal-2 systemd-entrypoint[9105]: WARNING: Illegal reflective access by io.protostuff.runtime.PolymorphicThrowableSchema (file:/usr/share/wazuh-indexer/plugins/opensearch-anomaly-detection/protostuff-runtime-1.7.4>
Nov 02 15:52:32 ubuntu-focal-2 systemd-entrypoint[9105]: WARNING: Please consider reporting this to the maintainers of io.protostuff.runtime.PolymorphicThrowableSchema
Nov 02 15:52:32 ubuntu-focal-2 systemd-entrypoint[9105]: WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
Nov 02 15:52:32 ubuntu-focal-2 systemd-entrypoint[9105]: WARNING: All illegal access operations will be denied in a future release
Nov 02 15:52:33 ubuntu-focal-2 systemd[1]: Started Wazuh-indexer.

root@ubuntu-focal-2:~# curl -k -u admin:admin https://localhost:9200
OpenSearch Security not initialized.
```

Variable in true:
```
Info: /Stage[main]/Wazuh::Indexer/File[configuration file]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[set ecusive ownership of /etc/wazuh-indexer]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Wazuh::Indexer/Exec[set ecusive ownership of /etc/wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[set ecusive ownership of /usr/share/wazuh-indexer]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Wazuh::Indexer/Exec[set ecusive ownership of /usr/share/wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[set ecusive ownership of /var/lib/wazuh-indexer]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Wazuh::Indexer/Exec[set ecusive ownership of /var/lib/wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]/ensure: ensure changed 'stopped' to 'running' (corrective)
Info: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]: Unscheduling refresh on Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[Clean security init lockfile]/returns: executed successfully
Notice: /Stage[main]/Wazuh::Indexer/Exec[Initialize the Opensearch security index in Wazuh indexer]/returns: executed successfully (corrective)
Notice: Applied catalog in 42.22 seconds
root@ubuntu-focal-2:~# ls -la /var/tmp/indexer-security-init.lock 
-rw-r--r-- 1 root root 0 Nov  2 16:31 /var/tmp/indexer-security-init.lock
root@ubuntu-focal-2:~# curl -k -u admin:admin https://localhost:9200
{
  "name" : "node-1",
  "cluster_name" : "wazuh-cluster",
  "cluster_uuid" : "iAXkb2b3TsKcsta2cXeD2g",
  "version" : {
    "number" : "7.10.2",
    "build_type" : "rpm",
    "build_hash" : "e505b10357c03ae8d26d675172402f2f2144ef0f",
    "build_date" : "2022-01-14T03:38:06.881862Z",
    "build_snapshot" : false,
    "lucene_version" : "8.10.1",
    "minimum_wire_compatibility_version" : "6.8.0",
    "minimum_index_compatibility_version" : "6.0.0-beta1"
  },
  "tagline" : "The OpenSearch Project: https://opensearch.org/"
}
```