### PR TITLE
Adding a check for RHEL 9

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -320,7 +320,9 @@ class wazuh::agent (
     case $::operatingsystem {
       'RedHat', 'OracleLinux':{
         $apply_template_os = 'rhel'
-        if ( $::operatingsystemrelease     =~ /^8.*/ ){
+        if ( $::operatingsystemrelease     =~ /^9.*/ ){
+          $rhel_version = '9'
+        }elsif ( $::operatingsystemrelease  =~ /^8.*/ ){
           $rhel_version = '8'
         }elsif ( $::operatingsystemrelease  =~ /^7.*/ ){
           $rhel_version = '7'

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -320,7 +320,7 @@ class wazuh::agent (
     case $::operatingsystem {
       'RedHat', 'OracleLinux':{
         $apply_template_os = 'rhel'
-        if ( $::operatingsystemrelease     =~ /^9.*/ ){
+        if ( $::operatingsystemrelease =~ /^9.*/ ){
           $rhel_version = '9'
         }elsif ( $::operatingsystemrelease  =~ /^8.*/ ){
           $rhel_version = '8'

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -438,7 +438,7 @@ class wazuh::manager (
   case $::operatingsystem{
     'RedHat', 'OracleLinux':{
       $apply_template_os = 'rhel'
-      if ( $::operatingsystemrelease     =~ /^9.*/ ){
+      if ( $::operatingsystemrelease =~ /^9.*/ ){
         $rhel_version = '9'
       }elsif ( $::operatingsystemrelease =~ /^8.*/ ){
         $rhel_version = '8'

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -438,7 +438,11 @@ class wazuh::manager (
   case $::operatingsystem{
     'RedHat', 'OracleLinux':{
       $apply_template_os = 'rhel'
-      if ( $::operatingsystemrelease     =~ /^7.*/ ){
+      if ( $::operatingsystemrelease     =~ /^9.*/ ){
+        $rhel_version = '9'
+      }elsif ( $::operatingsystemrelease =~ /^8.*/ ){
+        $rhel_version = '8'
+      }elsif ( $::operatingsystemrelease =~ /^7.*/ ){
         $rhel_version = '7'
       }elsif ( $::operatingsystemrelease =~ /^6.*/ ){
         $rhel_version = '6'


### PR DESCRIPTION
Adding a check for RHEL 9 in the agent.pp and manager.pp to prevent Puppet from throwing the error below.

`Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Evaluation Error: Error while evaluating a Function Call, This ossec module has not been tested on your distribution (file: /etc/puppetlabs/code/environments/production/modules/wazuh/manifests/manager.pp, line: 446, column: 9)`


