### PR TITLE
Set default value to empty string for in_level integrations

### DIFF
--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -4,7 +4,7 @@ define wazuh::integration(
   $hook_url = '',
   $api_key = '',
   $in_rule_id = '',
-  $in_level = 7,
+  $in_level = '',
   $in_group = '',
   $in_location = '',
   $in_format = '',


### PR DESCRIPTION
If a custom integration is only wanted for a specific rule where level is under 7, it does not work because of the default value set to 7.