### PR TITLE
Add condition to execute apt update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Add condition to execute apt update ([#1256](https://github.com/wazuh/wazuh-puppet/pull/1256))
 - Fix certificates.pp ([#1255](https://github.com/wazuh/wazuh-puppet/pull/1255))
 - Modify the version used into the Wazuh indexer and Wazuh manager deployment ([#1229](https://github.com/wazuh/wazuh-puppet/pull/1229))
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -53,15 +53,15 @@ class wazuh::repo (
             content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] $wazuh_repo_url $repo_release main\n",
             order   => '01',
             require => File['/usr/share/keyrings/wazuh.gpg'],
+            before  => Exec['apt-update'],
           }
         }
         default: { fail('This ossec module has not been tested on your distribution (or lsb package not installed)') }
       }
       # Define an exec resource to run 'apt-get update'
       exec { 'apt-update':
-        command     => '/usr/bin/apt-get update',
-        refreshonly => true,
-        path        => ['/bin', '/usr/bin'],
+        command => 'apt-get update',
+        path    => ['/bin', '/usr/bin'],
       }
     }
     'Linux', 'RedHat', 'Suse' : {


### PR DESCRIPTION
This PR adds a condition when the wazuh::repo class runs apt update because it needs to wait for the Wazuh repository to be configured.
Related issue https://github.com/wazuh/wazuh-puppet/issues/1253