### PR TITLE
added run_as variable

### DIFF
--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -10,6 +10,7 @@ class wazuh::dashboard (
   $dashboard_path_certs = '/etc/wazuh-dashboard/certs',
   $dashboard_fileuser = 'wazuh-dashboard',
   $dashboard_filegroup = 'wazuh-dashboard',
+  $dashboard_run_as = false,
 
   $dashboard_server_port = '443',
   $dashboard_server_host = '0.0.0.0',
@@ -28,6 +29,7 @@ class wazuh::dashboard (
       'port'     => '55000',
       'user'     => 'wazuh-wui',
       'password' => 'wazuh-wui',
+      'run_as'   => $dashboard_run_as,
     },
   ],
 

--- a/templates/wazuh_yml.erb
+++ b/templates/wazuh_yml.erb
@@ -240,5 +240,5 @@ hosts:
       port: <%= api_profile['port'] %>
       username: <%= api_profile['user'] %>
       password: <%= api_profile['password'] %>
-      run_as: false
+      run_as: <%= api_profile['run_as'] %>
 <% end -%>


### PR DESCRIPTION
Added the following variable since we need it for role mapping, here's [why](https://documentation.wazuh.com/current/user-manual/user-administration/rbac.html).