### PR TITLE
Make syscheck file_limit configurable

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -214,6 +214,8 @@ class wazuh::agent (
   $ossec_syscheck_synchronization_interval     = $wazuh::params_agent::ossec_syscheck_synchronization_interval,
   $ossec_syscheck_synchronization_max_eps      = $wazuh::params_agent::ossec_syscheck_synchronization_max_eps,
   $ossec_syscheck_synchronization_max_interval = $wazuh::params_agent::ossec_syscheck_synchronization_max_interval,
+  Wazuh::Enabled $ossec_syscheck_filelimit_enabled = $wazuh::params_agent::ossec_syscheck_filelimit_enabled,
+  Integer        $ossec_syscheck_filelimit_entries = $wazuh::params_agent::ossec_syscheck_filelimit_entries,
   $ossec_syscheck_nodiff             = $wazuh::params_agent::ossec_syscheck_nodiff,
   $ossec_syscheck_skip_nfs           = $wazuh::params_agent::ossec_syscheck_skip_nfs,
   $ossec_syscheck_windows_audit_interval      = $wazuh::params_agent::windows_audit_interval,

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -229,6 +229,8 @@ class wazuh::manager (
       $ossec_syscheck_synchronization_interval     = $wazuh::params_manager::ossec_syscheck_synchronization_interval,
       $ossec_syscheck_synchronization_max_eps      = $wazuh::params_manager::ossec_syscheck_synchronization_max_eps,
       $ossec_syscheck_synchronization_max_interval = $wazuh::params_manager::ossec_syscheck_synchronization_max_interval,
+      Wazuh::Enabled $ossec_syscheck_filelimit_enabled = $wazuh::params_agent::ossec_syscheck_filelimit_enabled,
+      Integer        $ossec_syscheck_filelimit_entries = $wazuh::params_agent::ossec_syscheck_filelimit_entries,
 
       $ossec_syscheck_nodiff                = $wazuh::params_manager::ossec_syscheck_nodiff,
       $ossec_syscheck_skip_nfs              = $wazuh::params_manager::ossec_syscheck_skip_nfs,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -208,6 +208,9 @@ class wazuh::params_agent {
   $ossec_syscheck_synchronization_max_eps = '10'
   $ossec_syscheck_synchronization_max_interval = '1h'
 
+  $ossec_syscheck_filelimit_enabled = 'yes'
+  $ossec_syscheck_filelimit_entries = '100000'
+
   $ossec_syscheck_nodiff = '/etc/ssl/private.key'
   $ossec_syscheck_skip_nfs = 'yes'
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -255,6 +255,9 @@ class wazuh::params_manager {
       $ossec_syscheck_synchronization_max_eps = '10'
       $ossec_syscheck_synchronization_max_interval = '1h'
 
+      $ossec_syscheck_filelimit_enabled = 'yes'
+      $ossec_syscheck_filelimit_entries = '100000'
+
       $ossec_syscheck_nodiff                           = '/etc/ssl/private.key'
       $ossec_syscheck_skip_nfs                         = 'yes'
 

--- a/templates/fragments/_syscheck.erb
+++ b/templates/fragments/_syscheck.erb
@@ -12,6 +12,12 @@
   <%- if @ossec_syscheck_auto_ignore -%>
   <auto_ignore frequency="10" timeframe="3600"><%=@ossec_syscheck_auto_ignore%></auto_ignore>
   <%- end -%>
+  <file_limit>
+    <%- if @ossec_syscheck_filelimit_enabled -%>
+    <enabled><%= @ossec_syscheck_filelimit_enabled %></enabled>
+    <%- end -%>
+    <entries><%= @ossec_syscheck_filelimit_entries %></entries>
+  </file_limit>
 
 <%- if @kernel == 'windows' -%>
 

--- a/types/enabled.pp
+++ b/types/enabled.pp
@@ -1,0 +1,2 @@
+# Type for allowed values when enabling/disabling Wazuh options
+type Wazuh::Enabled = Enum['yes', 'no']


### PR DESCRIPTION
We sometimes reach the limit of files scanned. So it would be nice if it could be made configurable by merging this PR.