### PR TITLE
Added logic to install latest revision

### DIFF
--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -8,7 +8,7 @@ class wazuh::indexer (
   $indexer_node_max_local_storage_nodes = '1',
   $indexer_service = 'wazuh-indexer',
   $indexer_package = 'wazuh-indexer',
-  $indexer_version = '4.9.1-1',
+  $indexer_version = '4.9.1',
   $indexer_fileuser = 'wazuh-indexer',
   $indexer_filegroup = 'wazuh-indexer',
 
@@ -28,9 +28,19 @@ class wazuh::indexer (
   $jvm_options_memory = '1g',
 ) {
 
+  # assign version according to the package manager
+  case $facts['os']['family'] {
+    'Debian': {
+      $indexer_version_install = "${indexer_version}-*"
+    }
+    'Linux', 'RedHat', default: {
+      $indexer_version_install = $indexer_version
+    }
+  }
+
   # install package
   package { 'wazuh-indexer':
-    ensure => $indexer_version,
+    ensure => $indexer_version_install,
     name   => $indexer_package,
   }
 

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -362,10 +362,20 @@ class wazuh::manager (
     fail('The ossec module does not yet support installing the OSSEC HIDS server on Windows')
   }
 
+  # assign version according to the package manager
+  case $facts['os']['family'] {
+    'Debian': {
+      $server_version_install = "${server_package_version}-*"
+    }
+    'Linux', 'RedHat', default: {
+      $server_version_install = $server_package_version
+    }
+  }
+
   # Install and configure Wazuh-manager package
 
   package { $wazuh::params_manager::server_package:
-    ensure  => $server_package_version, # lint:ignore:security_package_pinned_version
+    ensure  => $server_version_install, # lint:ignore:security_package_pinned_version
   }
 
   file {

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -5,7 +5,7 @@ class wazuh::params_manager {
     'Linux': {
 
     # Installation
-      $server_package_version                          = '4.9.1-1'
+      $server_package_version                          = '4.9.1'
 
       $manage_firewall                                 = false
 


### PR DESCRIPTION
Closes: https://github.com/wazuh/wazuh-puppet/issues/1105

## Description
The aim of this PR is to add the necessary logic to install the latest revision available of each Wazuh central component.

## Evidence
### Installation test in `apt` package manager

```shellsession
root@ip-172-31-45-214:/home/ubuntu# apt list --installed | grep wazuh

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

wazuh-dashboard/stable,now 4.9.0-2 amd64 [installed]
wazuh-indexer/stable,now 4.9.0-1 amd64 [installed]
wazuh-manager/stable,now 4.9.0-1 amd64 [installed]
```

### Installation test in `rpm` package manager

```shellsession
[root@ip-172-31-40-201 ec2-user]# rpm -qa | grep wazuh
wazuh-indexer-4.9.0-1.x86_64
wazuh-manager-4.9.0-1.x86_64
wazuh-dashboard-4.9.0-2.x86_64
```