### PR TITLE
Changed GitHub Runner OS version to Ubuntu 22.04

### DIFF
--- a/.github/workflows/Puppet_module_builder.yml
+++ b/.github/workflows/Puppet_module_builder.yml
@@ -57,7 +57,7 @@ env:
 
 jobs:
   build_module:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -87,7 +87,7 @@ jobs:
       - name: Modify name for stage build
         if: ${{ inputs.is_stage == false }}
         run: |
-            pip install sde --break-system-packages
+            pip install sde
             PUPPET_MODULE_VERSION="${PUPPET_MODULE_VERSION}-${{ env.COMMIT_SHORT_SHA}}"
             sde version $PUPPET_MODULE_VERSION ${{ github.workspace }}/metadata.json
             echo "PUPPET_MODULE_VERSION=$PUPPET_MODULE_VERSION" >> "$GITHUB_ENV"

--- a/.github/workflows/Puppet_module_builder.yml
+++ b/.github/workflows/Puppet_module_builder.yml
@@ -78,8 +78,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-            curl -O https://apt.puppet.com/puppet-tools-release-noble.deb
-            sudo dpkg -i puppet-tools-release-noble.deb
+            curl -O https://apt.puppet.com/puppet-tools-release-jammy.deb
+            sudo dpkg -i puppet-tools-release-jammy.deb
             sudo apt-get update
             sudo apt-get install pdk
             pdk set config user.analytics.disabled false --type boolean --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Changed GitHub Runner OS version to Ubuntu 22.04. ([#1142](https://github.com/wazuh/wazuh-puppet/pull/1142))
 
 ### Deleted
 


### PR DESCRIPTION
Related https://github.com/wazuh/wazuh-automation/issues/1891

GitHub Runner OS version changed due to python3 issues


## test 

https://github.com/wazuh/wazuh-puppet/actions/runs/11333526938