### PR TITLE
Modify the version used into the Wazuh indexer and Wazuh manager deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Modify the version used into the Wazuh indexer and Wazuh manager deployment ([#1229](https://github.com/wazuh/wazuh-puppet/pull/1229))
 
 ### Deleted
 

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -8,7 +8,7 @@ class wazuh::indexer (
   $indexer_node_max_local_storage_nodes = '1',
   $indexer_service = 'wazuh-indexer',
   $indexer_package = 'wazuh-indexer',
-  $indexer_version = '4.11.0-1',
+  $indexer_version = '4.11.0',
   $indexer_fileuser = 'wazuh-indexer',
   $indexer_filegroup = 'wazuh-indexer',
 

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -5,7 +5,7 @@ class wazuh::params_manager {
     'Linux': {
 
     # Installation
-      $server_package_version                          = '4.11.0-1'
+      $server_package_version                          = '4.11.0'
 
       $manage_firewall                                 = false
 


### PR DESCRIPTION
This PR fices the Wazuh indexer and Wazuh manager version used into the Puppet deployment class.
Related issue https://github.com/wazuh/external-devel-requests/issues/4680