### PR TITLE
Updating vulnerability detector default configuration with AlmaLinux support

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -198,6 +198,10 @@ class wazuh::manager (
       $vulnerability_detector_provider_msu_enabled           = $wazuh::params_manager::vulnerability_detector_provider_msu_enabled,
       $vulnerability_detector_provider_msu_update_interval   = $wazuh::params_manager::vulnerability_detector_provider_msu_update_interval,
 
+      $vulnerability_detector_provider_almalinux                    = $wazuh::params_manager::vulnerability_detector_provider_almalinux,
+      $vulnerability_detector_provider_almalinux_enabled            = $wazuh::params_manager::vulnerability_detector_provider_almalinux_enabled,
+      $vulnerability_detector_provider_almalinux_os                 = $wazuh::params_manager::vulnerability_detector_provider_almalinux_os,
+      $vulnerability_detector_provider_almalinux_update_interval    = $wazuh::params_manager::vulnerability_detector_provider_almalinux_update_interval,
 
       # syslog
       $syslog_output                        = $wazuh::params_manager::syslog_output,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -209,6 +209,13 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_msu_enabled           = 'no'
       $vulnerability_detector_provider_msu_update_interval   = '1h'
 
+      $vulnerability_detector_provider_almalinux                 = 'yes'
+      $vulnerability_detector_provider_almalinux_enabled         = 'no'
+      $vulnerability_detector_provider_almalinux_os              = ['8',
+        '9'
+      ]
+      $vulnerability_detector_provider_almalinux_update_interval = '1h'
+
       $syslog_output                                   = false
       $syslog_output_level                             = 2
       $syslog_output_port                              = 514

--- a/templates/fragments/_vulnerability_detector.erb
+++ b/templates/fragments/_vulnerability_detector.erb
@@ -66,4 +66,15 @@
     <% if @vulnerability_detector_provider_msu_update_interval %><update_interval><%= @vulnerability_detector_provider_msu_update_interval %></update_interval><% end %>
   </provider>
 <% end %>
+<% if @vulnerability_detector_provider_almalinux %>
+  <provider name="almalinux">
+    <% if @vulnerability_detector_provider_almalinux_enabled %><enabled><%= @vulnerability_detector_provider_almalinux_enabled %></enabled><% end %>
+    <% if !@vulnerability_detector_provider_almalinux_os.empty? %>
+    <% @vulnerability_detector_provider_almalinux_os.each do |os| %>
+    <os><%= os %></os>
+    <% end %>
+    <% end %>
+    <% if @vulnerability_detector_provider_almalinux_update_interval %><update_interval><%= @vulnerability_detector_provider_almalinux_update_interval %></update_interval><% end %>
+  </provider>
+<% end %>
 </vulnerability-detector>


### PR DESCRIPTION
## Description

This PR adds the corresponding AlmaLinux entry in the vulnerability detector default configuration after the changes in [Add support for AlmaLinux in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/16343#top)
#16343.

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new AlmaLinux provider