### PR TITLE
Add Debian Bookworm to VDT default configuration

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -335,7 +335,7 @@ class wazuh::params_agent {
                 }
               }
             }
-            /^(wheezy|stretch|buster|bullseye|sid|precise|trusty|vivid|wily|xenial|bionic|focal|groovy|jammy)$/: {
+            /^(wheezy|stretch|buster|bullseye|bookworm|sid|precise|trusty|vivid|wily|xenial|bionic|focal|groovy|jammy)$/: {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $wodle_openscap_content = undef

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -460,7 +460,7 @@ class wazuh::params_manager {
                 }
               }
             }
-            /^(wheezy|stretch|buster|bullseye|sid|precise|trusty|vivid|wily|xenial|bionic|focal|groovy|jammy)$/: {
+            /^(wheezy|stretch|buster|bullseye|bookworm|sid|precise|trusty|vivid|wily|xenial|bionic|focal|groovy|jammy)$/: {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
               $wodle_openscap_content = undef

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -16,7 +16,7 @@ class wazuh::repo (
         server => 'pgp.mit.edu'
       }
       case $::lsbdistcodename {
-        /(jessie|wheezy|stretch|buster|bullseye|sid|precise|trusty|vivid|wily|xenial|yakketi|bionic|focal|groovy|jammy)/: {
+        /(jessie|wheezy|stretch|buster|bullseye|bookworm|sid|precise|trusty|vivid|wily|xenial|yakketi|bionic|focal|groovy|jammy)/: {
 
           apt::source { 'wazuh':
             ensure   => present,


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#18516|

## Description

This PR adds the corresponding Debian Bookworm entry in the vulnerability detector default configuration after the changes in [Add support for Debian Bookworm in Vulnerability Detector](https://github.com/wazuh/wazuh/pull/18516)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Debian Bookworm provider