### PR TITLE
Deprecate update_from_year to use NVD API 2.0 feeds

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -177,13 +177,11 @@ class wazuh::manager (
       $vulnerability_detector_provider_redhat                    = $wazuh::params_manager::vulnerability_detector_provider_redhat,
       $vulnerability_detector_provider_redhat_enabled            = $wazuh::params_manager::vulnerability_detector_provider_redhat_enabled,
       $vulnerability_detector_provider_redhat_os                 = $wazuh::params_manager::vulnerability_detector_provider_redhat_os,
-      $vulnerability_detector_provider_redhat_update_from_year   = $wazuh::params_manager::vulnerability_detector_provider_redhat_update_from_year,
       $vulnerability_detector_provider_redhat_update_interval    = $wazuh::params_manager::vulnerability_detector_provider_redhat_update_interval,
 
       $vulnerability_detector_provider_nvd                       = $wazuh::params_manager::vulnerability_detector_provider_nvd,
       $vulnerability_detector_provider_nvd_enabled               = $wazuh::params_manager::vulnerability_detector_provider_nvd_enabled,
       $vulnerability_detector_provider_nvd_os                    = $wazuh::params_manager::vulnerability_detector_provider_nvd_os,
-      $vulnerability_detector_provider_nvd_update_from_year      = $wazuh::params_manager::vulnerability_detector_provider_nvd_update_from_year,
       $vulnerability_detector_provider_nvd_update_interval       = $wazuh::params_manager::vulnerability_detector_provider_nvd_update_interval,
       #lint:endignore
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -186,14 +186,12 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_redhat                    = 'yes'
       $vulnerability_detector_provider_redhat_enabled            = 'no'
       $vulnerability_detector_provider_redhat_os                 = ['5','6','7','8']
-      $vulnerability_detector_provider_redhat_update_from_year   = '2010'
       $vulnerability_detector_provider_redhat_update_interval    = '1h'      # syslog
 
 
       $vulnerability_detector_provider_nvd                    = 'yes'
       $vulnerability_detector_provider_nvd_enabled            = 'no'
       $vulnerability_detector_provider_nvd_os                 = []
-      $vulnerability_detector_provider_nvd_update_from_year   = '2010'
       $vulnerability_detector_provider_nvd_update_interval    = '1h'
 
       $vulnerability_detector_provider_arch                   = 'yes'

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -29,7 +29,6 @@
 <% if @vulnerability_detector_provider_redhat %>
   <provider name="redhat">
     <% if @vulnerability_detector_provider_redhat_enabled %><enabled><%= @vulnerability_detector_provider_redhat_enabled %></enabled><% end %>
-    <% if @vulnerability_detector_provider_redhat_update_from_year %><update_from_year><%= @vulnerability_detector_provider_redhat_update_from_year %></update_from_year><% end %>
     <% if @vulnerability_detector_provider_redhat_update_interval %><update_interval><%= @vulnerability_detector_provider_redhat_update_interval %></update_interval><% end %>
     <% if !@vulnerability_detector_provider_redhat_os.empty? %>
     <% @vulnerability_detector_provider_redhat_os.each do |os| %>
@@ -41,9 +40,8 @@
 <% if @vulnerability_detector_provider_nvd %>
   <provider name="nvd">
     <% if @vulnerability_detector_provider_nvd_enabled %><enabled><%= @vulnerability_detector_provider_nvd_enabled %></enabled><% end %>
-    <% if @vulnerability_detector_provider_nvd_update_from_year %><update_from_year><%= @vulnerability_detector_provider_nvd_update_from_year %></update_from_year><% end %>
     <% if @vulnerability_detector_provider_nvd_update_interval %><update_interval><%= @vulnerability_detector_provider_nvd_update_interval %></update_interval><% end %>
-  </provider>   
+  </provider>
 <% end %>
 <% if @vulnerability_detector_provider_arch %>
   <provider name="arch">
@@ -69,4 +67,3 @@
   </provider>
 <% end %>
 </vulnerability-detector>
-  


### PR DESCRIPTION
This PR deletes all variables and templates related to the update_from_year parameter