### PR TITLE
Add Amazon Linux 2023 VDT default configuration

### DIFF
--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -201,8 +201,8 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_alas                   = 'yes'
       $vulnerability_detector_provider_alas_enabled           = 'no'
       $vulnerability_detector_provider_alas_os              = ['amazon-linux',
-      'amazon-linux-2', 
-      'amazon-linux-2023'
+        'amazon-linux-2', 
+        'amazon-linux-2023'
       ]
       $vulnerability_detector_provider_alas_update_interval   = '1h'
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -201,7 +201,8 @@ class wazuh::params_manager {
       $vulnerability_detector_provider_alas                   = 'yes'
       $vulnerability_detector_provider_alas_enabled           = 'no'
       $vulnerability_detector_provider_alas_os              = ['amazon-linux',
-      'amazon-linux-2'
+      'amazon-linux-2', 
+      'amazon-linux-2023'
       ]
       $vulnerability_detector_provider_alas_update_interval   = '1h'
 


### PR DESCRIPTION
|Related issue|
|---|
|wazuh/wazuh#17617|

## Description

This PR adds the corresponding Amazon Linux 2023 entry in the vulnerability detector default configuration after the changes in [Add support for Amazon Linux 2023 in Vulnerability Detector](https://github.com/wazuh/wazuh/issues/17617)

## DoD

- [x] Search for all the places where the vulnerability detector configuration block is defined and add the new Amazon Linux 2023 provider