### PR TITLE
Change deprecated ::osfamily fact

### DIFF
--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -419,7 +419,7 @@ class wazuh::params_manager {
       $wazuh_api_template = 'wazuh/wazuh_api_yml.erb'
 
 
-      case $::osfamily {
+      case $facts['os']['family'] {
         'Debian': {
 
           $agent_service  = 'wazuh-agent'


### PR DESCRIPTION
As of https://www.puppet.com/docs/puppet/7/core_facts.html#osfamily the fact `osfamily` it is deprecated and is not available in puppet 8.