### PR TITLE
Updated `wazuh_extensions_version` variable

### DIFF
--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -12,7 +12,7 @@ class wazuh::filebeat_oss (
   $filebeat_oss_elastic_password = 'admin',
   $filebeat_oss_version = '7.10.2',
   $wazuh_app_version = '4.6.0_7.10.2',
-  $wazuh_extensions_version = '4.6',
+  $wazuh_extensions_version = '4.6.0',
   $wazuh_filebeat_module = 'wazuh-filebeat-0.2.tar.gz',
 
   $filebeat_fileuser = 'root',

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -12,7 +12,7 @@ class wazuh::filebeat_oss (
   $filebeat_oss_elastic_password = 'admin',
   $filebeat_oss_version = '7.10.2',
   $wazuh_app_version = '4.6.0_7.10.2',
-  $wazuh_extensions_version = '4.6.0',
+  $wazuh_extensions_version = 'v4.6.0',
   $wazuh_filebeat_module = 'wazuh-filebeat-0.2.tar.gz',
 
   $filebeat_fileuser = 'root',


### PR DESCRIPTION
## Description
Closes: https://github.com/wazuh/wazuh-puppet/issues/769

This PR modifies the `wazuh_extensions_version` variable of the `filebeat-oss.pp` file from the `4.6` value to the `4.6.0` value.
https://github.com/wazuh/wazuh-puppet/blob/6e5490a0c612af967757ad408ce753f61bf99e19/manifests/filebeat_oss.pp#L15
This change is necessary as the branches 4.x do not exist anymore.

## Testing

A deployment with Puppet with this change was performed.


<details><summary>:green_circle: Installing Puppet server</summary>

```console
root@ubuntu22:/home/vagrant# nano /etc/hosts
root@ubuntu22:/home/vagrant# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:b2:39:cc brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    inet 10.0.2.15/24 metric 100 brd 10.0.2.255 scope global dynamic eth0
       valid_lft 86281sec preferred_lft 86281sec
    inet6 fe80::a00:27ff:feb2:39cc/64 scope link 
       valid_lft forever preferred_lft forever
3: eth1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 08:00:27:92:c4:cd brd ff:ff:ff:ff:ff:ff
    altname enp0s8
    inet 192.168.57.202/24 brd 192.168.57.255 scope global eth1
       valid_lft forever preferred_lft forever
    inet6 fe80::a00:27ff:fe92:c4cd/64 scope link 
       valid_lft forever preferred_lft forever
root@ubuntu22:/home/vagrant# nano /etc/hosts
root@ubuntu22:/home/vagrant# apt-get update
apt-get install curl apt-transport-https lsb-release wget
Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Get:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease [119 kB]
Get:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease [109 kB]
Get:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease [110 kB]
Get:5 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 Packages [972 kB]
Get:6 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main Translation-en [223 kB]
Get:7 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 c-n-f Metadata [15.6 kB]
Get:8 https://mirrors.edge.kernel.org/ubuntu jammy-updates/restricted amd64 Packages [843 kB]
Get:9 https://mirrors.edge.kernel.org/ubuntu jammy-updates/restricted Translation-en [136 kB]
Get:10 https://mirrors.edge.kernel.org/ubuntu jammy-updates/restricted amd64 c-n-f Metadata [536 B]
Get:11 https://mirrors.edge.kernel.org/ubuntu jammy-updates/universe amd64 Packages [979 kB]
Get:12 https://mirrors.edge.kernel.org/ubuntu jammy-updates/universe Translation-en [213 kB]
Get:13 https://mirrors.edge.kernel.org/ubuntu jammy-updates/universe amd64 c-n-f Metadata [21.8 kB]
Get:14 https://mirrors.edge.kernel.org/ubuntu jammy-updates/multiverse amd64 Packages [41.6 kB]
Get:15 https://mirrors.edge.kernel.org/ubuntu jammy-updates/multiverse Translation-en [9,768 B]
Get:16 https://mirrors.edge.kernel.org/ubuntu jammy-updates/multiverse amd64 c-n-f Metadata [476 B]
Get:17 https://mirrors.edge.kernel.org/ubuntu jammy-backports/main amd64 Packages [41.7 kB]
Get:18 https://mirrors.edge.kernel.org/ubuntu jammy-backports/main Translation-en [10.5 kB]
Get:19 https://mirrors.edge.kernel.org/ubuntu jammy-backports/main amd64 c-n-f Metadata [388 B]
Get:20 https://mirrors.edge.kernel.org/ubuntu jammy-backports/universe amd64 Packages [24.3 kB]
Get:21 https://mirrors.edge.kernel.org/ubuntu jammy-backports/universe Translation-en [16.4 kB]
Get:22 https://mirrors.edge.kernel.org/ubuntu jammy-backports/universe amd64 c-n-f Metadata [644 B]
Get:23 https://mirrors.edge.kernel.org/ubuntu jammy-security/main amd64 Packages [764 kB]
Get:24 https://mirrors.edge.kernel.org/ubuntu jammy-security/main Translation-en [165 kB]              
Get:25 https://mirrors.edge.kernel.org/ubuntu jammy-security/main amd64 c-n-f Metadata [11.3 kB]       
Get:26 https://mirrors.edge.kernel.org/ubuntu jammy-security/restricted amd64 Packages [826 kB]        
Get:27 https://mirrors.edge.kernel.org/ubuntu jammy-security/restricted Translation-en [133 kB]        
Get:28 https://mirrors.edge.kernel.org/ubuntu jammy-security/restricted amd64 c-n-f Metadata [536 B]   
Get:29 https://mirrors.edge.kernel.org/ubuntu jammy-security/universe amd64 Packages [781 kB]          
Get:30 https://mirrors.edge.kernel.org/ubuntu jammy-security/universe Translation-en [143 kB]          
Get:31 https://mirrors.edge.kernel.org/ubuntu jammy-security/universe amd64 c-n-f Metadata [16.7 kB]   
Get:32 https://mirrors.edge.kernel.org/ubuntu jammy-security/multiverse amd64 Packages [36.5 kB]       
Get:33 https://mirrors.edge.kernel.org/ubuntu jammy-security/multiverse Translation-en [7,060 B]       
Get:34 https://mirrors.edge.kernel.org/ubuntu jammy-security/multiverse amd64 c-n-f Metadata [260 B]   
Fetched 6,769 kB in 8s (876 kB/s)                                                                      
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
lsb-release is already the newest version (11.1.0ubuntu4).
wget is already the newest version (1.21.2-2ubuntu1).
The following additional packages will be installed:
  libcurl4
The following NEW packages will be installed:
  apt-transport-https
The following packages will be upgraded:
  curl libcurl4
2 upgraded, 1 newly installed, 0 to remove and 153 not upgraded.
Need to get 486 kB of archives.
After this operation, 175 kB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 https://mirrors.edge.kernel.org/ubuntu jammy-updates/universe amd64 apt-transport-https all 2.4.10 [1,510 B]
Get:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 curl amd64 7.81.0-1ubuntu1.13 [194 kB]
Get:3 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 libcurl4 amd64 7.81.0-1ubuntu1.13 [290 kB]
Fetched 486 kB in 1s (681 kB/s)   
Selecting previously unselected package apt-transport-https.
(Reading database ... 75640 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_2.4.10_all.deb ...
Unpacking apt-transport-https (2.4.10) ...
Preparing to unpack .../curl_7.81.0-1ubuntu1.13_amd64.deb ...
Unpacking curl (7.81.0-1ubuntu1.13) over (7.81.0-1ubuntu1.7) ...
Preparing to unpack .../libcurl4_7.81.0-1ubuntu1.13_amd64.deb ...
Unpacking libcurl4:amd64 (7.81.0-1ubuntu1.13) over (7.81.0-1ubuntu1.7) ...
Setting up apt-transport-https (2.4.10) ...
Setting up libcurl4:amd64 (7.81.0-1ubuntu1.13) ...
Setting up curl (7.81.0-1ubuntu1.13) ...
Processing triggers for man-db (2.10.2-1) ...
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Scanning processes...                                                                                   
Scanning linux images...                                                                                

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
root@ubuntu22:/home/vagrant# wget https://apt.puppet.com/puppet7-release-focal.deb
dpkg -i puppet7-release-focal.deb
apt-get update
apt-get install -y puppetserver
--2023-09-12 08:20:40--  https://apt.puppet.com/puppet7-release-focal.deb
Resolving apt.puppet.com (apt.puppet.com)... 13.225.34.70, 13.225.34.117, 13.225.34.53, ...
Connecting to apt.puppet.com (apt.puppet.com)|13.225.34.70|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11318 (11K) [application/x-debian-package]
Saving to: ‘puppet7-release-focal.deb’

puppet7-release-focal.deb 100%[=====================================>]  11.05K  --.-KB/s    in 0.006s  

2023-09-12 08:20:41 (1.90 MB/s) - ‘puppet7-release-focal.deb’ saved [11318/11318]

Selecting previously unselected package puppet7-release.
(Reading database ... 75644 files and directories currently installed.)
Preparing to unpack puppet7-release-focal.deb ...
Unpacking puppet7-release (7.0.0-14focal) ...
Setting up puppet7-release (7.0.0-14focal) ...
Hit:1 https://mirrors.edge.kernel.org/ubuntu jammy InRelease
Hit:2 https://mirrors.edge.kernel.org/ubuntu jammy-updates InRelease
Hit:3 https://mirrors.edge.kernel.org/ubuntu jammy-backports InRelease
Hit:4 https://mirrors.edge.kernel.org/ubuntu jammy-security InRelease
Get:5 http://apt.puppet.com focal InRelease [128 kB]
Get:6 http://apt.puppet.com focal/puppet7 all Packages [17.9 kB]
Get:7 http://apt.puppet.com focal/puppet7 amd64 Packages [35.0 kB]
Fetched 181 kB in 1s (134 kB/s)  
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following additional packages will be installed:
  ca-certificates-java fontconfig-config fonts-dejavu-core java-common libavahi-client3
  libavahi-common-data libavahi-common3 libcups2 libfontconfig1 libjpeg-turbo8 libjpeg8 liblcms2-2
  libpcsclite1 libxi6 libxrender1 libxtst6 net-tools openjdk-8-jre-headless puppet-agent x11-common
Suggested packages:
  default-jre cups-common liblcms2-utils pcscd libnss-mdns fonts-dejavu-extra fonts-nanum
  fonts-ipafont-gothic fonts-ipafont-mincho fonts-wqy-microhei fonts-wqy-zenhei fonts-indic
The following NEW packages will be installed:
  ca-certificates-java fontconfig-config fonts-dejavu-core java-common libavahi-client3
  libavahi-common-data libavahi-common3 libcups2 libfontconfig1 libjpeg-turbo8 libjpeg8 liblcms2-2
  libpcsclite1 libxi6 libxrender1 libxtst6 net-tools openjdk-8-jre-headless puppet-agent puppetserver
  x11-common
0 upgraded, 21 newly installed, 0 to remove and 153 not upgraded.
Need to get 137 MB of archives.
After this operation, 323 MB of additional disk space will be used.
Get:1 http://apt.puppet.com focal/puppet7 amd64 puppet-agent amd64 7.26.0-1focal [31.5 MB]
Get:2 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 java-common all 0.72build2 [6,782 B]
Get:3 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 libavahi-common-data amd64 0.8-5ubuntu5.1 [23.5 kB]
Get:4 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 libavahi-common3 amd64 0.8-5ubuntu5.1 [23.7 kB]
Get:5 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 libavahi-client3 amd64 0.8-5ubuntu5.1 [28.0 kB]
Get:6 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 libcups2 amd64 2.4.1op1-1ubuntu4.4 [264 kB]
Get:7 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 liblcms2-2 amd64 2.12~rc1-2build2 [159 kB]
Get:8 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 libjpeg-turbo8 amd64 2.1.2-0ubuntu1 [134 kB]
Get:9 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 fonts-dejavu-core all 2.37-2build1 [1,041 kB]
Get:10 http://apt.puppet.com focal/puppet7 amd64 puppetserver all 7.13.0-1focal [72.9 MB]              
Get:11 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 fontconfig-config all 2.13.1-4.2ubuntu5 [29.1 kB]
Get:12 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 libfontconfig1 amd64 2.13.1-4.2ubuntu5 [131 kB]
Get:13 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 libjpeg8 amd64 8c-2ubuntu10 [2,264 B]   
Get:14 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 libpcsclite1 amd64 1.9.5-3ubuntu1 [19.8 kB]
Get:15 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 libxi6 amd64 2:1.8-1build1 [32.6 kB]    
Get:16 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 libxrender1 amd64 1:0.9.10-1build4 [19.7 kB]
Get:17 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 x11-common all 1:7.7+23ubuntu2 [23.4 kB]
Get:18 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 libxtst6 amd64 2:1.2.3-1build4 [13.4 kB]
Get:19 https://mirrors.edge.kernel.org/ubuntu jammy-updates/universe amd64 openjdk-8-jre-headless amd64 8u382-ga-1~22.04.1 [30.8 MB]
Get:20 https://mirrors.edge.kernel.org/ubuntu jammy-updates/main amd64 ca-certificates-java all 20190909ubuntu1.2 [12.1 kB]
Get:21 https://mirrors.edge.kernel.org/ubuntu jammy/main amd64 net-tools amd64 1.60+git20181103.0eebece-1ubuntu5 [204 kB]
Fetched 137 MB in 48s (2,886 kB/s)                                                                     
Selecting previously unselected package java-common.
(Reading database ... 75648 files and directories currently installed.)
Preparing to unpack .../00-java-common_0.72build2_all.deb ...
Unpacking java-common (0.72build2) ...
Selecting previously unselected package libavahi-common-data:amd64.
Preparing to unpack .../01-libavahi-common-data_0.8-5ubuntu5.1_amd64.deb ...
Unpacking libavahi-common-data:amd64 (0.8-5ubuntu5.1) ...
Selecting previously unselected package libavahi-common3:amd64.
Preparing to unpack .../02-libavahi-common3_0.8-5ubuntu5.1_amd64.deb ...
Unpacking libavahi-common3:amd64 (0.8-5ubuntu5.1) ...
Selecting previously unselected package libavahi-client3:amd64.
Preparing to unpack .../03-libavahi-client3_0.8-5ubuntu5.1_amd64.deb ...
Unpacking libavahi-client3:amd64 (0.8-5ubuntu5.1) ...
Selecting previously unselected package libcups2:amd64.
Preparing to unpack .../04-libcups2_2.4.1op1-1ubuntu4.4_amd64.deb ...
Unpacking libcups2:amd64 (2.4.1op1-1ubuntu4.4) ...
Selecting previously unselected package liblcms2-2:amd64.
Preparing to unpack .../05-liblcms2-2_2.12~rc1-2build2_amd64.deb ...
Unpacking liblcms2-2:amd64 (2.12~rc1-2build2) ...
Selecting previously unselected package libjpeg-turbo8:amd64.
Preparing to unpack .../06-libjpeg-turbo8_2.1.2-0ubuntu1_amd64.deb ...
Unpacking libjpeg-turbo8:amd64 (2.1.2-0ubuntu1) ...
Selecting previously unselected package fonts-dejavu-core.
Preparing to unpack .../07-fonts-dejavu-core_2.37-2build1_all.deb ...
Unpacking fonts-dejavu-core (2.37-2build1) ...
Selecting previously unselected package fontconfig-config.
Preparing to unpack .../08-fontconfig-config_2.13.1-4.2ubuntu5_all.deb ...
Unpacking fontconfig-config (2.13.1-4.2ubuntu5) ...
Selecting previously unselected package libfontconfig1:amd64.
Preparing to unpack .../09-libfontconfig1_2.13.1-4.2ubuntu5_amd64.deb ...
Unpacking libfontconfig1:amd64 (2.13.1-4.2ubuntu5) ...
Selecting previously unselected package libjpeg8:amd64.
Preparing to unpack .../10-libjpeg8_8c-2ubuntu10_amd64.deb ...
Unpacking libjpeg8:amd64 (8c-2ubuntu10) ...
Selecting previously unselected package libpcsclite1:amd64.
Preparing to unpack .../11-libpcsclite1_1.9.5-3ubuntu1_amd64.deb ...
Unpacking libpcsclite1:amd64 (1.9.5-3ubuntu1) ...
Selecting previously unselected package libxi6:amd64.
Preparing to unpack .../12-libxi6_2%3a1.8-1build1_amd64.deb ...
Unpacking libxi6:amd64 (2:1.8-1build1) ...
Selecting previously unselected package libxrender1:amd64.
Preparing to unpack .../13-libxrender1_1%3a0.9.10-1build4_amd64.deb ...
Unpacking libxrender1:amd64 (1:0.9.10-1build4) ...
Selecting previously unselected package x11-common.
Preparing to unpack .../14-x11-common_1%3a7.7+23ubuntu2_all.deb ...
Unpacking x11-common (1:7.7+23ubuntu2) ...
Selecting previously unselected package libxtst6:amd64.
Preparing to unpack .../15-libxtst6_2%3a1.2.3-1build4_amd64.deb ...
Unpacking libxtst6:amd64 (2:1.2.3-1build4) ...
Selecting previously unselected package openjdk-8-jre-headless:amd64.
Preparing to unpack .../16-openjdk-8-jre-headless_8u382-ga-1~22.04.1_amd64.deb ...
Unpacking openjdk-8-jre-headless:amd64 (8u382-ga-1~22.04.1) ...
Selecting previously unselected package ca-certificates-java.
Preparing to unpack .../17-ca-certificates-java_20190909ubuntu1.2_all.deb ...
Unpacking ca-certificates-java (20190909ubuntu1.2) ...
Selecting previously unselected package net-tools.
Preparing to unpack .../18-net-tools_1.60+git20181103.0eebece-1ubuntu5_amd64.deb ...
Unpacking net-tools (1.60+git20181103.0eebece-1ubuntu5) ...
Selecting previously unselected package puppet-agent.
Preparing to unpack .../19-puppet-agent_7.26.0-1focal_amd64.deb ...
Unpacking puppet-agent (7.26.0-1focal) ...
Selecting previously unselected package puppetserver.
Preparing to unpack .../20-puppetserver_7.13.0-1focal_all.deb ...
Unpacking puppetserver (7.13.0-1focal) ...
Setting up liblcms2-2:amd64 (2.12~rc1-2build2) ...
Setting up net-tools (1.60+git20181103.0eebece-1ubuntu5) ...
Setting up libxi6:amd64 (2:1.8-1build1) ...
Setting up java-common (0.72build2) ...
Setting up libxrender1:amd64 (1:0.9.10-1build4) ...
Setting up x11-common (1:7.7+23ubuntu2) ...
Setting up libavahi-common-data:amd64 (0.8-5ubuntu5.1) ...
Setting up fonts-dejavu-core (2.37-2build1) ...
Setting up libpcsclite1:amd64 (1.9.5-3ubuntu1) ...
Setting up libjpeg-turbo8:amd64 (2.1.2-0ubuntu1) ...
Setting up puppet-agent (7.26.0-1focal) ...
Created symlink /etc/systemd/system/multi-user.target.wants/pxp-agent.service → /lib/systemd/system/pxp-agent.service.
Created symlink /etc/systemd/system/multi-user.target.wants/puppet.service → /lib/systemd/system/puppet.service.
Removed /etc/systemd/system/multi-user.target.wants/pxp-agent.service.
Setting up libjpeg8:amd64 (8c-2ubuntu10) ...
Setting up fontconfig-config (2.13.1-4.2ubuntu5) ...
Setting up libxtst6:amd64 (2:1.2.3-1build4) ...
Setting up libavahi-common3:amd64 (0.8-5ubuntu5.1) ...
Setting up libfontconfig1:amd64 (2.13.1-4.2ubuntu5) ...
Setting up libavahi-client3:amd64 (0.8-5ubuntu5.1) ...
Setting up libcups2:amd64 (2.4.1op1-1ubuntu4.4) ...
Setting up openjdk-8-jre-headless:amd64 (8u382-ga-1~22.04.1) ...
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java to provide /usr/bin/java (java) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/jjs to provide /usr/bin/jjs (jjs) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/keytool to provide /usr/bin/keytool (keytool) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/pack200 to provide /usr/bin/pack200 (pack200) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmid to provide /usr/bin/rmid (rmid) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/rmiregistry to provide /usr/bin/rmiregistry (rmiregistry) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/unpack200 to provide /usr/bin/unpack200 (unpack200) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/orbd to provide /usr/bin/orbd (orbd) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/servertool to provide /usr/bin/servertool (servertool) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/tnameserv to provide /usr/bin/tnameserv (tnameserv) in auto mode
update-alternatives: using /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jexec to provide /usr/bin/jexec (jexec) in auto mode
Setting up ca-certificates-java (20190909ubuntu1.2) ...
head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
Adding debian:Certum_EC-384_CA.pem
Adding debian:DigiCert_Global_Root_G2.pem
Adding debian:GTS_Root_R4.pem
Adding debian:Buypass_Class_3_Root_CA.pem
Adding debian:Go_Daddy_Root_Certificate_Authority_-_G2.pem
Adding debian:emSign_Root_CA_-_G1.pem
Adding debian:Go_Daddy_Class_2_CA.pem
Adding debian:Comodo_AAA_Services_root.pem
Adding debian:SSL.com_EV_Root_Certification_Authority_RSA_R2.pem
Adding debian:ePKI_Root_Certification_Authority.pem
Adding debian:E-Tugra_Certification_Authority.pem
Adding debian:Entrust.net_Premium_2048_Secure_Server_CA.pem
Adding debian:AffirmTrust_Premium.pem
Adding debian:GlobalSign_Root_CA_-_R2.pem
Adding debian:Staat_der_Nederlanden_EV_Root_CA.pem
Adding debian:AC_RAIZ_FNMT-RCM.pem
Adding debian:OISTE_WISeKey_Global_Root_GB_CA.pem
Adding debian:Trustwave_Global_ECC_P384_Certification_Authority.pem
Adding debian:Hellenic_Academic_and_Research_Institutions_RootCA_2011.pem
Adding debian:GlobalSign_Root_CA_-_R3.pem
Adding debian:ISRG_Root_X1.pem
Adding debian:GlobalSign_Root_CA_-_R6.pem
Adding debian:Entrust_Root_Certification_Authority_-_G2.pem
Adding debian:OISTE_WISeKey_Global_Root_GC_CA.pem
Adding debian:GlobalSign_Root_CA.pem
Adding debian:Security_Communication_RootCA2.pem
Adding debian:QuoVadis_Root_CA_1_G3.pem
Adding debian:Hellenic_Academic_and_Research_Institutions_RootCA_2015.pem
Adding debian:Izenpe.com.pem
Adding debian:Certum_Trusted_Network_CA.pem
Adding debian:Amazon_Root_CA_3.pem
Adding debian:Amazon_Root_CA_2.pem
Adding debian:Hellenic_Academic_and_Research_Institutions_ECC_RootCA_2015.pem
Adding debian:emSign_Root_CA_-_C1.pem
Adding debian:Starfield_Class_2_CA.pem
Adding debian:TWCA_Root_Certification_Authority.pem
Adding debian:e-Szigno_Root_CA_2017.pem
Adding debian:Amazon_Root_CA_4.pem
Adding debian:D-TRUST_Root_Class_3_CA_2_EV_2009.pem
Adding debian:QuoVadis_Root_CA_2_G3.pem
Adding debian:GTS_Root_R3.pem
Adding debian:T-TeleSec_GlobalRoot_Class_2.pem
Adding debian:QuoVadis_Root_CA_3.pem
Adding debian:SecureTrust_CA.pem
Adding debian:AC_RAIZ_FNMT-RCM_SERVIDORES_SEGUROS.pem
Adding debian:XRamp_Global_CA_Root.pem
Adding debian:Certum_Trusted_Root_CA.pem
Adding debian:COMODO_RSA_Certification_Authority.pem
Adding debian:ANF_Secure_Server_Root_CA.pem
Adding debian:SwissSign_Silver_CA_-_G2.pem
Adding debian:SecureSign_RootCA11.pem
Adding debian:TeliaSonera_Root_CA_v1.pem
Adding debian:DigiCert_Global_Root_G3.pem
Adding debian:Microsec_e-Szigno_Root_CA_2009.pem
Adding debian:Microsoft_RSA_Root_Certificate_Authority_2017.pem
Adding debian:ACCVRAIZ1.pem
Adding debian:IdenTrust_Public_Sector_Root_CA_1.pem
Adding debian:SSL.com_Root_Certification_Authority_ECC.pem
Adding debian:emSign_ECC_Root_CA_-_C3.pem
Adding debian:Baltimore_CyberTrust_Root.pem
Adding debian:GTS_Root_R2.pem
Adding debian:AffirmTrust_Premium_ECC.pem
Adding debian:Actalis_Authentication_Root_CA.pem
Adding debian:Starfield_Root_Certificate_Authority_-_G2.pem
Adding debian:DigiCert_Assured_ID_Root_CA.pem
Adding debian:DigiCert_High_Assurance_EV_Root_CA.pem
Adding debian:USERTrust_ECC_Certification_Authority.pem
Adding debian:Secure_Global_CA.pem
Adding debian:Entrust_Root_Certification_Authority_-_EC1.pem
Adding debian:UCA_Global_G2_Root.pem
Adding debian:Certigna_Root_CA.pem
Adding debian:Autoridad_de_Certificacion_Firmaprofesional_CIF_A62634068.pem
Adding debian:certSIGN_Root_CA_G2.pem
Adding debian:Atos_TrustedRoot_2011.pem
Adding debian:certSIGN_ROOT_CA.pem
Adding debian:COMODO_Certification_Authority.pem
Adding debian:TWCA_Global_Root_CA.pem
Adding debian:SSL.com_EV_Root_Certification_Authority_ECC.pem
Adding debian:T-TeleSec_GlobalRoot_Class_3.pem
Adding debian:SwissSign_Gold_CA_-_G2.pem
Adding debian:DigiCert_Trusted_Root_G4.pem
Adding debian:DigiCert_Assured_ID_Root_G3.pem
Adding debian:Hongkong_Post_Root_CA_3.pem
Adding debian:Hongkong_Post_Root_CA_1.pem
Adding debian:IdenTrust_Commercial_Root_CA_1.pem
Adding debian:NetLock_Arany_=Class_Gold=_Főtanúsítvány.pem
Adding debian:SSL.com_Root_Certification_Authority_RSA.pem
Adding debian:UCA_Extended_Validation_Root.pem
Adding debian:Certigna.pem
Adding debian:Trustwave_Global_Certification_Authority.pem
Adding debian:GlobalSign_Root_R46.pem
Adding debian:GlobalSign_ECC_Root_CA_-_R4.pem
Adding debian:GLOBALTRUST_2020.pem
Adding debian:NAVER_Global_Root_Certification_Authority.pem
Adding debian:QuoVadis_Root_CA_3_G3.pem
Adding debian:Entrust_Root_Certification_Authority_-_G4.pem
Adding debian:EC-ACC.pem
Adding debian:Starfield_Services_Root_Certificate_Authority_-_G2.pem
Adding debian:AffirmTrust_Commercial.pem
Adding debian:CA_Disig_Root_R2.pem
Adding debian:Network_Solutions_Certificate_Authority.pem
Adding debian:Certum_Trusted_Network_CA_2.pem
Adding debian:Security_Communication_Root_CA.pem
Adding debian:DigiCert_Global_Root_CA.pem
Adding debian:GlobalSign_Root_E46.pem
Adding debian:COMODO_ECC_Certification_Authority.pem
Adding debian:GlobalSign_ECC_Root_CA_-_R5.pem
Adding debian:Cybertrust_Global_Root.pem
Adding debian:Microsoft_ECC_Root_Certificate_Authority_2017.pem
Adding debian:GDCA_TrustAUTH_R5_ROOT.pem
Adding debian:D-TRUST_Root_Class_3_CA_2_2009.pem
Adding debian:QuoVadis_Root_CA_2.pem
Adding debian:Buypass_Class_2_Root_CA.pem
Adding debian:TUBITAK_Kamu_SM_SSL_Kok_Sertifikasi_-_Surum_1.pem
Adding debian:emSign_ECC_Root_CA_-_G3.pem
Adding debian:Trustwave_Global_ECC_P256_Certification_Authority.pem
Adding debian:Amazon_Root_CA_1.pem
Adding debian:Entrust_Root_Certification_Authority.pem
Adding debian:USERTrust_RSA_Certification_Authority.pem
Adding debian:GTS_Root_R1.pem
Adding debian:CFCA_EV_ROOT.pem
Adding debian:SZAFIR_ROOT_CA2.pem
Adding debian:DigiCert_Assured_ID_Root_G2.pem
Adding debian:AffirmTrust_Networking.pem
done.
Setting up puppetserver (7.13.0-1focal) ...
usermod: no changes
Processing triggers for libc-bin (2.35-0ubuntu3.1) ...
Processing triggers for man-db (2.10.2-1) ...
Processing triggers for ca-certificates (20211016ubuntu0.22.04.1) ...
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...

done.
done.
Scanning processes...                                                                                   
Scanning linux images...                                                                                

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
root@ubuntu22:/home/vagrant# ln -s /opt/puppetlabs/bin/puppet /bin
ln -s /opt/puppetlabs/server/bin/puppetserver /bin
root@ubuntu22:/home/vagrant# nano /etc/default/puppetserver
root@ubuntu22:/home/vagrant# nano /etc/puppetlabs/puppet/puppet.conf
root@ubuntu22:/home/vagrant# nano /etc/puppetlabs/puppet/puppet.conf
root@ubuntu22:/home/vagrant# systemctl start puppetserver
systemctl enable puppetserver
systemctl status puppetserver
Synchronizing state of puppetserver.service with SysV service script with /lib/systemd/systemd-sysv-install.
Executing: /lib/systemd/systemd-sysv-install enable puppetserver
Created symlink /etc/systemd/system/multi-user.target.wants/puppetserver.service → /lib/systemd/system/puppetserver.service.
● puppetserver.service - puppetserver Service
     Loaded: loaded (/lib/systemd/system/puppetserver.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-09-12 08:25:32 UTC; 417ms ago
   Main PID: 4301 (java)
      Tasks: 48 (limit: 4915)
     Memory: 713.9M
        CPU: 21.652s
     CGroup: /system.slice/puppetserver.service
             └─4301 /usr/bin/java -Xms1g -Xmx1g -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.S>

Sep 12 08:25:20 ubuntu22 systemd[1]: Starting puppetserver Service...
Sep 12 08:25:22 ubuntu22 puppetserver[4301]: WARNING: abs already refers to: #'clojure.core/abs in name>
Sep 12 08:25:32 ubuntu22 systemd[1]: Started puppetserver Service.
Sep 12 08:25:32 ubuntu22 systemd[1]: /lib/systemd/system/puppetserver.service:45: Standard output type >
Sep 12 08:25:32 ubuntu22 systemd[1]: /lib/systemd/system/puppetserver.service:45: Standard output type >
Sep 12 08:25:32 ubuntu22 systemd[1]: /lib/systemd/system/puppetserver.service:45: Standard output type >
(reverse-i-search)`nano /etc': ^Cstemctl enable puppetserver

```
</details>

<details><summary>:green_circle: Installing Puppet agent</summary>

```console
root@ubuntu20:/home/vagrant# nano /etc/hosts
root@ubuntu20:/home/vagrant# apt-get update
0% [Working]
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Hit:2 http://us.archive.ubuntu.com/ubuntu focal InRelease                          
Get:3 http://security.ubuntu.com/ubuntu focal-security/main i386 Packages [646 kB]
Get:4 http://us.archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:5 http://us.archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]                           
Get:6 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [2,434 kB]                  
Get:7 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2,821 kB]                 
Get:8 http://security.ubuntu.com/ubuntu focal-security/main Translation-en [381 kB]                    
Get:9 http://security.ubuntu.com/ubuntu focal-security/main amd64 c-n-f Metadata [13.1 kB]             
Get:10 http://security.ubuntu.com/ubuntu focal-security/restricted i386 Packages [32.3 kB]             
Get:11 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [2,173 kB]           
Get:12 http://security.ubuntu.com/ubuntu focal-security/restricted Translation-en [304 kB]             
Get:13 http://us.archive.ubuntu.com/ubuntu focal-updates/main i386 Packages [878 kB]                   
Get:14 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 c-n-f Metadata [580 B]        
Get:15 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [879 kB]               
Get:16 http://us.archive.ubuntu.com/ubuntu focal-updates/main Translation-en [465 kB]                  
Get:17 http://security.ubuntu.com/ubuntu focal-security/universe i386 Packages [613 kB]                
Get:18 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 c-n-f Metadata [17.0 kB]           
Get:19 http://us.archive.ubuntu.com/ubuntu focal-updates/restricted i386 Packages [33.7 kB]            
Get:20 http://us.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [2,287 kB]          
Get:21 http://security.ubuntu.com/ubuntu focal-security/universe Translation-en [184 kB]               
Get:22 http://security.ubuntu.com/ubuntu focal-security/universe amd64 c-n-f Metadata [19.1 kB]        
Get:23 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [23.6 kB]            
Get:24 http://security.ubuntu.com/ubuntu focal-security/multiverse i386 Packages [7,196 B]             
Get:25 http://security.ubuntu.com/ubuntu focal-security/multiverse Translation-en [5,504 B]            
Get:26 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 c-n-f Metadata [548 B]        
Get:27 http://us.archive.ubuntu.com/ubuntu focal-updates/restricted Translation-en [320 kB]            
Get:28 http://us.archive.ubuntu.com/ubuntu focal-updates/restricted amd64 c-n-f Metadata [576 B]       
Get:29 http://us.archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1,110 kB]            
Get:30 http://us.archive.ubuntu.com/ubuntu focal-updates/universe i386 Packages [746 kB]               
Get:31 http://us.archive.ubuntu.com/ubuntu focal-updates/universe Translation-en [265 kB]              
Get:32 http://us.archive.ubuntu.com/ubuntu focal-updates/universe amd64 c-n-f Metadata [25.5 kB]       
Get:33 http://us.archive.ubuntu.com/ubuntu focal-updates/multiverse i386 Packages [8,436 B]            
Get:34 http://us.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [25.8 kB]           
Get:35 http://us.archive.ubuntu.com/ubuntu focal-updates/multiverse Translation-en [7,484 B]           
Get:36 http://us.archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 c-n-f Metadata [620 B]       
Get:37 http://us.archive.ubuntu.com/ubuntu focal-backports/main i386 Packages [36.1 kB]                
Get:38 http://us.archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [45.7 kB]               
Get:39 http://us.archive.ubuntu.com/ubuntu focal-backports/main amd64 c-n-f Metadata [1,420 B]         
Get:40 http://us.archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [25.0 kB]           
Get:41 http://us.archive.ubuntu.com/ubuntu focal-backports/universe i386 Packages [13.8 kB]            
Get:42 http://us.archive.ubuntu.com/ubuntu focal-backports/universe amd64 c-n-f Metadata [880 B]       
Fetched 17.2 MB in 13s (1,374 kB/s)                                                                    
Reading package lists... Done
root@ubuntu20:/home/vagrant# apt-get install curl apt-transport-https lsb-release wget
Reading package lists... Done
Building dependency tree       
Reading state information... Done
lsb-release is already the newest version (11.1.0ubuntu2).
wget is already the newest version (1.20.3-1ubuntu2).
The following additional packages will be installed:
  libcurl4
The following NEW packages will be installed:
  apt-transport-https
The following packages will be upgraded:
  curl libcurl4
2 upgraded, 1 newly installed, 0 to remove and 138 not upgraded.
Need to get 398 kB of archives.
After this operation, 166 kB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 http://us.archive.ubuntu.com/ubuntu focal-updates/universe amd64 apt-transport-https all 2.0.9 [1,704 B]
Get:2 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 curl amd64 7.68.0-1ubuntu2.19 [161 kB]
Get:3 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 libcurl4 amd64 7.68.0-1ubuntu2.19 [235 kB]
Fetched 398 kB in 1s (420 kB/s) 
Selecting previously unselected package apt-transport-https.
(Reading database ... 111809 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_2.0.9_all.deb ...
Unpacking apt-transport-https (2.0.9) ...
Preparing to unpack .../curl_7.68.0-1ubuntu2.19_amd64.deb ...
Unpacking curl (7.68.0-1ubuntu2.19) over (7.68.0-1ubuntu2.15) ...
Preparing to unpack .../libcurl4_7.68.0-1ubuntu2.19_amd64.deb ...
Unpacking libcurl4:amd64 (7.68.0-1ubuntu2.19) over (7.68.0-1ubuntu2.15) ...
Setting up apt-transport-https (2.0.9) ...
Setting up libcurl4:amd64 (7.68.0-1ubuntu2.19) ...
Setting up curl (7.68.0-1ubuntu2.19) ...
Processing triggers for man-db (2.9.1-1) ...
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
root@ubuntu20:/home/vagrant# wget https://apt.puppet.com/puppet7-release-focal.deb
--2023-09-12 08:32:40--  https://apt.puppet.com/puppet7-release-focal.deb
Resolving apt.puppet.com (apt.puppet.com)... 108.157.98.82, 108.157.98.117, 108.157.98.35, ...
Connecting to apt.puppet.com (apt.puppet.com)|108.157.98.82|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 11318 (11K) [application/x-debian-package]
Saving to: ‘puppet7-release-focal.deb’

puppet7-release-focal.deb 100%[=====================================>]  11.05K  --.-KB/s    in 0.006s  

2023-09-12 08:32:40 (1.94 MB/s) - ‘puppet7-release-focal.deb’ saved [11318/11318]

root@ubuntu20:/home/vagrant# dpkg -i puppet7-release-focal.deb
Selecting previously unselected package puppet7-release.
(Reading database ... 111813 files and directories currently installed.)
Preparing to unpack puppet7-release-focal.deb ...
Unpacking puppet7-release (7.0.0-14focal) ...
Setting up puppet7-release (7.0.0-14focal) ...
root@ubuntu20:/home/vagrant# apt-get update
0% [Working]
Hit:1 http://us.archive.ubuntu.com/ubuntu focal InRelease
Hit:2 http://security.ubuntu.com/ubuntu focal-security InRelease
Hit:3 http://us.archive.ubuntu.com/ubuntu focal-updates InRelease
Hit:4 http://us.archive.ubuntu.com/ubuntu focal-backports InRelease
Get:5 http://apt.puppet.com focal InRelease [128 kB]
Get:6 http://apt.puppet.com focal/puppet7 i386 Packages [17.9 kB]
Get:7 http://apt.puppet.com focal/puppet7 all Packages [17.9 kB]
Get:8 http://apt.puppet.com focal/puppet7 amd64 Packages [35.0 kB]
Fetched 199 kB in 2s (110 kB/s)
Reading package lists... Done
root@ubuntu20:/home/vagrant# apt-get install -y puppet-agent
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following NEW packages will be installed:
  puppet-agent
0 upgraded, 1 newly installed, 0 to remove and 138 not upgraded.
Need to get 31.5 MB of archives.
After this operation, 112 MB of additional disk space will be used.
Get:1 http://apt.puppet.com focal/puppet7 amd64 puppet-agent amd64 7.26.0-1focal [31.5 MB]
Fetched 31.5 MB in 8s (3,744 kB/s)                                                                     
Selecting previously unselected package puppet-agent.
(Reading database ... 111817 files and directories currently installed.)
Preparing to unpack .../puppet-agent_7.26.0-1focal_amd64.deb ...
Unpacking puppet-agent (7.26.0-1focal) ...
Setting up puppet-agent (7.26.0-1focal) ...
Created symlink /etc/systemd/system/multi-user.target.wants/pxp-agent.service → /lib/systemd/system/pxp-agent.service.
Created symlink /etc/systemd/system/multi-user.target.wants/puppet.service → /lib/systemd/system/puppet.service.
Removed /etc/systemd/system/multi-user.target.wants/pxp-agent.service.
Processing triggers for libc-bin (2.31-0ubuntu9.9) ...
root@ubuntu20:/home/vagrant# ln -s /opt/puppetlabs/bin/puppet /bin
root@ubuntu20:/home/vagrant# nano /etc/puppetlabs/puppet/puppet.conf
root@ubuntu20:/home/vagrant# puppet resource service puppet ensure=running enable=true
Notice: /Service[puppet]/ensure: ensure changed 'stopped' to 'running'
service { 'puppet':
  ensure   => 'running',
  enable   => 'true',
  provider => 'systemd',
}
root@ubuntu20:/home/vagrant# sudo systemctl status puppet
● puppet.service - Puppet agent
     Loaded: loaded (/lib/systemd/system/puppet.service; enabled; vendor preset: enabled)
     Active: active (running) since Tue 2023-09-12 08:33:35 UTC; 4s ago
       Docs: man:puppet-agent(8)
   Main PID: 3820 (puppet)
      Tasks: 2 (limit: 4612)
     Memory: 61.5M
     CGroup: /system.slice/puppet.service
             └─3820 /opt/puppetlabs/puppet/bin/ruby /opt/puppetlabs/puppet/bin/puppet agent --no-daemon>

Sep 12 08:33:35 ubuntu20 systemd[1]: Started Puppet agent.
Sep 12 08:33:36 ubuntu20 puppet-agent[3820]: Starting Puppet client version 7.26.0
root@ubuntu20:/home/vagrant# 


```
</details>

<details><summary>:green_circle: Setting up certificates</summary>

In the agent:
```console
root@ubuntu20:/home/vagrant# puppet agent -t
Info: csr_attributes file loading from /etc/puppetlabs/puppet/csr_attributes.yaml
Info: Creating a new SSL certificate request for ubuntu20
Info: Certificate Request fingerprint (SHA256): 25:85:F4:3C:B0:E0:82:1D:07:65:D4:E0:99:7F:B9:AE:19:E3:E9:F9:03:D9:5C:9F:E1:5E:11:0F:C2:90:CB:F2
Info: Certificate for ubuntu20 has not been signed yet
Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (ubuntu20).
Exiting now because the waitforcert setting is set to 0.

```

In the server:
```console
root@ubuntu20:/home/vagrant# puppet agent -t
Info: csr_attributes file loading from /etc/puppetlabs/puppet/csr_attributes.yaml
Info: Creating a new SSL certificate request for ubuntu20
Info: Certificate Request fingerprint (SHA256): 25:85:F4:3C:B0:E0:82:1D:07:65:D4:E0:99:7F:B9:AE:19:E3:E9:F9:03:D9:5C:9F:E1:5E:11:0F:C2:90:CB:F2
Info: Certificate for ubuntu20 has not been signed yet
Couldn't fetch certificate from CA server; you might still need to sign this agent's certificate (ubuntu20).
Exiting now because the waitforcert setting is set to 0.
```

In the agent again:
```console
root@ubuntu20:/home/vagrant# puppet agent -t
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Caching catalog for ubuntu20
Info: Applying configuration version '1694515681'
Notice: Applied catalog in 0.00 seconds
```
</details>

<details><summary>:green_circle: Wazuh Puppet module</summary>

Edited the `repo.pp` file to adapt it to `packages-dev.wazuh.com` and `pre-release`.
Edited the `filebeat-oss.pp` file to change `4.6` to `4.6.0`

```console
root@ubuntu22:/home/vagrant# wget https://github.com/wazuh/wazuh-puppet/tarball/4.6.0
--2023-09-12 11:39:20--  https://github.com/wazuh/wazuh-puppet/tarball/4.6.0
Resolving github.com (github.com)... 140.82.121.3
Connecting to github.com (github.com)|140.82.121.3|:443... connected.
HTTP request sent, awaiting response... 302 Found
Location: https://codeload.github.com/wazuh/wazuh-puppet/legacy.tar.gz/refs/heads/4.6.0 [following]
--2023-09-12 11:39:20--  https://codeload.github.com/wazuh/wazuh-puppet/legacy.tar.gz/refs/heads/4.6.0
Resolving codeload.github.com (codeload.github.com)... 140.82.121.10
Connecting to codeload.github.com (codeload.github.com)|140.82.121.10|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: unspecified [application/x-gzip]
Saving to: ‘4.6.0’

4.6.0                         [ <=>                                  ]  63.25K  --.-KB/s    in 0.1s    

2023-09-12 11:39:21 (591 KB/s) - ‘4.6.0’ saved [64768]

root@ubuntu22:/home/vagrant# ls
4.6.0  puppet7-release-focal.deb
root@ubuntu22:/home/vagrant# puppet module install /home/vagrant/4.6.0
Notice: Preparing to install into /etc/puppetlabs/code/environments/production/modules ...
Notice: Downloading from https://forgeapi.puppet.com ...
Notice: Installing -- do not interrupt ...
/etc/puppetlabs/code/environments/production/modules
└─┬ wazuh-wazuh (v4.6.0)
  ├── puppet-archive (v6.1.2)
  ├── puppet-nodejs (v7.0.1)
  ├── puppet-selinux (v3.4.1)
  ├── puppetlabs-apt (v7.7.1)
  ├─┬ puppetlabs-concat (v6.4.0)
  │ └── puppetlabs-translate (v2.2.0)
  ├── puppetlabs-firewall (v2.8.1)
  ├─┬ puppetlabs-powershell (v4.1.0)
  │ └── puppetlabs-pwshlib (v1.0.0)
  └── puppetlabs-stdlib (v6.6.0)       
root@ubuntu22:/home/vagrant# nano /etc/puppetlabs/code/environments/production/modules/wazuh/manifests/repo.pp 
root@ubuntu22:/home/vagrant# nano /etc/puppetlabs/code/environments/production/modules/wazuh/manifests/filebeat_oss.pp 


```
</details>


<details><summary>:green_circle: Install Wazuh stack</summary>

```console
root@ubuntu20:/home/vagrant# puppet agent -t
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Info: Caching catalog for ubuntu20
Info: Applying configuration version '1694521361'
Notice: /Stage[main]/Wazuh::Indexer/Exec[ensure full path of /etc/wazuh-indexer/certs]/returns: executed successfully
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs]/owner: owner changed 'root' to 'wazuh-indexer'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs]/group: group changed 'root' to 'wazuh-indexer'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs]/mode: mode changed '0755' to '0500'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/indexer.pem]/ensure: defined content as '{sha256}22caf38dc695aadb0c159d0cfdbb44cca6c949e7114ed57ee84d56a38828c4f8'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/indexer-key.pem]/ensure: defined content as '{sha256}5769f730947ff57b14673a7af29f43f38c5572ed2fe36e7e69515818f7893d29'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/root-ca.pem]/ensure: defined content as '{sha256}8205a2575219f5ccc77fbb2e41ef35adb5bbcb96e7a42393cf9b1e5831f9e78d'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/admin.pem]/ensure: defined content as '{sha256}8656b56d9f57d1d51df48c4019182e98b6e10fd534c7fb5c1675da16f6cf5720'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/admin-key.pem]/ensure: defined content as '{sha256}ac7742bb86b5a70d6c718034813b9eed5562e5897ed68ffb82b4e7eb56e965f6'
Notice: /Stage[main]/Wazuh::Indexer/File[configuration file]/content: 
--- /etc/wazuh-indexer/opensearch.yml	2023-09-06 20:21:01.000000000 +0000
+++ /tmp/puppet-file20230912-48203-qaa14j	2023-09-12 12:22:43.230447782 +0000
@@ -2,16 +2,10 @@
 node.name: "node-1"
 cluster.initial_master_nodes:
 - "node-1"
