### PR TITLE
Delete API parameters from wazuh.yml template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Delete API parameters from wazuh.yml template ([#1155](https://github.com/wazuh/wazuh-puppet/pull/1155)) \-
 - Add URI file after upload ([#1143](https://github.com/wazuh/wazuh-puppet/pull/1143)) \- (Puppet Module Builder)
 - Modfy Puppet module builder ([#1113](https://github.com/wazuh/wazuh-puppet/pull/1113)) \- (Puppet Module Builder)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Delete API parameters from wazuh.yml template ([#1155](https://github.com/wazuh/wazuh-puppet/pull/1155)) \-
+- Delete API parameters from wazuh.yml template ([#1155](https://github.com/wazuh/wazuh-puppet/pull/1155)) \- (Puppet Module)
 - Add URI file after upload ([#1143](https://github.com/wazuh/wazuh-puppet/pull/1143)) \- (Puppet Module Builder)
 - Modfy Puppet module builder ([#1113](https://github.com/wazuh/wazuh-puppet/pull/1113)) \- (Puppet Module Builder)
 

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -283,9 +283,6 @@ class wazuh::manager (
 
 
       $wazuh_api_cors_allow_credentials         = $::wazuh::params_manager::wazuh_api_cors_allow_credentials,
-      $wazuh_api_cache_enabled                  = $::wazuh::params_manager::wazuh_api_cache_enabled,
-
-      $wazuh_api_cache_time                     = $::wazuh::params_manager::wazuh_api_cache_time,
 
       $wazuh_api_access_max_login_attempts      = $::wazuh::params_manager::wazuh_api_access_max_login_attempts,
       $wazuh_api_access_block_time              = $::wazuh::params_manager::wazuh_api_access_block_time,

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -314,7 +314,7 @@ class wazuh::params_manager {
 
       #API
 
-      $wazuh_api_host = '0.0.0.0'
+      $wazuh_api_host = ['0.0.0.0']
       $wazuh_api_port = '55000'
 
       $wazuh_api_file =  undef
@@ -340,10 +340,6 @@ class wazuh::params_manager {
       $wazuh_api_cors_expose_headers = '"*"'
       $wazuh_api_cors_allow_headers = '"*"'
       $wazuh_api_cors_allow_credentials = 'no'
-
-      # Cache (time in seconds)
-      $wazuh_api_cache_enabled = 'yes'
-      $wazuh_api_cache_time = '0.750'
 
       # Access parameters
       $wazuh_api_access_max_login_attempts = 5

--- a/templates/wazuh_api_yml.erb
+++ b/templates/wazuh_api_yml.erb
@@ -24,10 +24,6 @@ cors:
   expose_headers: <%= @wazuh_api_cors_expose_headers %>
   allow_headers: <%= @wazuh_api_cors_allow_headers %>
   allow_credentials: <%= @wazuh_api_cors_allow_credentials %>
-# Cache (time in seconds)
-cache:
-  enabled: <%= @wazuh_api_cache_enabled %>
-  time: <%= @wazuh_api_cache_time %>
 # Access parameters
 access:
   max_login_attempts: <%= @wazuh_api_access_max_login_attempts %>


### PR DESCRIPTION
This PR modifies the host parameter and delete the cache related parameters into wazuh.yml, deprecated in 4.10.0 version.
Related issue https://github.com/wazuh/wazuh-puppet/issues/1154