### PR TITLE
Merge 4.5.4 into 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 - Support to 4.6.0 Wazuh release.
 
+## Wazuh Puppet v4.5.4
+
+### Added
+
+- Support to 4.5.4 Wazuh release.
+
 ## Wazuh Puppet v4.5.3
 
 ### Added


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-puppet/issues/807
The aim of this PR is to bump the 4.5.4 branch into the 4.6.0 branch.