### PR TITLE
Add option for distributed deploy

### DIFF
--- a/manifests/certificates_dist.pp
+++ b/manifests/certificates_dist.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Wazuh repository installation
-define class wazuh::certificates_dist (
+class wazuh::certificates_dist (
   $wazuh_repository = 'packages-dev.wazuh.com',
   $wazuh_version = '4.4',
 ) {
@@ -28,5 +28,14 @@ define class wazuh::certificates_dist (
       File['/tmp/wazuh-certs-tool.sh'],
       File['/tmp/config.yml'],
     ],
+  }
+  file { 'Copy all certificates into module':
+    ensure => 'directory',
+    source => '/tmp/wazuh-certificates/',
+    recurse => 'remote',
+    path => '/etc/puppetlabs/code/environments/production/modules/archive/files/',
+    owner => 'root',
+    group => 'root',
+    mode  => '0755',
   }
 }

--- a/manifests/certificates_dist.pp
+++ b/manifests/certificates_dist.pp
@@ -1,0 +1,32 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Wazuh repository installation
+define class wazuh::certificates_dist (
+  $wazuh_repository = 'packages-dev.wazuh.com',
+  $wazuh_version = '4.4',
+) {
+  file { 'Configure Wazuh Certificates config.yml':
+    owner   => 'root',
+    path    => '/tmp/config.yml',
+    group   => 'root',
+    mode    => '0640',
+    content => template('wazuh/wazuh_config_dist_yml.erb'),
+  }
+
+  file { '/tmp/wazuh-certs-tool.sh':
+    ensure => file,
+    source => "https://${wazuh_repository}/${wazuh_version}/wazuh-certs-tool.sh",
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0740',
+  }
+
+  exec { 'Create Wazuh Certificates':
+    path    => '/usr/bin:/bin',
+    command => 'bash /tmp/wazuh-certs-tool.sh --all',
+    creates => '/tmp/wazuh-certificates',
+    require => [
+      File['/tmp/wazuh-certs-tool.sh'],
+      File['/tmp/config.yml'],
+    ],
+  }
+}

