### PR TITLE
correct dashboard version for Debian

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -36,7 +36,7 @@ class wazuh::dashboard (
   # assign version according to the package manager
   case $facts['os']['family'] {
     'Debian': {
-      $dashboard_version_install = "${dashboard_version}-*"
+      $dashboard_version_install = "${dashboard_version}-1"
     }
     'Linux', 'RedHat', default: {
       $dashboard_version_install = $dashboard_version


### PR DESCRIPTION
Hello,

This patch corrects the version number for Debian systems.

Without it, the dashboard package is reinstalled at each puppet run:

Notice: /Stage[main]/Wazuh::Dashboard/Package[wazuh-dashboard]/ensure: ensure changed '4.7.2-1' to '4.7.2-*' (corrective)

The -1 is fixed, there never has been one in wazuh 4.x for now:

[apt-cache-dashboard.txt](https://github.com/wazuh/wazuh-puppet/files/13965488/apt-cache-dashboard.txt)