-#- "node-2"
-#- "node-3"
 cluster.name: "wazuh-cluster"
-#discovery.seed_hosts:
-#  - "node-1-ip"
-#  - "node-2-ip"
-#  - "node-3-ip"
-node.max_local_storage_nodes: "3"
-path.data: /var/lib/wazuh-indexer
-path.logs: /var/log/wazuh-indexer
+node.max_local_storage_nodes: "1"
+path.data: "/var/lib/wazuh-indexer"
+path.logs: "/var/log/wazuh-indexer"
 
 plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/indexer.pem
 plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-key.pem
@@ -29,14 +23,12 @@
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
 - "CN=node-1,OU=Wazuh,O=Wazuh,L=California,C=US"
-#- "CN=node-2,OU=Wazuh,O=Wazuh,L=California,C=US"
-#- "CN=node-3,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
 
 ### Option to allow Filebeat-oss 7.10.2 to work ###
-compatibility.override_main_response_version: true
\ No newline at end of file
+compatibility.override_main_response_version: true

Notice: /Stage[main]/Wazuh::Indexer/File[configuration file]/content: content changed '{sha256}d95d40b8ee093f122d8015d4a267eddbd92ba3e323c70f2ac7ab7d8ff9e584fe' to '{sha256}9e09ebb124ae8798fbd3a7643bdb0f29a4376d50ca9cb6b9d137a76f18b55e65'
Info: /Stage[main]/Wazuh::Indexer/File[configuration file]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]: Unscheduling refresh on Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[Initialize the Opensearch security index in Wazuh indexer]/returns: executed successfully
Notice: /Stage[main]/Wazuh::Dashboard/Package[wazuh-dashboard]/ensure: created
Notice: /Stage[main]/Wazuh::Dashboard/Exec[ensure full path of /etc/wazuh-dashboard/certs]/returns: executed successfully
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/certs]/owner: owner changed 'root' to 'wazuh-dashboard'
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/certs]/group: group changed 'root' to 'wazuh-dashboard'
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/certs]/mode: mode changed '0755' to '0500'
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/certs/dashboard.pem]/ensure: defined content as '{sha256}419a8f512e66b8693abb5058d201ed928a2519571021842797de2fe2ff92256a'
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/certs/dashboard-key.pem]/ensure: defined content as '{sha256}e2016fc8785ff09d5dd6f2d1ab8810bdd2e1e25d8036556d3779492d154d6d53'
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/certs/root-ca.pem]/ensure: defined content as '{sha256}8205a2575219f5ccc77fbb2e41ef35adb5bbcb96e7a42393cf9b1e5831f9e78d'
Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/opensearch_dashboards.yml]/content: 
--- /etc/wazuh-dashboard/opensearch_dashboards.yml	2023-09-06 20:36:31.000000000 +0000
+++ /tmp/puppet-file20230912-48203-16gx9hu	2023-09-12 12:24:20.822447215 +0000
@@ -2,8 +2,8 @@
 server.port: 443
 opensearch.hosts: https://localhost:9200
 opensearch.ssl.verificationMode: certificate
