### PR TITLE
Merge 4.7.3 into 4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Support to 4.8.0 Wazuh release.
+
 ## Wazuh Puppet v4.7.3
 
 ### Added


### PR DESCRIPTION
Related: https://github.com/wazuh/wazuh-puppet/issues/932
The aim of this PR is to bump the 4.7.3 changes to the 4.8.0 branch.