### PR TITLE
Decouple param_manager.pp from agent.pp

### DIFF
--- a/manifests/activeresponse.pp
+++ b/manifests/activeresponse.pp
@@ -17,9 +17,6 @@ define wazuh::activeresponse(
   $before_arg                         = undef,
   $content_arg                        = 'wazuh/fragments/_activeresponse.erb'
 ) {
-
-  require wazuh::params_manager
-
   concat::fragment { $active_response_name:
     target  => $target_arg,
     order   => $order_arg,


### PR DESCRIPTION
This PR deletes the dependencies between `wazuh::activeresponse` and `wazuh::params_manager` classes, generating dependency between OS supported list from Wazuh manager and Wazuh agent