### PR TITLE
Remove default puppet reference version from workflow

### DIFF
--- a/.github/workflows/Puppet_module_builder.yml
+++ b/.github/workflows/Puppet_module_builder.yml
@@ -19,7 +19,6 @@ on:
       wazuh_puppet_reference:
         description: "wazuh-puppet reference"
         type: string
-        default: "4.13.0"
         required: false
       id:
         description: "ID used to identify the workflow uniquely."
@@ -42,7 +41,6 @@ on:
       wazuh_puppet_reference:
         description: "wazuh-puppet reference"
         type: string
-        default: "4.13.0"
         required: false
       id:
         type: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
+- Remove default puppet reference version from workflow ([#1284](https://github.com/wazuh/wazuh-puppet/pull/1284))
 - Remove 'stable' branch ocurrencies ([#1281](https://github.com/wazuh/wazuh-puppet/pull/1281))
 
 ## [4.12.0]


### PR DESCRIPTION
# Description

The changes included in this PR aim to remove the default values of variables referencing the Wazuh-puppet repository.

## Related issue

- https://github.com/wazuh/internal-devel-requests/issues/2137