### PR TITLE
Add ip_update_interval parameter support

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -63,6 +63,7 @@ class wazuh::agent (
   $ossec_protocol                    = $wazuh::params_agent::ossec_protocol,
   $wazuh_max_retries                 = $wazuh::params_agent::wazuh_max_retries,
   $wazuh_retry_interval              = $wazuh::params_agent::wazuh_retry_interval,
+  $wazuh_ip_update_interval          = $wazuh::params_agent::wazuh_ip_update_interval,
   $ossec_config_ubuntu_profiles      = $wazuh::params_agent::ossec_config_ubuntu_profiles,
   $ossec_config_centos_profiles      = $wazuh::params_agent::ossec_config_centos_profiles,
   $ossec_notify_time                 = $wazuh::params_agent::ossec_notify_time,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -62,6 +62,7 @@ class wazuh::params_agent {
   $ossec_protocol = 'tcp'
   $wazuh_max_retries = '5'
   $wazuh_retry_interval = '5'
+  $wazuh_ip_update_interval = undef
   $ossec_config_ubuntu_profiles = 'ubuntu, ubuntu18, ubuntu18.04'
   $ossec_config_centos_profiles = 'centos, centos7, centos7.6'
   $ossec_notify_time = 10

--- a/templates/wazuh_agent.conf.erb
+++ b/templates/wazuh_agent.conf.erb
@@ -21,6 +21,9 @@
   <%- if @ossec_time_reconnect then -%>
     <time-reconnect><%= @ossec_time_reconnect %></time-reconnect>
   <%- end -%>
+  <%- if @wazuh_ip_update_interval then -%>
+    <ip_update_interval><%= @wazuh_ip_update_interval %></ip_update_interval>
+  <%- end -%>
   <%- if @ossec_crypto_method then -%>
     <crypto_method><%= @ossec_crypto_method %></crypto_method>
   <%- end -%>


### PR DESCRIPTION
Hello,

To work around routers with big IP tables, we need to use ip_update less frequently than the default (60 seconds). If we don't, we have a full CPU dedicated to continuously parsing the ip routing table...

Doc:
https://documentation.wazuh.com/current/user-manual/reference/internal-options.html#logcollector
(see logcollector.ip_update_interval)

This patch just adds the possibility to use the ip_update_interval parameter.