### PR TITLE
Change indexer_network_host default value

### DIFF
--- a/manifests/securityadmin.pp
+++ b/manifests/securityadmin.pp
@@ -2,7 +2,7 @@
 # Wazuh repository installation
 class wazuh::securityadmin (
   $indexer_security_init_lockfile = '/var/tmp/indexer-security-init.lock',
-  $indexer_network_host = 'localhost',
+  $indexer_network_host = '127.0.0.1',
 ) {
   exec { 'Initialize the Opensearch security index in Wazuh indexer':
     path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],


### PR DESCRIPTION
This PR modifies the `indexer_network_host` default value from `localhost` to `127.0.0.1`.
Issue related https://github.com/wazuh/wazuh-puppet/issues/983