--- a/manifests/dashboard_dist.pp
+++ b/manifests/dashboard_dist.pp
@@ -1,0 +1,120 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Setup for Wazuh Dashboard_dist
+class wazuh::dashboard (
+  $dashboard_package = 'wazuh-dashboard',
+  $dashboard_service = 'wazuh-dashboard',
+  $dashboard_version = '4.4.0',
+  $indexer_server_ip = 'localhost',
+  $indexer_server_port = '9200',
+  $manager_api_host = 'localhost',
+  $dashboard_path_certs = '/etc/wazuh-dashboard/certs',
+  $dashboard_fileuser = 'wazuh-dashboard',
+  $dashboard_filegroup = 'wazuh-dashboard',
+
+  $dashboard_server_port = '443',
+  $dashboard_server_host = '0.0.0.0',
+  $dashboard_server_hosts = "https://${indexer_server_ip}:${indexer_server_port}",
+
+  # If the keystore is used, the credentials are not managed by the module (TODO).
+  # If use_keystore is false, the keystore is deleted, the dashboard use the credentials in the configuration file.
+  $use_keystore = true,
+  $dashboard_user = 'kibanaserver',
+  $dashboard_password = 'kibanaserver',
+
+  $dashboard_wazuh_api_credentials = [
+    {
+      'id'       => 'default',
+      'url'      => 'https://'$manager_api_host,
+      'port'     => '55000',
+      'user'     => 'wazuh-wui',
+      'password' => 'wazuh-wui',
+    },
+  ],
+
+) {
+
+  # assign version according to the package manager
+  case $facts['os']['family'] {
+    'Debian': {
+      $dashboard_version_install = "${dashboard_version}-*"
+    }
+    'Linux', 'RedHat', default: {
+      $dashboard_version_install = $dashboard_version
+    }
+  }
+
+  # install package
+  package { 'wazuh-dashboard':
+    ensure => $dashboard_version_install,
+    name   => $dashboard_package,
+  }
+
+  exec { "ensure full path of ${dashboard_path_certs}":
+    path    => '/usr/bin:/bin',
+    command => "mkdir -p ${dashboard_path_certs}",
+    creates => $dashboard_path_certs,
+    require => Package['wazuh-dashboard'],
+  }
+  -> file { $dashboard_path_certs:
+    ensure => directory,
+    owner  => $dashboard_fileuser,
+    group  => $dashboard_filegroup,
+    mode   => '0500',
+  }
+
+  [
+    'dashboard.pem',
+    'dashboard-key.pem',
+    'root-ca.pem',
+  ].each |String $certfile| {
+    file { "${dashboard_path_certs}/${certfile}":
+      ensure  => file,
+      owner   => $dashboard_fileuser,
+      group   => $dashboard_filegroup,
+      mode    => '0400',
+      replace => true,
+      recurse => remote,
+      source  => "puppet:///modules/archive/${certfile}",
+    }
+  }
+
+  file { '/etc/wazuh-dashboard/opensearch_dashboards.yml':
+    content => template('wazuh/wazuh_dashboard_yml.erb'),
+    group   => $dashboard_filegroup,
+    mode    => '0640',
+    owner   => $dashboard_fileuser,
+    require => Package['wazuh-dashboard'],
+    notify  => Service['wazuh-dashboard'],
+  }
+
+  file { [ '/usr/share/wazuh-dashboard/data/wazuh/', '/usr/share/wazuh-dashboard/data/wazuh/config' ]:
+    ensure  => 'directory',
+    group   => $dashboard_filegroup,
+    mode    => '0755',
+    owner   => $dashboard_fileuser,
+    require => Package['wazuh-dashboard'],
+  }
+  -> file { '/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml':
+    content => template('wazuh/wazuh_yml.erb'),
+    group   => $dashboard_filegroup,
+    mode    => '0600',
+    owner   => $dashboard_fileuser,
+    notify  => Service['wazuh-dashboard'],
+  }
+
+  unless $use_keystore {
+    file { '/usr/share/wazuh-dashboard/config/opensearch_dashboards.keystore':
+      ensure  => absent,
+      require => Package['wazuh-dashboard'],
+      before  => Service['wazuh-dashboard'],
+    }
+  }
+
+  service { 'wazuh-dashboard':
+    ensure     => running,
+    enable     => true,
+    hasrestart => true,
+    name       => $dashboard_service,
+  }
+
+}

