### PR TITLE
Changed APT key and repository management

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -6,6 +6,7 @@ class wazuh::repo (
   case $::osfamily {
     'Debian' : {
       $wazuh_repo_url = 'https://packages.wazuh.com/4.x/apt'
+      $repo_release = 'stable'
 
       if $::lsbdistcodename =~ /(jessie|wheezy|stretch|precise|trusty|vivid|wily|xenial|yakketi|groovy)/
       and ! defined(Package['apt-transport-https']) and ! defined(Package['gnupg']) {
@@ -31,7 +32,7 @@ class wazuh::repo (
             ensure   => present,
             comment  => 'This is the WAZUH Ubuntu repository',
             location => 'https://packages.wazuh.com/4.x/apt',
-            release  => 'unstable',
+            release  => $repo_release,
             repos    => 'main',
             include  => {
               'src' => false,
@@ -49,7 +50,7 @@ class wazuh::repo (
 
           concat::fragment { 'wazuh-source':
             target  => '/etc/apt/sources.list.d/wazuh.list',
-            content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] $wazuh_repo_url unstable main\n",
+            content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] $wazuh_repo_url $repo_release main\n",
             order   => '01',
             require => File['/usr/share/keyrings/wazuh.gpg'],
           }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -5,6 +5,8 @@ class wazuh::repo (
 
   case $::osfamily {
     'Debian' : {
+      $wazuh_repo_url = 'https://packages-dev.wazuh.com/pre-release/apt'
+      
       if $::lsbdistcodename =~ /(jessie|wheezy|stretch|precise|trusty|vivid|wily|xenial|yakketi|groovy)/
       and ! defined(Package['apt-transport-https']) {
         ensure_packages(['apt-transport-https'], {'ensure' => 'present'})

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,9 +10,9 @@ class wazuh::repo (
         ensure_packages(['apt-transport-https'], {'ensure' => 'present'})
       }
       exec { 'import-wazuh-key':
+        path =>  [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
         command => '/bin/curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | /usr/bin/gpg --no-default-keyring --keyring /usr/share/keyrings/wazuh.gpg --import',
         unless  => '/usr/bin/gpg --no-default-keyring --keyring /usr/share/keyrings/wazuh.gpg --list-keys | /bin/grep -q 29111145',
-        path    => ['/bin', '/usr/bin'],
       }
 
       # Ensure permissions on the keyring

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,6 +36,19 @@ class wazuh::repo (
               'deb' => true,
             },
           }
+          # Manage the APT source list file content using concat
+          concat { '/etc/apt/sources.list.d/wazuh.list':
+            ensure  => present,
+            owner   => 'root',
+            group   => 'root',
+            mode    => '0644',
+          }
+
+          concat::fragment { 'wazuh-source':
+            target  => '/etc/apt/sources.list.d/wazuh.list',
+            content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] $wazuh_repo_url unstable main\n",
+            order   => '01',
+          }
         }
         default: { fail('This ossec module has not been tested on your distribution (or lsb package not installed)') }
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -36,20 +36,6 @@ class wazuh::repo (
               'deb' => true,
             },
           }
-
-          # Manage the APT source list file content using concat
-          concat { '/etc/apt/sources.list.d/wazuh.list':
-            ensure  => present,
-            owner   => 'root',
-            group   => 'root',
-            mode    => '0644',
-          }
-
-          concat::fragment { 'wazuh-source':
-            target  => '/etc/apt/sources.list.d/wazuh.list',
-            content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] https://packages-dev.wazuh.com/pre-release/apt/ unstable main\n",
-            order   => '01',
-          }
         }
         default: { fail('This ossec module has not been tested on your distribution (or lsb package not installed)') }
       }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,7 +10,7 @@ class wazuh::repo (
 
       if $::lsbdistcodename =~ /(jessie|wheezy|stretch|precise|trusty|vivid|wily|xenial|yakketi|groovy)/
       and ! defined(Package['apt-transport-https']) and ! defined(Package['gnupg']) {
-        ensure_packages(['apt-transport-https'], {'ensure' => 'present'})
+        ensure_packages(['apt-transport-https', 'gnupg'], {'ensure' => 'present'})
       }
       exec { 'import-wazuh-key':
         path =>  [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
@@ -31,7 +31,7 @@ class wazuh::repo (
           apt::source { 'wazuh':
             ensure   => present,
             comment  => 'This is the WAZUH Ubuntu repository',
-            location => 'https://packages.wazuh.com/4.x/apt',
+            location => $wazuh_repo_url,
             release  => $repo_release,
             repos    => 'main',
             include  => {


### PR DESCRIPTION
## Description

Closes: https://github.com/wazuh/wazuh-puppet/issues/939

The aim of this PR is to change the repository and the GPG key management in the Debian code block. The change consists in remove the `apt::key` method and manage the repository and the key manually.

## Testing

The testing has been performed in: https://github.com/wazuh/wazuh-puppet/issues/939#issuecomment-1985477246