### PR TITLE
Add ssl_agent_ca param in manager configuration

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -220,6 +220,7 @@ class wazuh::manager (
       $ossec_auth_use_password              = $wazuh::params_manager::ossec_auth_use_password,
       $ossec_auth_limit_maxagents           = $wazuh::params_manager::ossec_auth_limit_maxagents,
       $ossec_auth_ciphers                   = $wazuh::params_manager::ossec_auth_ciphers,
+      $ossec_auth_ssl_agent_ca              = $wazuh::params_manager::ossec_auth_ssl_agent_ca,
       $ossec_auth_ssl_verify_host           = $wazuh::params_manager::ossec_auth_ssl_verify_host,
       $ossec_auth_ssl_manager_cert          = $wazuh::params_manager::ossec_auth_ssl_manager_cert,
       $ossec_auth_ssl_manager_key           = $wazuh::params_manager::ossec_auth_ssl_manager_key,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -230,6 +230,7 @@ class wazuh::params_manager {
       $ossec_auth_use_password                         = 'no'
       $ossec_auth_limit_maxagents                      = 'yes'
       $ossec_auth_ciphers                              = 'HIGH:!ADH:!EXP:!MD5:!RC4:!3DES:!CAMELLIA:@STRENGTH'
+      $ossec_auth_ssl_agent_ca                         = undef
       $ossec_auth_ssl_verify_host                      = 'no'
       $ossec_auth_ssl_manager_cert                     = '/var/ossec/etc/sslmanager.cert'
       $ossec_auth_ssl_manager_key                      = '/var/ossec/etc/sslmanager.key'

--- a/templates/fragments/_auth.erb
+++ b/templates/fragments/_auth.erb
@@ -16,6 +16,9 @@
   <use_password><%= @ossec_auth_use_password %></use_password>
   <limit_maxagents><%= @ossec_auth_limit_maxagents %></limit_maxagents>
   <ciphers><%= @ossec_auth_ciphers %></ciphers>
+  <%- if @ossec_auth_ssl_agent_ca then -%>
+  <ssl_agent_ca><%= @ossec_auth_ssl_agent_ca %></ssl_agent_ca>
+  <%- end -%>
   <ssl_verify_host><%= @ossec_auth_ssl_verify_host %></ssl_verify_host>
   <ssl_manager_cert><%= @ossec_auth_ssl_manager_cert %></ssl_manager_cert>
   <ssl_manager_key><%= @ossec_auth_ssl_manager_key %></ssl_manager_key>


### PR DESCRIPTION
ssl_agent_ca parameter was missing in Wazuh Manager config template. This PR is to add the missing option.