### PR TITLE
Correct #879: stdlib deprecated validate_legacy()

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -7,22 +7,22 @@ class wazuh::agent (
 
   $agent_package_version             = $wazuh::params_agent::agent_package_version,
   $agent_package_revision            = $wazuh::params_agent::agent_package_revision,
-  $agent_package_name                = $wazuh::params_agent::agent_package_name,
-  $agent_service_name                = $wazuh::params_agent::agent_service_name,
+  String $agent_package_name         = $wazuh::params_agent::agent_package_name,
+  String $agent_service_name         = $wazuh::params_agent::agent_service_name,
   $agent_service_ensure              = $wazuh::params_agent::agent_service_ensure,
   $agent_msi_download_location       = $wazuh::params_agent::agent_msi_download_location,
 
   # Authd registration options
   $manage_client_keys                = $wazuh::params_agent::manage_client_keys,
-  $agent_name                        = $wazuh::params_agent::agent_name,
-  $agent_group                       = $wazuh::params_agent::agent_group,
+  String agent_name                  = $wazuh::params_agent::agent_name,
+  String $agent_group                = $wazuh::params_agent::agent_group,
   $agent_address                     = $wazuh::params_agent::agent_address,
-  $wazuh_agent_cert                  = $wazuh::params_agent::wazuh_agent_cert,
-  $wazuh_agent_key                   = $wazuh::params_agent::wazuh_agent_key,
-  $wazuh_agent_cert_path             = $wazuh::params_agent::wazuh_agent_cert_path,
-  $wazuh_agent_key_path              = $wazuh::params_agent::wazuh_agent_key_path,
+  String $wazuh_agent_cert           = $wazuh::params_agent::wazuh_agent_cert,
+  String $wazuh_agent_key            = $wazuh::params_agent::wazuh_agent_key,
+  String $wazuh_agent_cert_path      = $wazuh::params_agent::wazuh_agent_cert_path,
+  String $wazuh_agent_key_path       = $wazuh::params_agent::wazuh_agent_key_path,
   $agent_auth_password               = $wazuh::params_agent::agent_auth_password,
-  $wazuh_manager_root_ca_pem         = $wazuh::params_agent::wazuh_manager_root_ca_pem,
+  String $wazuh_manager_root_ca_pem  = $wazuh::params_agent::wazuh_manager_root_ca_pem,
   $wazuh_manager_root_ca_pem_path    = $wazuh::params_agent::wazuh_manager_root_ca_pem_path,
 
   ## ossec.conf generation parameters
@@ -248,8 +248,6 @@ class wazuh::agent (
   # )
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)
-  validate_legacy(String, 'validate_string', $agent_package_name)
-  validate_legacy(String, 'validate_string', $agent_service_name)
 
   if (( $ossec_syscheck_whodata_directories_1 == 'yes' ) or ( $ossec_syscheck_whodata_directories_2 == 'yes' )) {
     class { 'wazuh::audit':
@@ -479,14 +477,12 @@ class wazuh::agent (
   # Agent registration and service setup
   if ($manage_client_keys == 'yes') {
     if $agent_name {
-      validate_legacy(String, 'validate_string', $agent_name)
       $agent_auth_option_name = "-A \"${agent_name}\""
     } else {
       $agent_auth_option_name = ''
     }
 
     if $agent_group {
-      validate_legacy(String, 'validate_string', $agent_group)
       $agent_auth_option_group = "-G \"${agent_group}\""
     } else {
       $agent_auth_option_group = ''
@@ -517,7 +513,6 @@ class wazuh::agent (
 
         # https://documentation.wazuh.com/4.0/user-manual/registering/manager-verification/manager-verification-registration.html
         if $wazuh_manager_root_ca_pem != undef {
-          validate_legacy(String, 'validate_string', $wazuh_manager_root_ca_pem)
           file { '/var/ossec/etc/rootCA.pem':
             owner   => $wazuh::params_agent::keys_owner,
             group   => $wazuh::params_agent::keys_group,
@@ -527,7 +522,6 @@ class wazuh::agent (
           }
           $agent_auth_option_manager = '-v /var/ossec/etc/rootCA.pem'
         } elsif $wazuh_manager_root_ca_pem_path != undef {
-          validate_legacy(String, 'validate_string', $wazuh_manager_root_ca_pem)
           $agent_auth_option_manager = "-v ${wazuh_manager_root_ca_pem_path}"
         } else {
           $agent_auth_option_manager = ''  # Avoid errors when compounding final command
@@ -535,8 +529,6 @@ class wazuh::agent (
 
         # https://documentation.wazuh.com/4.0/user-manual/registering/manager-verification/agent-verification-registration.html
         if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
-          validate_legacy(String, 'validate_string', $wazuh_agent_cert)
-          validate_legacy(String, 'validate_string', $wazuh_agent_key)
           file { '/var/ossec/etc/sslagent.cert':
             owner   => $wazuh::params_agent::keys_owner,
             group   => $wazuh::params_agent::keys_group,
@@ -554,8 +546,6 @@ class wazuh::agent (
 
           $agent_auth_option_agent = '-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key'
         } elsif ($wazuh_agent_cert_path != undef) and ($wazuh_agent_key_path != undef) {
-          validate_legacy(String, 'validate_string', $wazuh_agent_cert_path)
-          validate_legacy(String, 'validate_string', $wazuh_agent_key_path)
           $agent_auth_option_agent = "-x ${wazuh_agent_cert_path} -k ${wazuh_agent_key_path}"
         } else {
           $agent_auth_option_agent = ''

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -14,10 +14,10 @@ class wazuh::manager (
 
       $ossec_logall                     = $wazuh::params_manager::ossec_logall,
       $ossec_logall_json                = $wazuh::params_manager::ossec_logall_json,
-      $ossec_emailnotification          = $wazuh::params_manager::ossec_emailnotification,
-      $ossec_emailto                    = $wazuh::params_manager::ossec_emailto,
-      $ossec_smtp_server                = $wazuh::params_manager::ossec_smtp_server,
-      $ossec_emailfrom                  = $wazuh::params_manager::ossec_emailfrom,
+      Boolean $ossec_emailnotification  = $wazuh::params_manager::ossec_emailnotification,
+      Array $ossec_emailto              = $wazuh::params_manager::ossec_emailto,
+      String $ossec_smtp_server         = $wazuh::params_manager::ossec_smtp_server,
+      String $ossec_emailfrom           = $wazuh::params_manager::ossec_emailfrom,
       $ossec_email_maxperhour           = $wazuh::params_manager::ossec_email_maxperhour,
       $ossec_email_log_source           = $wazuh::params_manager::ossec_email_log_source,
       $ossec_email_idsname              = $wazuh::params_manager::ossec_email_idsname,
@@ -175,7 +175,7 @@ class wazuh::manager (
       $vulnerability_indexer_ssl_key            = $wazuh::params_manager::vulnerability_indexer_ssl_key,
 
       # syslog
-      $syslog_output                        = $wazuh::params_manager::syslog_output,
+      Boolean $syslog_output                = $wazuh::params_manager::syslog_output,
       $syslog_output_level                  = $wazuh::params_manager::syslog_output_level,
       $syslog_output_port                   = $wazuh::params_manager::syslog_output_port,
       $syslog_output_server                 = $wazuh::params_manager::syslog_output_server,
@@ -247,14 +247,14 @@ class wazuh::manager (
       $ar_repeated_offenders                = $wazuh::params_manager::ar_repeated_offenders,
 
       $local_decoder_template               = $wazuh::params_manager::local_decoder_template,
-      $decoder_exclude                      = $wazuh::params_manager::decoder_exclude,
+      Array $decoder_exclude                = $wazuh::params_manager::decoder_exclude,
       $local_rules_template                 = $wazuh::params_manager::local_rules_template,
-      $rule_exclude                         = $wazuh::params_manager::rule_exclude,
+      Array $rule_exclude                   = $wazuh::params_manager::rule_exclude,
       $shared_agent_template                = $wazuh::params_manager::shared_agent_template,
 
-      $wazuh_manager_verify_manager_ssl     = $wazuh::params_manager::wazuh_manager_verify_manager_ssl,
-      $wazuh_manager_server_crt             = $wazuh::params_manager::wazuh_manager_server_crt,
-      $wazuh_manager_server_key             = $wazuh::params_manager::wazuh_manager_server_key,
+      Boolean $wazuh_manager_verify_manager_ssl = $wazuh::params_manager::wazuh_manager_verify_manager_ssl,
+      String $wazuh_manager_server_crt          = $wazuh::params_manager::wazuh_manager_server_crt,
+      String $wazuh_manager_server_key          = $wazuh::params_manager::wazuh_manager_server_key,
 
       $ossec_local_files                    = $::wazuh::params_manager::default_local_files,
 
@@ -305,13 +305,6 @@ class wazuh::manager (
 
 
 ) inherits wazuh::params_manager {
-  validate_legacy(
-    Boolean, 'validate_bool', $syslog_output,$wazuh_manager_verify_manager_ssl
-  )
-  validate_legacy(
-    Array, 'validate_array', $decoder_exclude, $rule_exclude
-  )
-
   ## Determine which kernel and family puppet is running on. Will be used on _localfile, _rootcheck, _syscheck & _sca
 
   if ($::kernel == 'windows') {
@@ -348,14 +341,10 @@ class wazuh::manager (
 
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)
-  validate_legacy(Boolean, 'validate_bool', $ossec_emailnotification)
   if ($ossec_emailnotification) {
     if $ossec_smtp_server == undef {
       fail('$ossec_emailnotification is enabled but $smtp_server was not set')
     }
-    validate_legacy(String, 'validate_string', $ossec_smtp_server)
-    validate_legacy(String, 'validate_string', $ossec_emailfrom)
-    validate_legacy(Array, 'validate_array', $ossec_emailto)
   }
 
   if $::osfamily == 'windows' {
@@ -623,10 +612,6 @@ class wazuh::manager (
   if $wazuh_manager_verify_manager_ssl {
 
     if ($wazuh_manager_server_crt != undef) and ($wazuh_manager_server_key != undef) {
-      validate_legacy(
-        String, 'validate_string', $wazuh_manager_server_crt, $wazuh_manager_server_key
-      )
-
       file { '/var/ossec/etc/sslmanager.key':
         content => $wazuh_manager_server_key,
         owner   => 'root',


### PR DESCRIPTION
As noted in #879 , validate_legacy() has been deprecated by stdlib and throw an error. This drops all calls to that function and replaces them by puppet data types.