### PR TITLE
937: template wazuh_api_yaml.erb config changes from v4.3.x to v4.4.x…

### DIFF
--- a/templates/wazuh_api_yml.erb
+++ b/templates/wazuh_api_yml.erb
@@ -38,6 +38,7 @@ drop_privileges: <%= @wazuh_api_drop_privileges %>
 # Enable features under development
 experimental_features: <%= @wazuh_api_experimental_features %>
 # Enable remote commands
+<%- if scope.function_versioncmp([@server_package_version, '4.4']) >= 0 -%>
 upload_configuration:
   remote_commands:
     localfile:
@@ -49,3 +50,12 @@ upload_configuration:
   limits:
     eps:
       allow: <%= @limits_eps %>
+<%- else -%>
+remote_commands:
+  localfile:
+    enabled: <%= @remote_commands_localfile %>
+    exceptions: <%= @remote_commands_localfile_exceptions %>
+  wodle_command:
+    enabled: <%= @remote_commands_wodle %>
+    exceptions: []
+<%- end -%>


### PR DESCRIPTION
… formats

Use `@server_package_version` on the template to check the version of the package and set the `upload_configuration:` section or `remote_commands:` accordingly to the package version.

This ensures the module is still able to manage a wazuh agent of a pre-4.4.x version.

This relates to (and fixes) https://github.com/wazuh/wazuh-puppet/issues/937