### PR TITLE
4.4.2 vuln detector wazuh agent

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -189,6 +189,47 @@ class wazuh::agent (
   # Docker-listener
   $wodle_docker_listener_disabled    = $wazuh::params_agent::wodle_docker_listener_disabled,
 
+  #vulnerability-detector
+  $vulnerability_detector_enabled                            = $wazuh::params_agent::vulnerability_detector_enabled,
+  $vulnerability_detector_interval                           = $wazuh::params_agent::vulnerability_detector_interval,
+  $vulnerability_detector_min_full_scan_interval             = $wazuh::params_agent::vulnerability_detector_min_full_scan_interval,
+  $vulnerability_detector_run_on_start                       = $wazuh::params_agent::vulnerability_detector_run_on_start,
+# lint:ignore:140chars
+  $vulnerability_detector_provider_canonical                 = $wazuh::params_agent::vulnerability_detector_provider_canonical,
+  $vulnerability_detector_provider_canonical_enabled         = $wazuh::params_agent::vulnerability_detector_provider_canonical_enabled,
+  $vulnerability_detector_provider_canonical_os              = $wazuh::params_agent::vulnerability_detector_provider_canonical_os,
+  $vulnerability_detector_provider_canonical_update_interval = $wazuh::params_agent::vulnerability_detector_provider_canonical_update_interval,
+
+  $vulnerability_detector_provider_debian                    = $wazuh::params_agent::vulnerability_detector_provider_debian,
+  $vulnerability_detector_provider_debian_enabled            = $wazuh::params_agent::vulnerability_detector_provider_debian_enabled,
+  $vulnerability_detector_provider_debian_os                 = $wazuh::params_agent::vulnerability_detector_provider_debian_os,
+  $vulnerability_detector_provider_debian_update_interval    = $wazuh::params_agent::vulnerability_detector_provider_debian_update_interval,
+
+  $vulnerability_detector_provider_redhat                    = $wazuh::params_agent::vulnerability_detector_provider_redhat,
+  $vulnerability_detector_provider_redhat_enabled            = $wazuh::params_agent::vulnerability_detector_provider_redhat_enabled,
+  $vulnerability_detector_provider_redhat_os                 = $wazuh::params_agent::vulnerability_detector_provider_redhat_os,
+  $vulnerability_detector_provider_redhat_update_interval    = $wazuh::params_agent::vulnerability_detector_provider_redhat_update_interval,
+
+  $vulnerability_detector_provider_nvd                       = $wazuh::params_agent::vulnerability_detector_provider_nvd,
+  $vulnerability_detector_provider_nvd_enabled               = $wazuh::params_agent::vulnerability_detector_provider_nvd_enabled,
+  $vulnerability_detector_provider_nvd_os                    = $wazuh::params_agent::vulnerability_detector_provider_nvd_os,
+  $vulnerability_detector_provider_nvd_update_from_year      = $wazuh::params_agent::vulnerability_detector_provider_nvd_update_from_year,
+  $vulnerability_detector_provider_nvd_update_interval       = $wazuh::params_agent::vulnerability_detector_provider_nvd_update_interval,
+      #lint:endignore
+
+  $vulnerability_detector_provider_arch                   = $wazuh::params_agent::vulnerability_detector_provider_arch,
+  $vulnerability_detector_provider_arch_enabled           = $wazuh::params_agent::vulnerability_detector_provider_arch_enabled,
+  $vulnerability_detector_provider_arch_update_interval   = $wazuh::params_agent::vulnerability_detector_provider_arch_update_interval,
+
+  $vulnerability_detector_provider_alas                   = $wazuh::params_agent::vulnerability_detector_provider_alas,
+  $vulnerability_detector_provider_alas_enabled           = $wazuh::params_agent::vulnerability_detector_provider_alas_enabled,
+  $vulnerability_detector_provider_alas_os                = $wazuh::params_agent::vulnerability_detector_provider_alas_os,
+  $vulnerability_detector_provider_alas_update_interval   = $wazuh::params_agent::vulnerability_detector_provider_alas_update_interval,
+
+  $vulnerability_detector_provider_msu                   = $wazuh::params_agent::vulnerability_detector_provider_msu,
+  $vulnerability_detector_provider_msu_enabled           = $wazuh::params_agent::vulnerability_detector_provider_msu_enabled,
+  $vulnerability_detector_provider_msu_update_interval   = $wazuh::params_agent::vulnerability_detector_provider_msu_update_interval,
+
   # Localfile
   $ossec_local_files                 = $wazuh::params_agent::default_local_files,
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -479,6 +479,14 @@ class wazuh::agent (
         content => template($ossec_sca_template);
     }
   }
