### PR TITLE
Add host parameter into securityadmin class

### DIFF
--- a/manifests/securityadmin.pp
+++ b/manifests/securityadmin.pp
@@ -1,12 +1,13 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Wazuh repository installation
 class wazuh::securityadmin (
-  $indexer_security_init_lockfile = '/var/tmp/indexer-security-init.lock',
+  $indexer_init_lockfile = '/var/tmp/indexer-init.lock',
+  $indexer_network_host = 'localhost',
 ) {
-  exec { 'Initialize the Opensearch security index in Wazuh indexer':
+  exec { 'Initialize the Opensearch security index and ISM Polciy in Wazuh indexer':
     path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
-    command => "/usr/share/wazuh-indexer/bin/indexer-security-init.sh && touch ${indexer_security_init_lockfile}",
-    creates => $indexer_security_init_lockfile,
+    command => "/usr/share/wazuh-indexer/bin/indexer-init.sh -i ${indexer_network_host} && touch ${indexer_init_lockfile}",
+    creates => $indexer_init_lockfile,
     require => Service['wazuh-indexer'],
   }
 }

--- a/manifests/securityadmin.pp
+++ b/manifests/securityadmin.pp
@@ -1,13 +1,13 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Wazuh repository installation
 class wazuh::securityadmin (
-  $indexer_init_lockfile = '/var/tmp/indexer-init.lock',
+  $indexer_security_init_lockfile = '/var/tmp/indexer-security-init.lock',
   $indexer_network_host = 'localhost',
 ) {
-  exec { 'Initialize the Opensearch security index':
+  exec { 'Initialize the Opensearch security index in Wazuh indexer':
     path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
-    command => "/usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho ${indexer_network_host} && touch ${indexer_init_lockfile}",
-    creates => $indexer_init_lockfile,
+    command => "/usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho ${indexer_network_host} && touch ${indexer_security_init_lockfile}",
+    creates => $indexer_security_init_lockfile,
     require => Service['wazuh-indexer'],
   }
 }

--- a/manifests/securityadmin.pp
+++ b/manifests/securityadmin.pp
@@ -4,9 +4,9 @@ class wazuh::securityadmin (
   $indexer_init_lockfile = '/var/tmp/indexer-init.lock',
   $indexer_network_host = 'localhost',
 ) {
-  exec { 'Initialize the Opensearch security index and ISM Polciy in Wazuh indexer':
+  exec { 'Initialize the Opensearch security index':
     path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
-    command => "/usr/share/wazuh-indexer/bin/indexer-init.sh -i ${indexer_network_host} && touch ${indexer_init_lockfile}",
+    command => "/usr/share/wazuh-indexer/bin/indexer-security-init.sh -ho ${indexer_network_host} && touch ${indexer_init_lockfile}",
     creates => $indexer_init_lockfile,
     require => Service['wazuh-indexer'],
   }


### PR DESCRIPTION
This PR adds the `indexer_network_host` parameter into `securitadmin` class to be able to parameterize the IP of the Wazuh indexer node.
Related issue: https://github.com/wazuh/wazuh-puppet/issues/971.