### PR TITLE
Add 'ignore' feature to ossec_local_files parameter

### DIFF
--- a/templates/fragments/_localfile.erb
+++ b/templates/fragments/_localfile.erb
@@ -23,6 +23,9 @@
     <%- if localfile.key?('only-future-events') -%>
     <only-future-events><%= localfile['only-future-events'] %></only-future-events>
     <%- end -%>
+    <%- if localfile.key?('ignore') -%>
+    <ignore type="<%= localfile['ignore']['type'] %>"><%= localfile['ignore']['value'] %></ignore>
+    <%- end -%>
     <%- if localfile.key?('target') -%>
     <target><%= localfile['target'] %></target>
     <%- end -%>


### PR DESCRIPTION
Could be used with: 

```yaml
- location:   /var/log/audit/audit.log
  ignore:
    type: PCRE2
    value: 'comm="(ipset|runc|grep|conmon|iptables|ip6tables|awk)"'
  log_format: audit
- location:   /var/log/syslog
  log_format: syslog
```