### PR TITLE
Add Rocky 8 support

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -338,7 +338,7 @@ class wazuh::agent (
         }
       }'Amazon':{
         $apply_template_os = 'amazon'
-      }'CentOS','Centos','centos','AlmaLinux':{
+      }'CentOS','Centos','centos','AlmaLinux','Rocky':{
         $apply_template_os = 'centos'
       }
       default: { fail('OS not supported') }

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -458,7 +458,7 @@ class wazuh::params_agent {
                 }
               }
             }
-            'AlmaLinux': {
+            'AlmaLinux','Rocky': {
               if ( $::operatingsystemrelease =~ /^8.*/ ) {
                 $ossec_service_provider = 'redhat'
               }

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -539,7 +539,7 @@ class wazuh::params_manager {
                 }
               }
             }
-            'AlmaLinux': {
+            'AlmaLinux','Rocky': {
               if ( $::operatingsystemrelease =~ /^8.*/ ) {
                 $ossec_service_provider = 'redhat'
                 $api_service_provider = 'redhat'

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -35,7 +35,7 @@ class wazuh::repo (
     }
     'Linux', 'RedHat' : {
         case $::os[name] {
-          /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux)$/: {
+          /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux|Rocky)$/: {
             if ( $::operatingsystemrelease =~ /^5.*/ ) {
               $baseurl  = 'https://packages.wazuh.com/4.x/yum/5/'
               $gpgkey   = 'http://packages.wazuh.com/key/GPG-KEY-WAZUH'


### PR DESCRIPTION
While Wazuh still doesn't have a built-in Rocky 8 SCA profile (https://github.com/wazuh/wazuh/issues/13406), this will at least allow the agent to be installed on Rocky 8 hosts. This PR is similar to #556, but targets the 4.3 branch as requested in #555.