### PR TITLE
Add buster and bookworm versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -104,8 +104,9 @@
         "Wheezy",
         "Jessie",
         "Stretch",
-        "Sid",
-        "bullseye"
+        "buster",
+        "bullseye",
+        "bookworm"
       ]
     }
   ],


### PR DESCRIPTION
This PR adds Debian buster and bookworm version into Puppet metadata.