### PR TITLE
Fix ossec rules_exclude and add support for multiple files in exclude

### DIFF
--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -249,7 +249,7 @@ class wazuh::manager (
       $local_decoder_template               = $wazuh::params_manager::local_decoder_template,
       $decoder_exclude                      = $wazuh::params_manager::decoder_exclude,
       $local_rules_template                 = $wazuh::params_manager::local_rules_template,
-      $rule_exclude                         = $wazuh::params_manager::rule_exclude,
+      $ossec_ruleset_rule_exclude           = $wazuh::params_manager::ossec_ruleset_rule_exclude,
       $shared_agent_template                = $wazuh::params_manager::shared_agent_template,
 
       $wazuh_manager_verify_manager_ssl     = $wazuh::params_manager::wazuh_manager_verify_manager_ssl,

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -289,17 +289,6 @@ class wazuh::params_agent {
       $wodle_syscollector_processes = 'yes'
       $wodle_syscollector_hotfixes = undef
 
-      $ossec_ruleset_decoder_dir = 'ruleset/decoders'
-      $ossec_ruleset_rule_dir = 'ruleset/rules'
-      $ossec_ruleset_rule_exclude = '0215-policy_rules.xml'
-      $ossec_ruleset_list = [ 'etc/lists/audit-keys',
-        'etc/lists/amazon/aws-eventnames',
-        'etc/lists/security-eventchannel',
-      ]
-
-      $ossec_ruleset_user_defined_decoder_dir = 'etc/decoders'
-      $ossec_ruleset_user_defined_rule_dir = 'etc/rules'
-
       case $::osfamily {
         'Debian': {
           $service_has_status = false

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -243,7 +243,7 @@ class wazuh::params_manager {
 
       $ossec_ruleset_decoder_dir = 'ruleset/decoders'
       $ossec_ruleset_rule_dir = 'ruleset/rules'
-      $ossec_ruleset_rule_exclude = '0215-policy_rules.xml'
+      $ossec_ruleset_rule_exclude = ['0215-policy_rules.xml']
       $ossec_ruleset_list = [ 'etc/lists/audit-keys',
         'etc/lists/amazon/aws-eventnames',
         'etc/lists/security-eventchannel',
@@ -280,7 +280,6 @@ class wazuh::params_manager {
       $local_decoder_template              = 'wazuh/local_decoder.xml.erb'
       $decoder_exclude                     = []
       $local_rules_template                = 'wazuh/local_rules.xml.erb'
-      $rule_exclude                        = []
       $shared_agent_template               = 'wazuh/ossec_shared_agent.conf.erb'
 
       $wazuh_manager_verify_manager_ssl    = false

--- a/templates/fragments/_ruleset.erb
+++ b/templates/fragments/_ruleset.erb
@@ -13,6 +13,7 @@
    <%- @ossec_ruleset_rule_exclude.each do |list_element| -%>
     <rule_exclude><%= list_element %></rule_exclude>
    <%- end -%>
+  <%- end -%>
   <%- @ossec_ruleset_list.each do |list_element| -%>
   <list><%= list_element %></list>
   <%- end -%>
@@ -25,4 +26,3 @@
   <rule_dir><%= @ossec_ruleset_user_defined_rule_dir %></rule_dir>
   <%- end -%>
 </ruleset>
-

--- a/templates/fragments/_ruleset.erb
+++ b/templates/fragments/_ruleset.erb
@@ -9,9 +9,10 @@
   <% if @ossec_ruleset_rule_dir -%>
   <rule_dir><%= @ossec_ruleset_rule_dir %></rule_dir>
   <%- end -%>
-  <% if @ossec_ruleset_rule_exclude -%>
-  <rule_exclude><%= @ossec_ruleset_rule_exclude %></rule_exclude>
-  <%- end -%>
+  <%- if @ossec_ruleset_rule_exclude -%>
+   <%- @ossec_ruleset_rule_exclude.each do |list_element| -%>
+    <rule_exclude><%= list_element %></rule_exclude>
+   <%- end -%>
   <%- @ossec_ruleset_list.each do |list_element| -%>
   <list><%= list_element %></list>
   <%- end -%>


### PR DESCRIPTION
- fix the parameter to configure rule exclusion in manager
(rule_exclude had not been used, ossec_ruleset_rule_exclude was not fully implemented)
- add configuration support for multiple rules exclusion files 
e.g. `ossec_ruleset_rule_exclude => ['0215-policy_rules.xml', '0020-syslog_rules.xml'],`
- remove rule exclusion code from agent, as according to documentation ossec ruleset is only supported by manager. 
  agent did not include any ruleset fragments or templates