### PR TITLE
Fixed Wazuh indexer deployment error in Ubuntu 18

### DIFF
--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -145,7 +145,7 @@ class wazuh::indexer (
   }
 
   exec { 'Initialize the Opensearch security index in Wazuh indexer':
-    path    => ['/usr/bin', '/bin', '/usr/sbin'],
+    path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
     command => "/usr/share/wazuh-indexer/bin/indexer-security-init.sh && touch ${indexer_security_init_lockfile}",
     creates => $indexer_security_init_lockfile,
     require => Service['wazuh-indexer'],


### PR DESCRIPTION
## Description

Related issue: https://github.com/wazuh/wazuh/issues/19409

The aim of this PR is to fix the Wazuh indexer deployment in Ubuntu 18 systems. When deploying this component, an error was reporting that the `runuser` command was not found, even if the command was installed.

```console
Info: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]: Unscheduling refresh on Service[wazuh-indexer]
Error: /usr/share/wazuh-indexer/bin/indexer-security-init.sh: line 112: runuser: command not found

Error: /Stage[main]/Wazuh::Indexer/Exec[Initialize the Opensearch security index in Wazuh indexer]/returns: change from 'notrun' to ['0'] failed: /usr/share/wazuh-indexer/bin/indexer-security-init.sh: line 112: runuser: command not found
```

This PR modifies the path that the task uses, adding the `/sbin` path where the `runuser` is located in Ubuntu 18 systems.

## Testing

<details><summary>:green_circle: Indexer installation in Ubuntu 18 system</summary>

```console
root@indexer:/home/vagrant# puppet agent -t
Info: Using configured environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Notice: /File[/opt/puppetlabs/puppet/cache/locales/ja]/ensure: created
Notice: /File[/opt/puppetlabs/puppet/cache/locales/ja/puppetlabs-apt.po]/ensure: defined content as '{md5}129cd352e440bd317a8c5493d4fbf5f3'
Notice: /File[/opt/puppetlabs/puppet/cache/locales/ja/puppetlabs-concat.po]/ensure: defined content as '{md5}c9dad056a76901974ded7b150267573a'
Notice: /File[/opt/puppetlabs/puppet/cache/locales/ja/puppetlabs-stdlib.po]/ensure: defined content as '{md5}805e5d893d2025ad57da8ec0614a6753'
Info: Loading facts
Info: Caching catalog for indexer
Info: Applying configuration version '1696496118'
Notice: /Stage[main]/Wazuh::Certificates/File[Configure Wazuh Certificates config.yml]/ensure: defined content as '{md5}80e7f98468c8befcfe9971ae3f1d6609'
Notice: /Stage[main]/Wazuh::Certificates/File[/tmp/wazuh-certs-tool.sh]/ensure: defined content as '{mtime}2023-09-23 06:21:37 UTC'
Notice: /Stage[main]/Wazuh::Certificates/Exec[Create Wazuh Certificates]/returns: executed successfully
Notice: /Stage[main]/Wazuh::Indexer/File_line[Insert line limits nofile for wazuh-indexer]/ensure: created
Info: /Stage[main]/Wazuh::Indexer/File_line[Insert line limits nofile for wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/File_line[Insert line limits memlock for wazuh-indexer]/ensure: created
Info: /Stage[main]/Wazuh::Indexer/File_line[Insert line limits memlock for wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Repo/Apt::Key[wazuh]/Apt_key[wazuh]/ensure: created
Notice: /Stage[main]/Apt/File[preferences]/ensure: created
Info: /Stage[main]/Apt/File[preferences]: Scheduling refresh of Class[Apt::Update]
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/content: 
--- /etc/apt/apt.conf.d/15update-stamp	2021-05-14 18:43:17.000000000 +0000
+++ /tmp/puppet-file20231005-5202-96fhf1	2023-10-05 08:55:09.284564783 +0000
@@ -1 +1,2 @@
+// This file is managed by Puppet. DO NOT EDIT.
 APT::Update::Post-Invoke-Success {"touch /var/lib/apt/periodic/update-success-stamp 2>/dev/null || true";};

Info: Computing checksum on file /etc/apt/apt.conf.d/15update-stamp
Info: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]: Filebucketed /etc/apt/apt.conf.d/15update-stamp to puppet with sum b9de0ac9e2c9854b1bb213e362dc4e41
Notice: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]/content: content changed '{md5}b9de0ac9e2c9854b1bb213e362dc4e41' to '{md5}0962d70c4ec78bbfa6f3544ae0c41974'
Info: /Stage[main]/Apt/Apt::Setting[conf-update-stamp]/File[/etc/apt/apt.conf.d/15update-stamp]: Scheduling refresh of Class[Apt::Update]
Notice: /Stage[main]/Wazuh::Repo/Apt::Source[wazuh]/Apt::Setting[list-wazuh]/File[/etc/apt/sources.list.d/wazuh.list]/ensure: defined content as '{md5}b50d1939fbda19eba3f4910243e3ac3d'
Info: /Stage[main]/Wazuh::Repo/Apt::Source[wazuh]/Apt::Setting[list-wazuh]/File[/etc/apt/sources.list.d/wazuh.list]: Scheduling refresh of Class[Apt::Update]
Info: Class[Apt::Update]: Scheduling refresh of Exec[apt_update]
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Wazuh::Indexer/Package[wazuh-indexer]/ensure: created
Info: /Stage[main]/Wazuh::Indexer/Package[wazuh-indexer]: Scheduling refresh of Exec[set recusive ownership of /etc/wazuh-indexer]
Info: /Stage[main]/Wazuh::Indexer/Package[wazuh-indexer]: Scheduling refresh of Exec[set recusive ownership of /usr/share/wazuh-indexer]
Info: /Stage[main]/Wazuh::Indexer/Package[wazuh-indexer]: Scheduling refresh of Exec[set recusive ownership of /var/lib/wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[ensure full path of /etc/wazuh-indexer/certs]/returns: executed successfully
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs]/owner: owner changed 'root' to 'wazuh-indexer'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs]/group: group changed 'root' to 'wazuh-indexer'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs]/mode: mode changed '0755' to '0500'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/indexer.pem]/ensure: defined content as '{md5}bc69122dada73e8539a7491d47bc527f'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/indexer-key.pem]/ensure: defined content as '{md5}c10c9381549580d5196f9cb2ef6d4826'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/root-ca.pem]/ensure: defined content as '{md5}da51b59d264f7c1837c77f8f8a42b470'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/admin.pem]/ensure: defined content as '{md5}fd4555f83b83a591686dfbae45e36cda'
Notice: /Stage[main]/Wazuh::Indexer/File[/etc/wazuh-indexer/certs/admin-key.pem]/ensure: defined content as '{md5}9891657f2760eac3958a0f9e87b61f3f'
Notice: /Stage[main]/Wazuh::Indexer/File[configuration file]/content: 
--- /etc/wazuh-indexer/opensearch.yml	2023-09-22 21:18:30.000000000 +0000
+++ /tmp/puppet-file20231005-5202-7i59qh	2023-10-05 08:58:51.583658785 +0000
@@ -2,16 +2,10 @@
 node.name: "node-1"
 cluster.initial_master_nodes:
 - "node-1"
-#- "node-2"
-#- "node-3"
 cluster.name: "wazuh-cluster"
-#discovery.seed_hosts:
-#  - "node-1-ip"
-#  - "node-2-ip"
-#  - "node-3-ip"
-node.max_local_storage_nodes: "3"
-path.data: /var/lib/wazuh-indexer
-path.logs: /var/log/wazuh-indexer
+node.max_local_storage_nodes: "1"
+path.data: "/var/lib/wazuh-indexer"
+path.logs: "/var/log/wazuh-indexer"
 
 plugins.security.ssl.http.pemcert_filepath: /etc/wazuh-indexer/certs/indexer.pem
 plugins.security.ssl.http.pemkey_filepath: /etc/wazuh-indexer/certs/indexer-key.pem
@@ -29,14 +23,12 @@
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
 - "CN=node-1,OU=Wazuh,O=Wazuh,L=California,C=US"
-#- "CN=node-2,OU=Wazuh,O=Wazuh,L=California,C=US"
-#- "CN=node-3,OU=Wazuh,O=Wazuh,L=California,C=US"
 plugins.security.restapi.roles_enabled:
 - "all_access"
 - "security_rest_api_access"
 
 plugins.security.system_indices.enabled: true
-plugins.security.system_indices.indices: [".plugins-ml-model", ".plugins-ml-task", ".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opensearch-notifications-*", ".opensearch-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
+plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opensearch-observability", ".opendistro-asynchronous-search-response*", ".replication-metadata-store"]
 
 ### Option to allow Filebeat-oss 7.10.2 to work ###
-compatibility.override_main_response_version: true
\ No newline at end of file
+compatibility.override_main_response_version: true

Info: Computing checksum on file /etc/wazuh-indexer/opensearch.yml
Info: /Stage[main]/Wazuh::Indexer/File[configuration file]: Filebucketed /etc/wazuh-indexer/opensearch.yml to puppet with sum 9ee953958f2ca5d4b7753673aec33d42
Notice: /Stage[main]/Wazuh::Indexer/File[configuration file]/content: content changed '{md5}9ee953958f2ca5d4b7753673aec33d42' to '{md5}e7ccb3255cc6687a06c277be3fc7c239'
Info: /Stage[main]/Wazuh::Indexer/File[configuration file]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[set recusive ownership of /etc/wazuh-indexer]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Wazuh::Indexer/Exec[set recusive ownership of /etc/wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[set recusive ownership of /usr/share/wazuh-indexer]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Wazuh::Indexer/Exec[set recusive ownership of /usr/share/wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[set recusive ownership of /var/lib/wazuh-indexer]: Triggered 'refresh' from 1 event
Info: /Stage[main]/Wazuh::Indexer/Exec[set recusive ownership of /var/lib/wazuh-indexer]: Scheduling refresh of Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Wazuh::Indexer/Service[wazuh-indexer]: Unscheduling refresh on Service[wazuh-indexer]
Notice: /Stage[main]/Wazuh::Indexer/Exec[Initialize the Opensearch security index in Wazuh indexer]/returns: executed successfully
Notice: Applied catalog in 243.05 seconds
```
</details>

Adding `/sbin` to the path parameter does not have a negative impact on Puppet deployments in other systems as it is a directory that typically contains system administration binaries, and it is present on most Unix-like systems.