-#opensearch.username:
-#opensearch.password:
+opensearch.username: kibanaserver
+opensearch.password: kibanaserver
 opensearch.requestHeadersWhitelist: ["securitytenant","Authorization"]
 opensearch_security.multitenancy.enabled: false
 opensearch_security.readonly_mode.roles: ["kibana_read_only"]
@@ -12,4 +12,3 @@
 server.ssl.certificate: "/etc/wazuh-dashboard/certs/dashboard.pem"
 opensearch.ssl.certificateAuthorities: ["/etc/wazuh-dashboard/certs/root-ca.pem"]
 uiSettings.overrides.defaultRoute: /app/wazuh
-

Notice: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/opensearch_dashboards.yml]/content: content changed '{sha256}2124a5b7d56f2430415b9cfb1d66dbd10f1ea0c416f6282538323417eaab75ee' to '{sha256}e7dcefa3591e0557500ae74c953d8d60ebbb5fd6e934bd7673443cbce47ef8a6'
Info: /Stage[main]/Wazuh::Dashboard/File[/etc/wazuh-dashboard/opensearch_dashboards.yml]: Scheduling refresh of Service[wazuh-dashboard]
Notice: /Stage[main]/Wazuh::Dashboard/File[/usr/share/wazuh-dashboard/data/wazuh/]/ensure: created
Notice: /Stage[main]/Wazuh::Dashboard/File[/usr/share/wazuh-dashboard/data/wazuh/config]/ensure: created
Notice: /Stage[main]/Wazuh::Dashboard/File[/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml]/ensure: defined content as '{sha256}797b2fd0b16994267394ffb667430d1e7d7f86d1789e27b6946f85e10376be8f'
Info: /Stage[main]/Wazuh::Dashboard/File[/usr/share/wazuh-dashboard/data/wazuh/config/wazuh.yml]: Scheduling refresh of Service[wazuh-dashboard]
Notice: /Stage[main]/Wazuh::Dashboard/Service[wazuh-dashboard]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Wazuh::Dashboard/Service[wazuh-dashboard]: Unscheduling refresh on Service[wazuh-dashboard]
Notice: Applied catalog in 98.64 seconds

```
</details>

<details><summary>:green_circle: Wazuh stack working correctly</summary>

![image](https://github.com/wazuh/wazuh-puppet/assets/72193239/e3db12ca-36f1-4f50-bd1a-4433b05a9445)

</details>