--- a/manifests/filebeat_oss_dist.pp
+++ b/manifests/filebeat_oss_dist.pp
@@ -1,0 +1,109 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Setup for Filebeat_oss
+class wazuh::filebeat_oss_dist (
+  $filebeat_oss_indexer_ip = '127.0.0.1',
+  $filebeat_oss_indexer_port = '9200',
+  $indexer_server_ip = "\"${filebeat_oss_indexer_ip}:${filebeat_oss_indexer_port}\"",
+
+  $filebeat_oss_archives = false,
+  $filebeat_oss_package = 'filebeat',
+  $filebeat_oss_service = 'filebeat',
+  $filebeat_oss_elastic_user = 'admin',
+  $filebeat_oss_elastic_password = 'admin',
+  $filebeat_oss_version = '7.10.2',
+  $wazuh_app_version = '4.4.0_7.10.2',
+  $wazuh_extensions_version = '4.4',
+  $wazuh_filebeat_module = 'wazuh-filebeat-0.2.tar.gz',
+
+  $filebeat_fileuser = 'root',
+  $filebeat_filegroup = 'root',
+  $filebeat_path_certs = '/etc/filebeat/certs',
+) {
+
+  package { 'filebeat':
+    ensure => $filebeat_oss_version,
+    name   => $filebeat_oss_package,
+  }
+
+  file { '/etc/filebeat/filebeat.yml':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0640',
+    notify  => Service['filebeat'], ## Restarts the service
+    content => template('wazuh/filebeat_oss_yml.erb'),
+    require => Package['filebeat'],
+  }
+
+  # work around:
+  #  Use cmp to compare the content of local and remote file. When they differ than rm the file to get it recreated by the file resource.
+  #  Needed since GitHub can only ETAG and result in changes of the mtime everytime.
+  # TODO: Include file into the wazuh/wazuh-puppet project or use file { checksum => '..' } for this instead of the exec construct.
+  exec { 'cleanup /etc/filebeat/wazuh-template.json':
+    command => '/bin/rm /etc/filebeat/wazuh-template.json',
+    onlyif  => '/bin/test -f /etc/filebeat/wazuh-template.json',
+    unless  => "/bin/curl -s 'https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_extensions_version}/extensions/elasticsearch/7.x/wazuh-template.json' | /bin/cmp -s '/etc/filebeat/wazuh-template.json'",
+  }
+  -> file { '/etc/filebeat/wazuh-template.json':
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0440',
+    replace => false,  # only copy content when file not exist
+    source  => "https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_extensions_version}/extensions/elasticsearch/7.x/wazuh-template.json",
+    notify  => Service['filebeat'],
+    require => Package['filebeat'],
+  }
+
+  archive { "/tmp/${$wazuh_filebeat_module}":
+    ensure       => present,
+    source       => "https://packages.wazuh.com/4.x/filebeat/${$wazuh_filebeat_module}",
+    extract      => true,
+    extract_path => '/usr/share/filebeat/module',
+    creates      => '/usr/share/filebeat/module/wazuh',
+    cleanup      => true,
+    notify       => Service['filebeat'],
+    require      => Package['filebeat'],
+  }
+
+  file { '/usr/share/filebeat/module/wazuh':
+    ensure  => 'directory',
+    mode    => '0755',
+    require => Package['filebeat'],
+  }
+
+  exec { "ensure full path of ${filebeat_path_certs}":
+    path    => '/usr/bin:/bin',
+    command => "mkdir -p ${filebeat_path_certs}",
+    creates => $filebeat_path_certs,
+    require => Package['filebeat'],
+  }
+  -> file { $filebeat_path_certs:
+    ensure => directory,
+    owner  => $filebeat_fileuser,
+    group  => $filebeat_filegroup,
+    mode   => '0500',
+  }
+
+  $_certfiles = {
+    'manager-master.pem'     => 'filebeat.pem',
+    'manager-master-key.pem' => 'filebeat-key.pem',
+    'root-ca.pem'    => 'root-ca.pem',
+  }
+  $_certfiles.each |String $certfile_source, String $certfile_target| {
+    file { "${filebeat_path_certs}/${certfile_target}":
+      ensure  => file,
+      owner   => $filebeat_fileuser,
+      group   => $filebeat_filegroup,
+      mode    => '0400',
+      replace => true,
+      recurse => remote,
+      source  => "puppet:///modules/archive/${certfile_source}",
+    }
+  }
+
+  service { 'filebeat':
+    ensure  => running,
+    enable  => true,
+    name    => $filebeat_oss_service,
+    require => Package['filebeat'],
+  }
+}

