### PR TITLE
Add refreshonly option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Add refreshonly option ([#1265](https://github.com/wazuh/wazuh-puppet/pull/1265))
 
 ### Deleted
 

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -61,6 +61,7 @@ class wazuh::repo (
       # Define an exec resource to run 'apt-get update'
       exec { 'apt-update':
         command => 'apt-get update',
+        refreshonly => true,
         path    => ['/bin', '/usr/bin'],
       }
     }


### PR DESCRIPTION
This PR adds `refreshonly` option for `apt update` command because the command execution should only be executed when changes have been made to the repository configuration files, in order to maintain the idempotence of the class.

The command's operation was tested before and after the class execution to verify its operation.

Before the change:

``` puppet
root@master1:~# puppet agent -t
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Notice: Requesting catalog from puppet:8140 (127.0.2.1)
Notice: Catalog compiled by master1
Info: Caching catalog for master1
Info: Applying configuration version '1740415593'
Notice: /Stage[repo]/Wazuh::Repo/Exec[apt-update]/returns: executed successfully (corrective)
Notice: Applied catalog in 3.58 seconds
root@master1:~#
```

After the change:

``` puppet
root@master1:~# puppet agent -t
Info: Using environment 'production'
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Loading facts
Notice: Requesting catalog from puppet:8140 (127.0.2.1)
Notice: Catalog compiled by master1
Info: Caching catalog for master1
Info: Applying configuration version '1740415702'
Notice: Applied catalog in 4.50 seconds
root@master1:~#
```