+  if($configure_vulnerability_detector == true){
+    concat::fragment {
+      'ossec.conf_vulnerability_detector':
+        order   => 26,
+        target  => 'agent_ossec.conf',
+        content => template($ossec_vulnerability_detector_template);
+    }
+  }
   if ($configure_syscheck == true) {
     concat::fragment {
       'ossec.conf_syscheck':

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -177,7 +177,6 @@ class wazuh::manager (
       $vulnerability_detector_provider_redhat                    = $wazuh::params_manager::vulnerability_detector_provider_redhat,
       $vulnerability_detector_provider_redhat_enabled            = $wazuh::params_manager::vulnerability_detector_provider_redhat_enabled,
       $vulnerability_detector_provider_redhat_os                 = $wazuh::params_manager::vulnerability_detector_provider_redhat_os,
-      $vulnerability_detector_provider_redhat_update_from_year   = $wazuh::params_manager::vulnerability_detector_provider_redhat_update_from_year,
       $vulnerability_detector_provider_redhat_update_interval    = $wazuh::params_manager::vulnerability_detector_provider_redhat_update_interval,
 
       $vulnerability_detector_provider_nvd                       = $wazuh::params_manager::vulnerability_detector_provider_nvd,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -79,6 +79,54 @@ class wazuh::params_agent {
   $active_response_ca_verification                 = 'yes'
   $active_response_repeated_offenders              = []
 
+  #vulnerability detector
+  $vulnerability_detector_enabled                            = 'no'
+  $vulnerability_detector_interval                           = '5m'
+  $vulnerability_detector_min_full_scan_interval             = '6h'
+  $vulnerability_detector_run_on_start                       = 'yes'
+
+  $vulnerability_detector_provider_canonical                 = 'yes'
+  $vulnerability_detector_provider_canonical_enabled         = 'no'
+  $vulnerability_detector_provider_canonical_os              = ['trusty',
+        'xenial',
+        'bionic'
+      ]
+  $vulnerability_detector_provider_canonical_update_interval = '1h'
+
+  $vulnerability_detector_provider_debian                 = 'yes'
+  $vulnerability_detector_provider_debian_enabled         = 'no'
+  $vulnerability_detector_provider_debian_os              = ['wheezy',
+        'stretch',
+        'jessie',
+        'buster'
+      ]
+  $vulnerability_detector_provider_debian_update_interval = '1h'
+  $vulnerability_detector_provider_redhat                    = 'yes'
+  $vulnerability_detector_provider_redhat_enabled            = 'no'
+  $vulnerability_detector_provider_redhat_os                 = ['5','6','7','8']
+  $vulnerability_detector_provider_redhat_update_interval    = '1h'      # syslog
+
+  $vulnerability_detector_provider_nvd                    = 'yes'
+  $vulnerability_detector_provider_nvd_enabled            = 'no'
+  $vulnerability_detector_provider_nvd_os                 = []
+  $vulnerability_detector_provider_nvd_update_from_year   = '2010'
+  $vulnerability_detector_provider_nvd_update_interval    = '1h'
+
+  $vulnerability_detector_provider_arch                   = 'yes'
+  $vulnerability_detector_provider_arch_enabled           = 'no'
+  $vulnerability_detector_provider_arch_update_interval   = '1h'
+
+  $vulnerability_detector_provider_alas                   = 'yes'
+  $vulnerability_detector_provider_alas_enabled           = 'no'
+  $vulnerability_detector_provider_alas_os              = ['amazon-linux',
+      'amazon-linux-2'
+      ]
+  $vulnerability_detector_provider_alas_update_interval   = '1h'
+
+  $vulnerability_detector_provider_msu                   = 'yes'
+  $vulnerability_detector_provider_msu_enabled           = 'no'
+  $vulnerability_detector_provider_msu_update_interval   = '1h'
+
   # agent autoenrollment
   $wazuh_enrollment_enabled                        = undef
   $wazuh_enrollment_manager_address                = undef

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -186,7 +186,6 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_redhat                    = 'yes'
       $vulnerability_detector_provider_redhat_enabled            = 'no'
       $vulnerability_detector_provider_redhat_os                 = ['5','6','7','8']
-      $vulnerability_detector_provider_redhat_update_from_year   = '2010'
       $vulnerability_detector_provider_redhat_update_interval    = '1h'      # syslog
 
 

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -29,7 +29,6 @@
 <% if @vulnerability_detector_provider_redhat %>
   <provider name="redhat">
     <% if @vulnerability_detector_provider_redhat_enabled %><enabled><%= @vulnerability_detector_provider_redhat_enabled %></enabled><% end %>
-    <% if @vulnerability_detector_provider_redhat_update_from_year %><update_from_year><%= @vulnerability_detector_provider_redhat_update_from_year %></update_from_year><% end %>
     <% if @vulnerability_detector_provider_redhat_update_interval %><update_interval><%= @vulnerability_detector_provider_redhat_update_interval %></update_interval><% end %>
     <% if !@vulnerability_detector_provider_redhat_os.empty? %>
     <% @vulnerability_detector_provider_redhat_os.each do |os| %>


### PR DESCRIPTION
This pull request do:

1. Add support for fragment vulnerability-detector for wazuh agent
   
   We do the same logic we have for wazuh-manager with vulnerability-detector for wazuh agent.

2. Fix parameter "update_from_year" for redhat vulnerability-detector
	
	The parameter "update_from_year" is only available in provider "nvd". We delete from redhat logic vulnerability-detector.

This new feature is request in https://github.com/wazuh/wazuh-puppet/issues/667

I tested with puppet7 and Ubuntu22, Ubuntu20 and Windows 2019