--- a/manifests/indexer_dist.pp
+++ b/manifests/indexer_dist.pp
@@ -1,0 +1,136 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Setup for Wazuh Indexer
+class wazuh::indexer_dist (
+  # opensearch.yml configuration
+  $indexer_network_host = '0.0.0.0',
+  $indexer_cluster_name = 'wazuh-cluster',
+  $indexer_node_name = 'node1',
+  $indexer_node_max_local_storage_nodes = '1',
+  $indexer_service = 'wazuh-indexer',
+  $indexer_package = 'wazuh-indexer',
+  $indexer_version = '4.4.0-1',
+  $indexer_fileuser = 'wazuh-indexer',
+  $indexer_filegroup = 'wazuh-indexer',
+
+  $indexer_path_data = '/var/lib/wazuh-indexer',
+  $indexer_path_logs = '/var/log/wazuh-indexer',
+  $indexer_path_certs = '/etc/wazuh-indexer/certs',
+  $indexer_security_init_lockfile = '/var/tmp/indexer-security-init.lock',
+  $full_indexer_reinstall = false, # Change to true when whant a full reinstall of Wazuh indexer
+
+  $indexer_ip = 'localhost',
+  $indexer_port = '9200',
+  $indexer_discovery_hosts = ['$(indexer_node1_name)', '$(indexer_node2_name)', '$(indexer_node3_name)'],
+  $indexer_cluster_initial_master_nodes = ['$(indexer_node1_name)', '$(indexer_node2_name)', '$(indexer_node3_name)'],
+  $indexer_master_node = 'puppet',
+
+  # JVM options
+  $jvm_options_memory = '1g',
+) {
+
+  # install package
+  package { 'wazuh-indexer':
+    ensure => $indexer_version,
+    name   => $indexer_package,
+  }
+
+  exec { "ensure full path of ${indexer_path_certs}":
+    path    => '/usr/bin:/bin',
+    command => "mkdir -p ${indexer_path_certs}",
+    creates => $indexer_path_certs,
+    require => Package['wazuh-indexer'],
+  }
+  -> file { $indexer_path_certs:
+    ensure => directory,
+    owner  => $indexer_fileuser,
+    group  => $indexer_filegroup,
+    mode   => '0500',
+  }
+
+  [
+   'indexer-$(indexer_node_name).pem',
+   'indexer-$(indexer_node_name)-key.pem',
+   'root-ca.pem',
+   'admin.pem',
+   'admin-key.pem',
+  ].each |String $certfile| {
+    file { "${indexer_path_certs}/${certfile}":
+      ensure  => file,
+      owner   => $indexer_fileuser,
+      group   => $indexer_filegroup,
+      mode    => '0400',
+      replace => false,  # only copy content when file not exist
+      source  => "$indexer_master_node:///tmp/wazuh-certificates/${certfile}",
+    }
+  }
+
+
+  file { 'configuration file':
+    path    => '/etc/wazuh-indexer/opensearch.yml',
+    content => template('wazuh/wazuh_indexer_yml.erb'),
+    group   => $indexer_filegroup,
+    mode    => '0660',
+    owner   => $indexer_fileuser,
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
+  file_line { 'Insert line initial size of total heap space':
+    path    => '/etc/wazuh-indexer/jvm.options',
+    line    => "-Xms${jvm_options_memory}",
+    match   => '^-Xms',
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
+  file_line { 'Insert line maximum size of total heap space':
+    path    => '/etc/wazuh-indexer/jvm.options',
+    line    => "-Xmx${jvm_options_memory}",
+    match   => '^-Xmx',
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
+  service { 'wazuh-indexer':
+    ensure  => running,
+    enable  => true,
+    name    => $indexer_service,
+    require => Package['wazuh-indexer'],
+  }
+
+  file_line { "Insert line limits nofile for ${indexer_fileuser}":
+    path   => '/etc/security/limits.conf',
+    line   => "${indexer_fileuser} - nofile  65535",
+    match  => "^${indexer_fileuser} - nofile\s",
+    notify => Service['wazuh-indexer'],
+  }
+  file_line { "Insert line limits memlock for ${indexer_fileuser}":
+    path   => '/etc/security/limits.conf',
+    line   => "${indexer_fileuser} - memlock unlimited",
+    match  => "^${indexer_fileuser} - memlock\s",
+    notify => Service['wazuh-indexer'],
+  }
+
+  # TODO: this should be done by the package itself and not by puppet at all
+  [
+    '/etc/wazuh-indexer',
+    '/usr/share/wazuh-indexer',
+    '/var/lib/wazuh-indexer',
+  ].each |String $file| {
+    exec { "set recusive ownership of ${file}":
+      path        => '/usr/bin:/bin',
+      command     => "chown ${indexer_fileuser}:${indexer_filegroup} -R ${file}",
+      refreshonly => true,  # only run when package is installed or updated
+      subscribe   => Package['wazuh-indexer'],
+      notify      => Service['wazuh-indexer'],
+    }
+  }
+
+  if $full_indexer_reinstall {
+    file { $indexer_security_init_lockfile:
+      ensure  => absent,
+      require => Package['wazuh-indexer'],
+      before  => Exec['Initialize the Opensearch security index in Wazuh indexer'],
+    }
+  }
+}

--- a/manifests/indexer_dist.pp
+++ b/manifests/indexer_dist.pp
@@ -20,9 +20,9 @@ class wazuh::indexer_dist (
 
   $indexer_ip = 'localhost',
   $indexer_port = '9200',
-  $indexer_discovery_hosts = ['$(indexer_node1_name)', '$(indexer_node2_name)', '$(indexer_node3_name)'],
-  $indexer_cluster_initial_master_nodes = ['$(indexer_node1_name)', '$(indexer_node2_name)', '$(indexer_node3_name)'],
-  $indexer_master_node = 'puppet',
+  $indexer_discovery_hosts = [$node1host, $node2host, $node3host],
+  $indexer_cluster_initial_master_nodes = [$node1host, $node2host, $node3host],
+  $indexer_cluster_CN = [$indexer_node1_name, $indexer_node2_name, $indexer_node3_name],
 
   # JVM options
   $jvm_options_memory = '1g',
@@ -48,8 +48,8 @@ class wazuh::indexer_dist (
   }
 
   [
-   'indexer-$(indexer_node_name).pem',
-   'indexer-$(indexer_node_name)-key.pem',
+   "indexer-$indexer_node_name.pem",
+   "indexer-$indexer_node_name-key.pem",
    'root-ca.pem',
    'admin.pem',
    'admin-key.pem',
@@ -59,15 +59,17 @@ class wazuh::indexer_dist (
       owner   => $indexer_fileuser,
       group   => $indexer_filegroup,
       mode    => '0400',
-      replace => false,  # only copy content when file not exist
-      source  => "$indexer_master_node:///tmp/wazuh-certificates/${certfile}",
+      replace => true,
+      recurse => remote,
+      source  => "puppet:///modules/archive/${certfile}",
     }
   }
 
 
+
   file { 'configuration file':
     path    => '/etc/wazuh-indexer/opensearch.yml',
-    content => template('wazuh/wazuh_indexer_yml.erb'),
+    content => template('wazuh/wazuh_indexer_yml_dist.erb'),
     group   => $indexer_filegroup,
     mode    => '0660',
     owner   => $indexer_fileuser,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -21,8 +21,8 @@ class wazuh::repo (
           apt::source { 'wazuh':
             ensure   => present,
             comment  => 'This is the WAZUH Ubuntu repository',
-            location => 'https://packages.wazuh.com/4.x/apt',
-            release  => 'stable',
+            location => 'https://packages-dev.wazuh.com/pre-release/apt',
+            release  => 'unstable',
             repos    => 'main',
             include  => {
               'src' => false,
@@ -37,10 +37,10 @@ class wazuh::repo (
         case $::os[name] {
           /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux)$/: {
             if ( $::operatingsystemrelease =~ /^5.*/ ) {
-              $baseurl  = 'https://packages.wazuh.com/4.x/yum/5/'
+              $baseurl  = 'https://packages-dev.wazuh.com/pre-release/yum/5/'
               $gpgkey   = 'http://packages.wazuh.com/key/GPG-KEY-WAZUH'
             } else {
-              $baseurl  = 'https://packages.wazuh.com/4.x/yum/'
+              $baseurl  = 'https://packages-dev.wazuh.com/pre-release/yum/'
               $gpgkey   = 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
             }
           }

--- a/manifests/repo_use.pp
+++ b/manifests/repo_use.pp
@@ -1,0 +1,11 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Wazuh repository installation
+class wazuh::repo_use (
+) {
+ include wazuh::repo
+ if $facts['os']['family'] == 'Debian' {
+   Class['wazuh::repo'] -> Class['apt::update'] -> Package['wazuh-indexer']
+ } else {
+   Class['wazuh::repo'] -> Package['wazuh-indexer']
+ }
+}

--- a/manifests/securityadmin.pp
+++ b/manifests/securityadmin.pp
@@ -1,0 +1,11 @@
+# Copyright (C) 2015, Wazuh Inc.
+# Wazuh repository installation
+class wazuh::securityadmin (
+) {
+  exec { 'Initialize the Opensearch security index in Wazuh indexer':
+    path    => ['/usr/bin', '/bin', '/usr/sbin'],
+    command => "/usr/share/wazuh-indexer/bin/indexer-security-init.sh && touch ${indexer_security_init_lockfile}",
+    creates => $indexer_security_init_lockfile,
+    require => Service['wazuh-indexer'],
+  }
+}

--- a/manifests/securityadmin.pp
+++ b/manifests/securityadmin.pp
@@ -1,6 +1,7 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Wazuh repository installation
 class wazuh::securityadmin (
+  $indexer_security_init_lockfile = '/var/tmp/indexer-security-init.lock',
 ) {
   exec { 'Initialize the Opensearch security index in Wazuh indexer':
     path    => ['/usr/bin', '/bin', '/usr/sbin'],

--- a/metadata.json
+++ b/metadata.json
@@ -89,7 +89,9 @@
         "Wily",
         "Xenial",
         "Yakketi",
-        "Bionic"
+        "Bionic",
+        "focal",
+        "jammy"
       ]
     },
     {
@@ -98,7 +100,8 @@
         "Wheezy",
         "Jessie",
         "Stretch",
-        "Sid"
+        "Sid",
+        "bullseye"
       ]
     }
   ],

--- a/templates/wazuh_config_dist_yml.erb
+++ b/templates/wazuh_config_dist_yml.erb
@@ -1,0 +1,18 @@
+nodes:
+  indexer:
+    - name: indexer-<%= @indexer_node1_name %>
+      ip: <%= @node1ip %>
+    - name: indexer-<%= @indexer_node2_name %>
+      ip: <%= @node2ip %>
+    - name: indexer-<%= @indexer_node3_name %>
+      ip: <%= @node3ip %>
+  server:
+    - name: manager-master
+      ip: <%= @masterip %>
+      node_type: master
+    - name: manager-worker
+      ip: <%= @workerip %>
+      node_type: worker
+  dashboard:
+    - name: dashboard
+      ip: <%= @dashboardip %>

--- a/templates/wazuh_config_dist_yml.erb
+++ b/templates/wazuh_config_dist_yml.erb
@@ -1,18 +1,18 @@
 nodes:
   indexer:
     - name: indexer-<%= @indexer_node1_name %>
-      ip: <%= @node1ip %>
+      ip: <%= @node1host %>
     - name: indexer-<%= @indexer_node2_name %>
-      ip: <%= @node2ip %>
+      ip: <%= @node2host %>
     - name: indexer-<%= @indexer_node3_name %>
-      ip: <%= @node3ip %>
+      ip: <%= @node3host %>
   server:
     - name: manager-master
-      ip: <%= @masterip %>
+      ip: <%= @masterhost %>
       node_type: master
     - name: manager-worker
-      ip: <%= @workerip %>
+      ip: <%= @workerhost %>
       node_type: worker
   dashboard:
     - name: dashboard
-      ip: <%= @dashboardip %>
+      ip: <%= @dashboardhost %>

--- a/templates/wazuh_indexer_yml_dist.erb
+++ b/templates/wazuh_indexer_yml_dist.erb
@@ -1,3 +1,4 @@
+
 network.host: "<%= @indexer_network_host %>"
 node.name: "<%= @indexer_node_name %>"
 cluster.initial_master_nodes:
@@ -14,31 +15,26 @@ discovery.seed_hosts:
 node.max_local_storage_nodes: "<%= @indexer_node_max_local_storage_nodes %>"
 path.data: "<%= @indexer_path_data %>"
 path.logs: "<%= @indexer_path_logs %>"
-
 plugins.security.ssl.http.pemcert_filepath: <%= @indexer_path_certs %>/indexer-<%= @indexer_node_name %>.pem
 plugins.security.ssl.http.pemkey_filepath: <%= @indexer_path_certs %>/indexer-<%= @indexer_node_name %>-key.pem
 plugins.security.ssl.http.pemtrustedcas_filepath: <%= @indexer_path_certs %>/root-ca.pem
-plugins.security.ssl.transport.pemcert_filepath: <%= @indexer_path_certs %>/indexer.pem
-plugins.security.ssl.transport.pemkey_filepath: <%= @indexer_path_certs %>/indexer-key.pem
+plugins.security.ssl.transport.pemcert_filepath: <%= @indexer_path_certs %>/indexer-<%= @indexer_node_name %>.pem
+plugins.security.ssl.transport.pemkey_filepath: <%= @indexer_path_certs %>/indexer-<%= @indexer_node_name %>-key.pem
 plugins.security.ssl.transport.pemtrustedcas_filepath: <%= @indexer_path_certs %>/root-ca.pem
 plugins.security.ssl.http.enabled: true
 plugins.security.ssl.transport.enforce_hostname_verification: false
 plugins.security.ssl.transport.resolve_hostname: false
-
 plugins.security.authcz.admin_dn:
 - "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
-<% @indexer_cluster_initial_master_nodes.each do |node| -%>
-- "CN=<%= node %>,OU=Wazuh,O=Wazuh,L=California,C=US"
+<% @indexer_cluster_CN.each do |cn| -%>
+- "CN=indexer-<%= cn %>,OU=Wazuh,O=Wazuh,L=California,C=US"
 <% end -%>
 plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
-
-plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
-
-### Option to allow Filebeat-oss 7.10.2 to work ###
+plugins.security.allow_default_init_securityindex: true
+cluster.routing.allocation.disk.threshold_enabled: false
 compatibility.override_main_response_version: true

--- a/templates/wazuh_indexer_yml_dist.erb
+++ b/templates/wazuh_indexer_yml_dist.erb
@@ -1,0 +1,44 @@
+network.host: "<%= @indexer_network_host %>"
+node.name: "<%= @indexer_node_name %>"
+cluster.initial_master_nodes:
+<% @indexer_cluster_initial_master_nodes.each do |node| -%>
+- "<%= node %>"
+<% end -%>
+cluster.name: "<%= @indexer_cluster_name %>"
+<% if not @indexer_discovery_hosts.empty? -%>
+discovery.seed_hosts:
+<% @indexer_discovery_hosts.each do |host| -%>
+- "<%= host %>"
+<% end -%>
+<% end -%>
+node.max_local_storage_nodes: "<%= @indexer_node_max_local_storage_nodes %>"
+path.data: "<%= @indexer_path_data %>"
+path.logs: "<%= @indexer_path_logs %>"
+
+plugins.security.ssl.http.pemcert_filepath: <%= @indexer_path_certs %>/indexer-<%= @indexer_node_name %>.pem
+plugins.security.ssl.http.pemkey_filepath: <%= @indexer_path_certs %>/indexer-<%= @indexer_node_name %>-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: <%= @indexer_path_certs %>/root-ca.pem
+plugins.security.ssl.transport.pemcert_filepath: <%= @indexer_path_certs %>/indexer.pem
+plugins.security.ssl.transport.pemkey_filepath: <%= @indexer_path_certs %>/indexer-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: <%= @indexer_path_certs %>/root-ca.pem
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.transport.enforce_hostname_verification: false
+plugins.security.ssl.transport.resolve_hostname: false
+
+plugins.security.authcz.admin_dn:
+- "CN=admin,OU=Wazuh,O=Wazuh,L=California,C=US"
+plugins.security.check_snapshot_restore_write_privileges: true
+plugins.security.enable_snapshot_restore_privilege: true
+plugins.security.nodes_dn:
+<% @indexer_cluster_initial_master_nodes.each do |node| -%>
+- "CN=<%= node %>,OU=Wazuh,O=Wazuh,L=California,C=US"
+<% end -%>
+plugins.security.restapi.roles_enabled:
+- "all_access"
+- "security_rest_api_access"
+
+plugins.security.system_indices.enabled: true
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+
+### Option to allow Filebeat-oss 7.10.2 to work ###
+compatibility.override_main_response_version: true


### PR DESCRIPTION
This PR modifies several manifests and templates into Wazuh Puppet deployment to add an option to deploy in distributed mode.
Closes https://github.com/wazuh/wazuh-puppet/issues/632