### PR TITLE
Merge 4.7.0 into 4.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ All notable changes to this project will be documented in this file.
 
 - Support to 4.6.0 Wazuh release.
 
+## Wazuh Puppet v4.5.4
+
+### Added
+
+- Support to 4.5.4 Wazuh release.
+
 ## Wazuh Puppet v4.5.3
 
 ### Added

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -577,8 +577,9 @@ class wazuh::agent (
           ${agent_auth_option_manager}  ${agent_auth_option_agent} ${agent_auth_option_password} ${agent_auth_option_address}"
 
         exec { 'agent-auth-linux':
+          path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
           command => $agent_auth_command,
-          unless  => "/bin/egrep -q '.' ${::wazuh::params_agent::keys_file}",
+          unless  => "egrep -q '.' ${::wazuh::params_agent::keys_file}",
           require => Concat['agent_ossec.conf'],
           before  => Service[$agent_service_name],
           notify  => Service[$agent_service_name],

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -46,10 +46,12 @@ class wazuh::filebeat_oss (
   #  Needed since GitHub can only ETAG and result in changes of the mtime everytime.
   # TODO: Include file into the wazuh/wazuh-puppet project or use file { checksum => '..' } for this instead of the exec construct.
   exec { 'cleanup /etc/filebeat/wazuh-template.json':
-    command => '/bin/rm -f /etc/filebeat/wazuh-template.json',
-    onlyif  => '/bin/test -f /etc/filebeat/wazuh-template.json',
-    unless  => "/bin/curl -s 'https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_extensions_version}/extensions/elasticsearch/7.x/wazuh-template.json' | /bin/cmp -s '/etc/filebeat/wazuh-template.json'",
+    path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
+    command => 'rm -f /etc/filebeat/wazuh-template.json',
+    onlyif  => 'test -f /etc/filebeat/wazuh-template.json',
+    unless  => "curl -s 'https://raw.githubusercontent.com/wazuh/wazuh/${wazuh_extensions_version}/extensions/elasticsearch/7.x/wazuh-template.json' | cmp -s '/etc/filebeat/wazuh-template.json'",
   }
+
   -> file { '/etc/filebeat/wazuh-template.json':
     owner   => 'root',
     group   => 'root',


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-puppet/issues/807
The aim of this PR is to bump the 4.7.0 branch into the 4.7.1 branch.