### PR TITLE
Puppet 8 changes

### DIFF
--- a/manifests/activeresponse.pp
+++ b/manifests/activeresponse.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 #Define for a specific ossec active-response
-define wazuh::activeresponse(
+define wazuh::activeresponse (
   $active_response_name               = 'Rendering active-response template',
   $active_response_disabled           = undef,
   $active_response_linux_ca_store     = undef,
@@ -21,6 +21,6 @@ define wazuh::activeresponse(
     target  => $target_arg,
     order   => $order_arg,
     before  => $before_arg,
-    content => template($content_arg)
+    content => template($content_arg),
   }
 }

--- a/manifests/addlog.pp
+++ b/manifests/addlog.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 #Define a log-file to add to ossec
-define wazuh::addlog(
+define wazuh::addlog (
   $logfile      = undef,
   $logtype      = 'syslog',
   $logcommand   = undef,
@@ -15,5 +15,4 @@ define wazuh::addlog(
     content => template('wazuh/fragments/_localfile_generation.erb'),
     order   => 21,
   }
-
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,7 +4,6 @@
 class wazuh::agent (
 
   # Versioning and package names
-
   $agent_package_version             = $wazuh::params_agent::agent_package_version,
   $agent_package_revision            = $wazuh::params_agent::agent_package_revision,
   $agent_package_name                = $wazuh::params_agent::agent_package_name,
@@ -56,7 +55,6 @@ class wazuh::agent (
   $ossec_labels_template                = $wazuh::params_agent::ossec_labels_template,
 
   # Server configuration
-
   $wazuh_register_endpoint           = $wazuh::params_agent::wazuh_register_endpoint,
   $wazuh_reporting_endpoint          = $wazuh::params_agent::wazuh_reporting_endpoint,
   $ossec_port                        = $wazuh::params_agent::ossec_port,
@@ -74,7 +72,6 @@ class wazuh::agent (
   $client_buffer_events_per_second   = $wazuh::params_agent::client_buffer_events_per_second,
 
   # Auto enrollment configuration
-
   $wazuh_enrollment_enabled          = $wazuh::params_agent::wazuh_enrollment_enabled,
   $wazuh_enrollment_manager_address  = $wazuh::params_agent::wazuh_enrollment_manager_address,
   $wazuh_enrollment_port             = $wazuh::params_agent::wazuh_enrollment_port,
@@ -90,7 +87,6 @@ class wazuh::agent (
   $wazuh_enrollment_auto_method      = $wazuh::params_agent::wazuh_enrollment_auto_method,
   $wazuh_delay_after_enrollment      = $wazuh::params_agent::wazuh_delay_after_enrollment,
   $wazuh_enrollment_use_source_ip    = $wazuh::params_agent::wazuh_enrollment_use_source_ip,
-
 
   # Rootcheck
   $ossec_rootcheck_disabled           = $wazuh::params_agent::ossec_rootcheck_disabled,
@@ -108,7 +104,6 @@ class wazuh::agent (
   $ossec_rootcheck_rootkit_trojans    = $wazuh::params_agent::ossec_rootcheck_rootkit_trojans,
   $ossec_rootcheck_skip_nfs           = $wazuh::params_agent::ossec_rootcheck_skip_nfs,
   $ossec_rootcheck_system_audit      = $wazuh::params_agent::ossec_rootcheck_system_audit,
-
 
   # rootcheck windows
   $ossec_rootcheck_windows_disabled        = $wazuh::params_agent::ossec_rootcheck_windows_disabled,
@@ -231,7 +226,6 @@ class wazuh::agent (
   $ossec_labels                      = $wazuh::params_agent::ossec_labels,
 
   ## Selinux
-
   $selinux                           = $wazuh::params_agent::selinux,
   $manage_firewall                   = $wazuh::params_agent::manage_firewall,
 
@@ -242,15 +236,6 @@ class wazuh::agent (
   # Logging
   $logging_log_format                = $wazuh::params_agent::logging_log_format,
 ) inherits wazuh::params_agent {
-  # validate_bool(
-  #   $ossec_active_response, $ossec_rootcheck,
-  #   $selinux,
-  # )
-  # This allows arrays of integers, sadly
-  # (commented due to stdlib version requirement)
-  validate_legacy(String, 'validate_string', $agent_package_name)
-  validate_legacy(String, 'validate_string', $agent_service_name)
-
   if (( $ossec_syscheck_whodata_directories_1 == 'yes' ) or ( $ossec_syscheck_whodata_directories_2 == 'yes' )) {
     class { 'wazuh::audit':
       audit_manage_rules      => $audit_manage_rules,
@@ -260,7 +245,6 @@ class wazuh::agent (
     }
   }
 
-
   if $manage_client_keys == 'yes' {
     if $wazuh_register_endpoint == undef {
       fail('The $wazuh_register_endpoint parameter is needed in order to register the Agent.')
@@ -268,7 +252,7 @@ class wazuh::agent (
   }
 
   # Package installation
-  case $::kernel {
+  case $facts['kernel'] {
     'Linux': {
       package { $agent_package_name:
         ensure => "${agent_package_version}-${agent_package_revision}", # lint:ignore:security_package_pinned_version
@@ -284,12 +268,12 @@ class wazuh::agent (
         group              => 'Administrators',
         mode               => '0774',
         source             => "${agent_msi_download_location}/wazuh-agent-${agent_package_version}-${agent_package_revision}.msi",
-        source_permissions => ignore
+        source_permissions => ignore,
       }
 
       # We dont need to pin the package version on Windows since we install if from the right MSI.
       -> package { $agent_package_name:
-        ensure          => "${agent_package_version}",
+        ensure          => $agent_package_version,
         provider        => 'windows',
         source          => "${download_path}\\wazuh-agent-${agent_package_version}-${agent_package_revision}.msi",
         install_options => [
@@ -302,45 +286,49 @@ class wazuh::agent (
     default: { fail('OS not supported') }
   }
 
-  case $::kernel {
-  'Linux': {
-    ## ossec.conf generation concats
-    case $::operatingsystem {
-      'RedHat', 'OracleLinux', 'Suse':{
-        $apply_template_os = 'rhel'
-        if ( $::operatingsystemrelease =~ /^9.*/ ){
-          $rhel_version = '9'
-        }elsif ( $::operatingsystemrelease =~ /^8.*/ ){
-          $rhel_version = '8'
-        }elsif ( $::operatingsystemrelease =~ /^7.*/ ){
-          $rhel_version = '7'
-        }elsif ( $::operatingsystemrelease =~ /^6.*/ ){
-          $rhel_version = '6'
-        }elsif ( $::operatingsystemrelease =~ /^5.*/ ){
-          $rhel_version = '5'
-        }else{
-          fail('This ossec module has not been tested on your distribution')
+  case $facts['kernel'] {
+    'Linux': {
+      ## ossec.conf generation concats
+      case $facts['os']['name'] {
+        'RedHat', 'OracleLinux', 'Suse':{
+          $apply_template_os = 'rhel'
+          if ( $facts['os']['release']['full'] =~ /^9.*/ ) {
+            $rhel_version = '9'
+          }
+          elsif ( $facts['os']['release']['full'] =~ /^8.*/ ) {
+            $rhel_version = '8'
+          }
+          elsif ( $facts['os']['release']['full'] =~ /^7.*/ ) {
+            $rhel_version = '7'
+          }
+          elsif ( $facts['os']['release']['full'] =~ /^6.*/ ) {
+            $rhel_version = '6'
+          }
+          elsif ( $facts['os']['release']['full'] =~ /^5.*/ ) {
+            $rhel_version = '5'
+          }
+          else {
+            fail('This ossec module has not been tested on your distribution')
+          }
+        } 'Debian', 'debian', 'Ubuntu', 'ubuntu':{
+          $apply_template_os = 'debian'
+          if ( $facts['os']['distro']['codename'] == 'wheezy') or ($facts['os']['distro']['codename'] == 'jessie') {
+            $debian_additional_templates = 'yes'
+          }
+        } 'Amazon':{
+          $apply_template_os = 'amazon'
+        } 'CentOS','Centos','centos','AlmaLinux','Rocky':{
+          $apply_template_os = 'centos'
+        } 'SLES':{
+          $apply_template_os = 'suse'
         }
-      }'Debian', 'debian', 'Ubuntu', 'ubuntu':{
-        $apply_template_os = 'debian'
-        if ( $::lsbdistcodename == 'wheezy') or ($::lsbdistcodename == 'jessie'){
-          $debian_additional_templates = 'yes'
-        }
-      }'Amazon':{
-        $apply_template_os = 'amazon'
-      }'CentOS','Centos','centos','AlmaLinux','Rocky':{
-        $apply_template_os = 'centos'
-      }'SLES':{
-        $apply_template_os = 'suse'
+        default: { fail('OS not supported') }
       }
-      default: { fail('OS not supported') }
-    }
-  }'windows': {
+    } 'windows': {
       $apply_template_os = 'windows'
     }
     default: { fail('OS not supported') }
   }
-
 
   concat { 'agent_ossec.conf':
     path    => $wazuh::params_agent::config_file,
@@ -355,7 +343,7 @@ class wazuh::agent (
   concat::fragment {
     'ossec.conf_header':
       target  => 'agent_ossec.conf',
-      order   => 00,
+      order   => '00',
       before  => Service[$agent_service_name],
       content => "<ossec_config>\n";
     'ossec.conf_agent':
@@ -448,19 +436,19 @@ class wazuh::agent (
   }
   if ($configure_active_response == true) {
     wazuh::activeresponse { 'active-response configuration':
-      active_response_disabled           =>  $ossec_active_response_disabled,
-      active_response_linux_ca_store     =>  $ossec_active_response_linux_ca_store,
-      active_response_ca_verification    =>  $ossec_active_response_ca_verification,
-      active_response_repeated_offenders =>  $ossec_active_response_repeated_offenders,
+      active_response_disabled           => $ossec_active_response_disabled,
+      active_response_linux_ca_store     => $ossec_active_response_linux_ca_store,
+      active_response_ca_verification    => $ossec_active_response_ca_verification,
+      active_response_repeated_offenders => $ossec_active_response_repeated_offenders,
       order_arg                          => 40,
       before_arg                         => Service[$agent_service_name],
-      target_arg                         => 'agent_ossec.conf'
+      target_arg                         => 'agent_ossec.conf',
     }
   }
 
-  if ($configure_labels == true){
+  if ($configure_labels == true) {
     concat::fragment {
-        'ossec.conf_labels':
+      'ossec.conf_labels':
         target  => 'agent_ossec.conf',
         order   => 45,
         before  => Service[$agent_service_name],
@@ -479,14 +467,12 @@ class wazuh::agent (
   # Agent registration and service setup
   if ($manage_client_keys == 'yes') {
     if $agent_name {
-      validate_legacy(String, 'validate_string', $agent_name)
       $agent_auth_option_name = "-A \"${agent_name}\""
     } else {
       $agent_auth_option_name = ''
     }
 
     if $agent_group {
-      validate_legacy(String, 'validate_string', $agent_group)
       $agent_auth_option_group = "-G \"${agent_group}\""
     } else {
       $agent_auth_option_group = ''
@@ -504,9 +490,9 @@ class wazuh::agent (
       $agent_auth_option_address = ''
     }
 
-    case $::kernel {
+    case $facts['kernel'] {
       'Linux': {
-        file { $::wazuh::params_agent::keys_file:
+        file { $wazuh::params_agent::keys_file:
           owner => $wazuh::params_agent::keys_owner,
           group => $wazuh::params_agent::keys_group,
           mode  => $wazuh::params_agent::keys_mode,
@@ -517,7 +503,6 @@ class wazuh::agent (
 
         # https://documentation.wazuh.com/4.0/user-manual/registering/manager-verification/manager-verification-registration.html
         if $wazuh_manager_root_ca_pem != undef {
-          validate_legacy(String, 'validate_string', $wazuh_manager_root_ca_pem)
           file { '/var/ossec/etc/rootCA.pem':
             owner   => $wazuh::params_agent::keys_owner,
             group   => $wazuh::params_agent::keys_group,
@@ -527,7 +512,6 @@ class wazuh::agent (
           }
           $agent_auth_option_manager = '-v /var/ossec/etc/rootCA.pem'
         } elsif $wazuh_manager_root_ca_pem_path != undef {
-          validate_legacy(String, 'validate_string', $wazuh_manager_root_ca_pem)
           $agent_auth_option_manager = "-v ${wazuh_manager_root_ca_pem_path}"
         } else {
           $agent_auth_option_manager = ''  # Avoid errors when compounding final command
@@ -535,8 +519,6 @@ class wazuh::agent (
 
         # https://documentation.wazuh.com/4.0/user-manual/registering/manager-verification/agent-verification-registration.html
         if ($wazuh_agent_cert != undef) and ($wazuh_agent_key != undef) {
-          validate_legacy(String, 'validate_string', $wazuh_agent_cert)
-          validate_legacy(String, 'validate_string', $wazuh_agent_key)
           file { '/var/ossec/etc/sslagent.cert':
             owner   => $wazuh::params_agent::keys_owner,
             group   => $wazuh::params_agent::keys_group,
@@ -554,8 +536,6 @@ class wazuh::agent (
 
           $agent_auth_option_agent = '-x /var/ossec/etc/sslagent.cert -k /var/ossec/etc/sslagent.key'
         } elsif ($wazuh_agent_cert_path != undef) and ($wazuh_agent_key_path != undef) {
-          validate_legacy(String, 'validate_string', $wazuh_agent_cert_path)
-          validate_legacy(String, 'validate_string', $wazuh_agent_key_path)
           $agent_auth_option_agent = "-x ${wazuh_agent_cert_path} -k ${wazuh_agent_key_path}"
         } else {
           $agent_auth_option_agent = ''
@@ -567,7 +547,7 @@ class wazuh::agent (
         exec { 'agent-auth-linux':
           path    => ['/usr/bin', '/bin', '/usr/sbin', '/sbin'],
           command => $agent_auth_command,
-          unless  => "egrep -q '.' ${::wazuh::params_agent::keys_file}",
+          unless  => "egrep -q '.' ${wazuh::params_agent::keys_file}",
           require => Concat['agent_ossec.conf'],
           before  => Service[$agent_service_name],
           notify  => Service[$agent_service_name],
@@ -625,7 +605,7 @@ class wazuh::agent (
 
   # SELinux
   # Requires selinux module specified in metadata.json
-  if ($::osfamily == 'RedHat' and $selinux == true) {
+  if ($facts['os']['family'] == 'RedHat' and $selinux == true) {
     selinux::module { 'ossec-logrotate':
       ensure    => 'present',
       source_te => 'puppet:///modules/wazuh/ossec-logrotate.te',
@@ -656,5 +636,4 @@ class wazuh::agent (
       require => Package[$wazuh::params_agent::agent_package_name],
     }
   }
-
 }

--- a/manifests/audit.pp
+++ b/manifests/audit.pp
@@ -7,10 +7,9 @@ class wazuh::audit (
   $audit_rules = [],
   $audit_package_title = 'Installing Audit..',
 ) {
-
-  case $::kernel {
+  case $facts['kernel'] {
     'Linux': {
-      case $::operatingsystem {
+      case $facts['os']['name'] {
         'Debian', 'debian', 'Ubuntu', 'ubuntu': {
           package { $audit_package_title:
             name => 'auditd',
@@ -18,7 +17,7 @@ class wazuh::audit (
         }
         default: {
           package { $audit_package_title:
-            name => 'audit'
+            name => 'audit',
           }
         }
       }
@@ -31,7 +30,7 @@ class wazuh::audit (
 
       if $audit_manage_rules == true {
         file { '/etc/audit/rules.d/audit.rules':
-          ensure  => present,
+          ensure  => file,
           require => Service['auditd'],
         }
 
@@ -39,13 +38,13 @@ class wazuh::audit (
           file_line { "Append rule ${rule} to /etc/audit/rules.d/audit.rules":
             path    => '/etc/audit/rules.d/audit.rules',
             line    => $rule,
-            require => File['/etc/audit/rules.d/audit.rules']
+            require => File['/etc/audit/rules.d/audit.rules'],
           }
         }
       }
     }
     default: {
-      fail("Module Audit not supported on ${::operatingsystem}")
+      fail("Module Audit not supported on ${facts['os']['name']}")
     }
   }
 }

--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -35,12 +35,12 @@ class wazuh::certificates (
     ],
   }
   file { 'Copy all certificates into module':
-    ensure => 'directory',
-    source => '/tmp/wazuh-certificates/',
+    ensure  => 'directory',
+    source  => '/tmp/wazuh-certificates/',
     recurse => 'remote',
-    path => '/etc/puppetlabs/code/environments/production/modules/archive/files/',
-    owner => 'root',
-    group => 'root',
-    mode  => '0755',
+    path    => '/etc/puppetlabs/code/environments/production/modules/archive/files/',
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0755',
   }
 }

--- a/manifests/command.pp
+++ b/manifests/command.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Define an ossec command
-define wazuh::command(
+define wazuh::command (
   $command_name,
   $command_executable,
   $command_expect  = 'srcip',

--- a/manifests/dashboard.pp
+++ b/manifests/dashboard.pp
@@ -11,6 +11,9 @@ class wazuh::dashboard (
   $dashboard_fileuser = 'wazuh-dashboard',
   $dashboard_filegroup = 'wazuh-dashboard',
 
+  $dashboard_cert_content = 'puppet:///modules/archive/dashboard.pem',
+  $dashboard_certkey_content = 'puppet:///modules/archive/dashboard-key.pem',
+  $dashboard_rootca_content = 'puppet:///modules/archive/root-ca.pem',
   $dashboard_server_port = '443',
   $dashboard_server_host = '0.0.0.0',
   $dashboard_server_hosts = "https://${indexer_server_ip}:${indexer_server_port}",
@@ -32,7 +35,6 @@ class wazuh::dashboard (
   ],
 
 ) {
-
   # assign version according to the package manager
   case $facts['os']['family'] {
     'Debian': {
@@ -62,20 +64,34 @@ class wazuh::dashboard (
     mode   => '0500',
   }
 
-  [
-    'dashboard.pem',
-    'dashboard-key.pem',
-    'root-ca.pem',
-  ].each |String $certfile| {
-    file { "${dashboard_path_certs}/${certfile}":
-      ensure  => file,
-      owner   => $dashboard_fileuser,
-      group   => $dashboard_filegroup,
-      mode    => '0400',
-      replace => true,
-      recurse => remote,
-      source  => "puppet:///modules/archive/${certfile}",
-    }
+  file { "${dashboard_path_certs}/dashboard.pem":
+    ensure  => file,
+    owner   => $dashboard_fileuser,
+    group   => $dashboard_filegroup,
+    mode    => '0400',
+    source  => $dashboard_cert_content,
+    require => Package['wazuh-dashboard'],
+    notify  => Service['wazuh-dashboard'],
+  }
+
+  file { "${dashboard_path_certs}/dashboard-key.pem":
+    ensure  => file,
+    owner   => $dashboard_fileuser,
+    group   => $dashboard_filegroup,
+    mode    => '0400',
+    source  => $dashboard_certkey_content,
+    require => Package['wazuh-dashboard'],
+    notify  => Service['wazuh-dashboard'],
+  }
+
+  file { "${dashboard_path_certs}/root-ca.pem":
+    ensure  => file,
+    owner   => $dashboard_fileuser,
+    group   => $dashboard_filegroup,
+    mode    => '0400',
+    source  => $dashboard_rootca_content,
+    require => Package['wazuh-dashboard'],
+    notify  => Service['wazuh-dashboard'],
   }
 
   file { '/etc/wazuh-dashboard/opensearch_dashboards.yml':
@@ -87,7 +103,7 @@ class wazuh::dashboard (
     notify  => Service['wazuh-dashboard'],
   }
 
-  file { [ '/usr/share/wazuh-dashboard/data/wazuh/', '/usr/share/wazuh-dashboard/data/wazuh/config' ]:
+  file { ['/usr/share/wazuh-dashboard/data/wazuh/', '/usr/share/wazuh-dashboard/data/wazuh/config']:
     ensure  => 'directory',
     group   => $dashboard_filegroup,
     mode    => '0755',

--- a/manifests/email_alert.pp
+++ b/manifests/email_alert.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Define an email alert
-define wazuh::email_alert(
+define wazuh::email_alert (
   $alert_email,
   $alert_group    = false,
   $target_arg     = 'manager_ossec.conf',

--- a/manifests/filebeat_oss.pp
+++ b/manifests/filebeat_oss.pp
@@ -20,7 +20,6 @@ class wazuh::filebeat_oss (
   $filebeat_filegroup = 'root',
   $filebeat_path_certs = '/etc/filebeat/certs',
 ) {
-
   package { 'filebeat':
     ensure => $filebeat_oss_version,
     name   => $filebeat_oss_package,

--- a/manifests/indexer.pp
+++ b/manifests/indexer.pp
@@ -12,6 +12,12 @@ class wazuh::indexer (
   $indexer_fileuser = 'wazuh-indexer',
   $indexer_filegroup = 'wazuh-indexer',
 
+  $indexer_node_cert_content = 'puppet:///modules/archive/indexer-node.pem',
+  $indexer_node_certkey_content = 'puppet:///modules/archive/indexer-node-key.pem',
+  $indexer_node_rootca_content = 'puppet:///modules/archive/root-ca.pem',
+  $indexer_node_admincert_content = 'puppet:///modules/archive/admin.pem',
+  $indexer_node_adminkey_content = 'puppet:///modules/archive/admin-key.pem',
+
   $indexer_path_data = '/var/lib/wazuh-indexer',
   $indexer_path_logs = '/var/log/wazuh-indexer',
   $indexer_path_certs = '/etc/wazuh-indexer/certs',
@@ -22,12 +28,11 @@ class wazuh::indexer (
   $indexer_port = '9200',
   $indexer_discovery_hosts = [], # Empty array for single-node configuration
   $indexer_cluster_initial_master_nodes = ['node-1'],
-  $indexer_cluster_CN = ['node-1'],
+  $indexer_cluster_cn = ['node-1'],
 
   # JVM options
   $jvm_options_memory = '1g',
 ) {
-
   # assign version according to the package manager
   case $facts['os']['family'] {
     'Debian': {
@@ -57,25 +62,55 @@ class wazuh::indexer (
     mode   => '0500',
   }
 
-  [
-   "indexer-$indexer_node_name.pem",
-   "indexer-$indexer_node_name-key.pem",
-   'root-ca.pem',
-   'admin.pem',
-   'admin-key.pem',
-  ].each |String $certfile| {
-    file { "${indexer_path_certs}/${certfile}":
-      ensure  => file,
-      owner   => $indexer_fileuser,
-      group   => $indexer_filegroup,
-      mode    => '0400',
-      replace => true,
-      recurse => remote,
-      source  => "puppet:///modules/archive/${certfile}",
-    }
+  file { "${indexer_path_certs}/indexer-${indexer_node_name}.pem":
+    ensure  => file,
+    owner   => $indexer_fileuser,
+    group   => $indexer_filegroup,
+    mode    => '0400',
+    source  => $indexer_node_cert_content,
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
   }
 
+  file { "${indexer_path_certs}/indexer-${indexer_node_name}-key.pem":
+    ensure  => file,
+    owner   => $indexer_fileuser,
+    group   => $indexer_filegroup,
+    mode    => '0400',
+    source  => $indexer_node_certkey_content,
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
 
+  file { "${indexer_path_certs}/root-ca.pem":
+    ensure  => file,
+    owner   => $indexer_fileuser,
+    group   => $indexer_filegroup,
+    mode    => '0400',
+    source  => $indexer_node_rootca_content,
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
+  file { "${indexer_path_certs}/admin.pem":
+    ensure  => file,
+    owner   => $indexer_fileuser,
+    group   => $indexer_filegroup,
+    mode    => '0400',
+    source  => $indexer_node_admincert_content,
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
+
+  file { "${indexer_path_certs}/admin-key.pem":
+    ensure  => file,
+    owner   => $indexer_fileuser,
+    group   => $indexer_filegroup,
+    mode    => '0400',
+    source  => $indexer_node_adminkey_content,
+    require => Package['wazuh-indexer'],
+    notify  => Service['wazuh-indexer'],
+  }
 
   file { 'configuration file':
     path    => '/etc/wazuh-indexer/opensearch.yml',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,3 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Blank container class
-class wazuh { }
+class wazuh {}

--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 #Define for a specific ossec integration
-define wazuh::integration(
+define wazuh::integration (
   $hook_url = '',
   $api_key = '',
   $in_rule_id = '',
@@ -10,12 +10,11 @@ define wazuh::integration(
   $in_format = '',
   $in_max_log = '',
 ) {
-
   require wazuh::params_manager
 
   concat::fragment { $name:
     target  => 'manager_ossec.conf',
     order   => 60,
-    content => template('wazuh/fragments/_integration.erb')
+    content => template('wazuh/fragments/_integration.erb'),
   }
 }

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -2,330 +2,300 @@
 # Main ossec server config
 class wazuh::manager (
 
-    # Installation
+  # Installation
+  $server_package_version           = $wazuh::params_manager::server_package_version,
+  $manage_firewall                  = $wazuh::params_manager::manage_firewall,
 
-      $server_package_version           = $wazuh::params_manager::server_package_version,
-      $manage_firewall                  = $wazuh::params_manager::manage_firewall,
+  ### Ossec.conf blocks
 
+  ## Global
+  $ossec_logall                     = $wazuh::params_manager::ossec_logall,
+  $ossec_logall_json                = $wazuh::params_manager::ossec_logall_json,
+  $ossec_emailnotification          = $wazuh::params_manager::ossec_emailnotification,
+  $ossec_emailto                    = $wazuh::params_manager::ossec_emailto,
+  $ossec_smtp_server                = $wazuh::params_manager::ossec_smtp_server,
+  $ossec_emailfrom                  = $wazuh::params_manager::ossec_emailfrom,
+  $ossec_email_maxperhour           = $wazuh::params_manager::ossec_email_maxperhour,
+  $ossec_email_log_source           = $wazuh::params_manager::ossec_email_log_source,
+  $ossec_email_idsname              = $wazuh::params_manager::ossec_email_idsname,
+  $ossec_white_list                 = $wazuh::params_manager::ossec_white_list,
+  $ossec_alert_level                = $wazuh::params_manager::ossec_alert_level,
+  $ossec_email_alert_level          = $wazuh::params_manager::ossec_email_alert_level,
+  $ossec_remote_connection          = $wazuh::params_manager::ossec_remote_connection,
+  $ossec_remote_port                = $wazuh::params_manager::ossec_remote_port,
+  $ossec_remote_protocol            = $wazuh::params_manager::ossec_remote_protocol,
+  $ossec_remote_local_ip            = $wazuh::params_manager::ossec_remote_local_ip,
+  $ossec_remote_allowed_ips         = $wazuh::params_manager::ossec_remote_allowed_ips,
+  $ossec_remote_queue_size          = $wazuh::params_manager::ossec_remote_queue_size,
 
-    ### Ossec.conf blocks
+  # ossec.conf generation parameters
+  $configure_rootcheck                  = $wazuh::params_manager::configure_rootcheck,
+  $configure_wodle_openscap             = $wazuh::params_manager::configure_wodle_openscap,
+  $configure_wodle_cis_cat              = $wazuh::params_manager::configure_wodle_cis_cat,
+  $configure_wodle_osquery              = $wazuh::params_manager::configure_wodle_osquery,
+  $configure_wodle_syscollector         = $wazuh::params_manager::configure_wodle_syscollector,
+  $configure_wodle_docker_listener      = $wazuh::params_manager::configure_wodle_docker_listener,
+  $configure_vulnerability_detection    = $wazuh::params_manager::configure_vulnerability_detection,
+  $configure_vulnerability_indexer      = $wazuh::params_manager::configure_vulnerability_indexer,
+  $configure_sca                        = $wazuh::params_manager::configure_sca,
+  $configure_syscheck                   = $wazuh::params_manager::configure_syscheck,
+  $configure_command                    = $wazuh::params_manager::configure_command,
+  $configure_localfile                  = $wazuh::params_manager::configure_localfile,
+  $configure_ruleset                    = $wazuh::params_manager::configure_ruleset,
+  $configure_auth                       = $wazuh::params_manager::configure_auth,
+  $configure_cluster                    = $wazuh::params_manager::configure_cluster,
+  $configure_active_response            = $wazuh::params_manager::configure_active_response,
 
-      ## Global
+  # ossec.conf templates paths
+  $ossec_manager_template                       = $wazuh::params_manager::ossec_manager_template,
+  $ossec_rootcheck_template                     = $wazuh::params_manager::ossec_rootcheck_template,
+  $ossec_wodle_openscap_template                = $wazuh::params_manager::ossec_wodle_openscap_template,
+  $ossec_wodle_cis_cat_template                 = $wazuh::params_manager::ossec_wodle_cis_cat_template,
+  $ossec_wodle_osquery_template                 = $wazuh::params_manager::ossec_wodle_osquery_template,
+  $ossec_wodle_syscollector_template            = $wazuh::params_manager::ossec_wodle_syscollector_template,
+  $ossec_wodle_docker_listener_template         = $wazuh::params_manager::ossec_wodle_docker_listener_template,
+  $ossec_vulnerability_detection_template       = $wazuh::params_manager::ossec_vulnerability_detection_template,
+  $ossec_vulnerability_indexer_template         = $wazuh::params_manager::ossec_vulnerability_indexer_template,
+  $ossec_sca_template                           = $wazuh::params_manager::ossec_sca_template,
+  $ossec_syscheck_template                      = $wazuh::params_manager::ossec_syscheck_template,
+  $ossec_default_commands_template              = $wazuh::params_manager::ossec_default_commands_template,
+  $ossec_localfile_template                     = $wazuh::params_manager::ossec_localfile_template,
+  $ossec_ruleset_template                       = $wazuh::params_manager::ossec_ruleset_template,
+  $ossec_auth_template                          = $wazuh::params_manager::ossec_auth_template,
+  $ossec_cluster_template                       = $wazuh::params_manager::ossec_cluster_template,
+  $ossec_active_response_template               = $wazuh::params_manager::ossec_active_response_template,
+  $ossec_syslog_output_template                 = $wazuh::params_manager::ossec_syslog_output_template,
 
-      $ossec_logall                     = $wazuh::params_manager::ossec_logall,
-      $ossec_logall_json                = $wazuh::params_manager::ossec_logall_json,
-      $ossec_emailnotification          = $wazuh::params_manager::ossec_emailnotification,
-      $ossec_emailto                    = $wazuh::params_manager::ossec_emailto,
-      $ossec_smtp_server                = $wazuh::params_manager::ossec_smtp_server,
-      $ossec_emailfrom                  = $wazuh::params_manager::ossec_emailfrom,
-      $ossec_email_maxperhour           = $wazuh::params_manager::ossec_email_maxperhour,
-      $ossec_email_log_source           = $wazuh::params_manager::ossec_email_log_source,
-      $ossec_email_idsname              = $wazuh::params_manager::ossec_email_idsname,
-      $ossec_white_list                 = $wazuh::params_manager::ossec_white_list,
-      $ossec_alert_level                = $wazuh::params_manager::ossec_alert_level,
-      $ossec_email_alert_level          = $wazuh::params_manager::ossec_email_alert_level,
-      $ossec_remote_connection          = $wazuh::params_manager::ossec_remote_connection,
-      $ossec_remote_port                = $wazuh::params_manager::ossec_remote_port,
-      $ossec_remote_protocol            = $wazuh::params_manager::ossec_remote_protocol,
-      $ossec_remote_local_ip            = $wazuh::params_manager::ossec_remote_local_ip,
-      $ossec_remote_allowed_ips         = $wazuh::params_manager::ossec_remote_allowed_ips,
-      $ossec_remote_queue_size          = $wazuh::params_manager::ossec_remote_queue_size,
+  # active-response
+  $ossec_active_response_command                =  $wazuh::params_manager::active_response_command,
+  $ossec_active_response_location               =  $wazuh::params_manager::active_response_location,
+  $ossec_active_response_level                  =  $wazuh::params_manager::active_response_level,
+  $ossec_active_response_agent_id               =  $wazuh::params_manager::active_response_agent_id,
+  $ossec_active_response_rules_id               =  $wazuh::params_manager::active_response_rules_id,
+  $ossec_active_response_timeout                =  $wazuh::params_manager::active_response_timeout,
+  $ossec_active_response_repeated_offenders     =  $wazuh::params_manager::active_response_repeated_offenders,
 
-      # ossec.conf generation parameters
+  ## Rootcheck
+  $ossec_rootcheck_disabled             = $wazuh::params_manager::ossec_rootcheck_disabled,
+  $ossec_rootcheck_check_files          = $wazuh::params_manager::ossec_rootcheck_check_files,
+  $ossec_rootcheck_check_trojans        = $wazuh::params_manager::ossec_rootcheck_check_trojans,
+  $ossec_rootcheck_check_dev            = $wazuh::params_manager::ossec_rootcheck_check_dev,
+  $ossec_rootcheck_check_sys            = $wazuh::params_manager::ossec_rootcheck_check_sys,
+  $ossec_rootcheck_check_pids           = $wazuh::params_manager::ossec_rootcheck_check_pids,
+  $ossec_rootcheck_check_ports          = $wazuh::params_manager::ossec_rootcheck_check_ports,
+  $ossec_rootcheck_check_if             = $wazuh::params_manager::ossec_rootcheck_check_if,
+  $ossec_rootcheck_frequency            = $wazuh::params_manager::ossec_rootcheck_frequency,
+  $ossec_rootcheck_ignore_list          = $wazuh::params_manager::ossec_rootcheck_ignore_list,
+  $ossec_rootcheck_ignore_sregex_list   = $wazuh::params_manager::ossec_rootcheck_ignore_sregex_list,
+  $ossec_rootcheck_rootkit_files        = $wazuh::params_manager::ossec_rootcheck_rootkit_files,
+  $ossec_rootcheck_rootkit_trojans      = $wazuh::params_manager::ossec_rootcheck_rootkit_trojans,
+  $ossec_rootcheck_skip_nfs             = $wazuh::params_manager::ossec_rootcheck_skip_nfs,
+  $ossec_rootcheck_system_audit         = $wazuh::params_manager::ossec_rootcheck_system_audit,
 
-      $configure_rootcheck                  = $wazuh::params_manager::configure_rootcheck,
-      $configure_wodle_openscap             = $wazuh::params_manager::configure_wodle_openscap,
-      $configure_wodle_cis_cat              = $wazuh::params_manager::configure_wodle_cis_cat,
-      $configure_wodle_osquery              = $wazuh::params_manager::configure_wodle_osquery,
-      $configure_wodle_syscollector         = $wazuh::params_manager::configure_wodle_syscollector,
-      $configure_wodle_docker_listener      = $wazuh::params_manager::configure_wodle_docker_listener,
-      $configure_vulnerability_detection    = $wazuh::params_manager::configure_vulnerability_detection,
-      $configure_vulnerability_indexer      = $wazuh::params_manager::configure_vulnerability_indexer,
-      $configure_sca                        = $wazuh::params_manager::configure_sca,
-      $configure_syscheck                   = $wazuh::params_manager::configure_syscheck,
-      $configure_command                    = $wazuh::params_manager::configure_command,
-      $configure_localfile                  = $wazuh::params_manager::configure_localfile,
-      $configure_ruleset                    = $wazuh::params_manager::configure_ruleset,
-      $configure_auth                       = $wazuh::params_manager::configure_auth,
-      $configure_cluster                    = $wazuh::params_manager::configure_cluster,
-      $configure_active_response            = $wazuh::params_manager::configure_active_response,
+  # SCA
 
-    # ossec.conf templates paths
-      $ossec_manager_template                       = $wazuh::params_manager::ossec_manager_template,
-      $ossec_rootcheck_template                     = $wazuh::params_manager::ossec_rootcheck_template,
-      $ossec_wodle_openscap_template                = $wazuh::params_manager::ossec_wodle_openscap_template,
-      $ossec_wodle_cis_cat_template                 = $wazuh::params_manager::ossec_wodle_cis_cat_template,
-      $ossec_wodle_osquery_template                 = $wazuh::params_manager::ossec_wodle_osquery_template,
-      $ossec_wodle_syscollector_template            = $wazuh::params_manager::ossec_wodle_syscollector_template,
-      $ossec_wodle_docker_listener_template         = $wazuh::params_manager::ossec_wodle_docker_listener_template,
-      $ossec_vulnerability_detection_template       = $wazuh::params_manager::ossec_vulnerability_detection_template,
-      $ossec_vulnerability_indexer_template         = $wazuh::params_manager::ossec_vulnerability_indexer_template,
-      $ossec_sca_template                           = $wazuh::params_manager::ossec_sca_template,
-      $ossec_syscheck_template                      = $wazuh::params_manager::ossec_syscheck_template,
-      $ossec_default_commands_template              = $wazuh::params_manager::ossec_default_commands_template,
-      $ossec_localfile_template                     = $wazuh::params_manager::ossec_localfile_template,
-      $ossec_ruleset_template                       = $wazuh::params_manager::ossec_ruleset_template,
-      $ossec_auth_template                          = $wazuh::params_manager::ossec_auth_template,
-      $ossec_cluster_template                       = $wazuh::params_manager::ossec_cluster_template,
-      $ossec_active_response_template               = $wazuh::params_manager::ossec_active_response_template,
-      $ossec_syslog_output_template                 = $wazuh::params_manager::ossec_syslog_output_template,
+  ## Amazon
+  $sca_amazon_enabled = $wazuh::params_manager::sca_amazon_enabled,
+  $sca_amazon_scan_on_start = $wazuh::params_manager::sca_amazon_scan_on_start,
+  $sca_amazon_interval = $wazuh::params_manager::sca_amazon_interval,
+  $sca_amazon_skip_nfs = $wazuh::params_manager::sca_amazon_skip_nfs,
+  $sca_amazon_policies = $wazuh::params_manager::sca_amazon_policies,
 
-      # active-response
-      $ossec_active_response_command                =  $wazuh::params_manager::active_response_command,
-      $ossec_active_response_location               =  $wazuh::params_manager::active_response_location,
-      $ossec_active_response_level                  =  $wazuh::params_manager::active_response_level,
-      $ossec_active_response_agent_id               =  $wazuh::params_manager::active_response_agent_id,
-      $ossec_active_response_rules_id               =  $wazuh::params_manager::active_response_rules_id,
-      $ossec_active_response_timeout                =  $wazuh::params_manager::active_response_timeout,
-      $ossec_active_response_repeated_offenders     =  $wazuh::params_manager::active_response_repeated_offenders,
+  ## RHEL
+  $sca_rhel_enabled = $wazuh::params_manager::sca_rhel_enabled,
+  $sca_rhel_scan_on_start = $wazuh::params_manager::sca_rhel_scan_on_start,
+  $sca_rhel_interval = $wazuh::params_manager::sca_rhel_interval,
+  $sca_rhel_skip_nfs = $wazuh::params_manager::sca_rhel_skip_nfs,
+  $sca_rhel_policies = $wazuh::params_manager::sca_rhel_policies,
 
+  ## <Linux else>
+  $sca_else_enabled = $wazuh::params_manager::sca_else_enabled,
+  $sca_else_scan_on_start = $wazuh::params_manager::sca_else_scan_on_start,
+  $sca_else_interval = $wazuh::params_manager::sca_else_interval,
+  $sca_else_skip_nfs = $wazuh::params_manager::sca_else_skip_nfs,
+  $sca_else_policies = $wazuh::params_manager::sca_else_policies,
 
-      ## Rootcheck
+  ## Wodles
 
-      $ossec_rootcheck_disabled             = $wazuh::params_manager::ossec_rootcheck_disabled,
-      $ossec_rootcheck_check_files          = $wazuh::params_manager::ossec_rootcheck_check_files,
-      $ossec_rootcheck_check_trojans        = $wazuh::params_manager::ossec_rootcheck_check_trojans,
-      $ossec_rootcheck_check_dev            = $wazuh::params_manager::ossec_rootcheck_check_dev,
-      $ossec_rootcheck_check_sys            = $wazuh::params_manager::ossec_rootcheck_check_sys,
-      $ossec_rootcheck_check_pids           = $wazuh::params_manager::ossec_rootcheck_check_pids,
-      $ossec_rootcheck_check_ports          = $wazuh::params_manager::ossec_rootcheck_check_ports,
-      $ossec_rootcheck_check_if             = $wazuh::params_manager::ossec_rootcheck_check_if,
-      $ossec_rootcheck_frequency            = $wazuh::params_manager::ossec_rootcheck_frequency,
-      $ossec_rootcheck_ignore_list          = $wazuh::params_manager::ossec_rootcheck_ignore_list,
-      $ossec_rootcheck_ignore_sregex_list   = $wazuh::params_manager::ossec_rootcheck_ignore_sregex_list,
-      $ossec_rootcheck_rootkit_files        = $wazuh::params_manager::ossec_rootcheck_rootkit_files,
-      $ossec_rootcheck_rootkit_trojans      = $wazuh::params_manager::ossec_rootcheck_rootkit_trojans,
-      $ossec_rootcheck_skip_nfs             = $wazuh::params_manager::ossec_rootcheck_skip_nfs,
-      $ossec_rootcheck_system_audit         = $wazuh::params_manager::ossec_rootcheck_system_audit,
+  #openscap
+  $wodle_openscap_disabled              = $wazuh::params_manager::wodle_openscap_disabled,
+  $wodle_openscap_timeout               = $wazuh::params_manager::wodle_openscap_timeout,
+  $wodle_openscap_interval              = $wazuh::params_manager::wodle_openscap_interval,
+  $wodle_openscap_scan_on_start         = $wazuh::params_manager::wodle_openscap_scan_on_start,
 
-      # SCA
+  #cis-cat
+  $wodle_ciscat_disabled                = $wazuh::params_manager::wodle_ciscat_disabled,
+  $wodle_ciscat_timeout                 = $wazuh::params_manager::wodle_ciscat_timeout,
+  $wodle_ciscat_interval                = $wazuh::params_manager::wodle_ciscat_interval,
+  $wodle_ciscat_scan_on_start           = $wazuh::params_manager::wodle_ciscat_scan_on_start,
+  $wodle_ciscat_java_path               = $wazuh::params_manager::wodle_ciscat_java_path,
+  $wodle_ciscat_ciscat_path             = $wazuh::params_manager::wodle_ciscat_ciscat_path,
 
-      ## Amazon
-      $sca_amazon_enabled = $wazuh::params_manager::sca_amazon_enabled,
-      $sca_amazon_scan_on_start = $wazuh::params_manager::sca_amazon_scan_on_start,
-      $sca_amazon_interval = $wazuh::params_manager::sca_amazon_interval,
-      $sca_amazon_skip_nfs = $wazuh::params_manager::sca_amazon_skip_nfs,
-      $sca_amazon_policies = $wazuh::params_manager::sca_amazon_policies,
+  #osquery
+  $wodle_osquery_disabled               = $wazuh::params_manager::wodle_osquery_disabled,
+  $wodle_osquery_run_daemon             = $wazuh::params_manager::wodle_osquery_run_daemon,
+  $wodle_osquery_log_path               = $wazuh::params_manager::wodle_osquery_log_path,
+  $wodle_osquery_config_path            = $wazuh::params_manager::wodle_osquery_config_path,
+  $wodle_osquery_add_labels             = $wazuh::params_manager::wodle_osquery_add_labels,
 
-      ## RHEL
-      $sca_rhel_enabled = $wazuh::params_manager::sca_rhel_enabled,
-      $sca_rhel_scan_on_start = $wazuh::params_manager::sca_rhel_scan_on_start,
-      $sca_rhel_interval = $wazuh::params_manager::sca_rhel_interval,
-      $sca_rhel_skip_nfs = $wazuh::params_manager::sca_rhel_skip_nfs,
-      $sca_rhel_policies = $wazuh::params_manager::sca_rhel_policies,
+  #syscollector
+  $wodle_syscollector_disabled          = $wazuh::params_manager::wodle_syscollector_disabled,
+  $wodle_syscollector_interval          = $wazuh::params_manager::wodle_syscollector_interval,
+  $wodle_syscollector_scan_on_start     = $wazuh::params_manager::wodle_syscollector_scan_on_start,
+  $wodle_syscollector_hardware          = $wazuh::params_manager::wodle_syscollector_hardware,
+  $wodle_syscollector_os                = $wazuh::params_manager::wodle_syscollector_os,
+  $wodle_syscollector_network           = $wazuh::params_manager::wodle_syscollector_network,
+  $wodle_syscollector_packages          = $wazuh::params_manager::wodle_syscollector_packages,
+  $wodle_syscollector_ports             = $wazuh::params_manager::wodle_syscollector_ports,
+  $wodle_syscollector_processes         = $wazuh::params_manager::wodle_syscollector_processes,
 
-      ## <Linux else>
-      $sca_else_enabled = $wazuh::params_manager::sca_else_enabled,
-      $sca_else_scan_on_start = $wazuh::params_manager::sca_else_scan_on_start,
-      $sca_else_interval = $wazuh::params_manager::sca_else_interval,
-      $sca_else_skip_nfs = $wazuh::params_manager::sca_else_skip_nfs,
-      $sca_else_policies = $wazuh::params_manager::sca_else_policies,
+  #docker-listener
+  $wodle_docker_listener_disabled       = $wazuh::params_manager::wodle_docker_listener_disabled,
 
+  #vulnerability-detection
+  $vulnerability_detection_enabled                  = $wazuh::params_manager::vulnerability_detection_enabled,
+  $vulnerability_detection_index_status             = $wazuh::params_manager::vulnerability_detection_index_status,
+  $vulnerability_detection_feed_update_interval     = $wazuh::params_manager::vulnerability_detection_feed_update_interval,
 
-      ## Wodles
+  #vulnerability-indexer
+  $vulnerability_indexer_enabled            = $wazuh::params_manager::vulnerability_indexer_enabled,
+  $vulnerability_indexer_hosts_host         = $wazuh::params_manager::vulnerability_indexer_hosts_host,
+  $vulnerability_indexer_hosts_port         = $wazuh::params_manager::vulnerability_indexer_hosts_port,
+  $vulnerability_indexer_username           = $wazuh::params_manager::vulnerability_indexer_username,
+  $vulnerability_indexer_password           = $wazuh::params_manager::vulnerability_indexer_password,
+  $vulnerability_indexer_ssl_ca             = $wazuh::params_manager::vulnerability_indexer_ssl_ca,
+  $vulnerability_indexer_ssl_certificate    = $wazuh::params_manager::vulnerability_indexer_ssl_certificate,
+  $vulnerability_indexer_ssl_key            = $wazuh::params_manager::vulnerability_indexer_ssl_key,
 
-      #openscap
-      $wodle_openscap_disabled              = $wazuh::params_manager::wodle_openscap_disabled,
-      $wodle_openscap_timeout               = $wazuh::params_manager::wodle_openscap_timeout,
-      $wodle_openscap_interval              = $wazuh::params_manager::wodle_openscap_interval,
-      $wodle_openscap_scan_on_start         = $wazuh::params_manager::wodle_openscap_scan_on_start,
+  # syslog
+  $syslog_output                        = $wazuh::params_manager::syslog_output,
+  $syslog_output_level                  = $wazuh::params_manager::syslog_output_level,
+  $syslog_output_port                   = $wazuh::params_manager::syslog_output_port,
+  $syslog_output_server                 = $wazuh::params_manager::syslog_output_server,
+  $syslog_output_format                 = $wazuh::params_manager::syslog_output_format,
 
-      #cis-cat
-      $wodle_ciscat_disabled                = $wazuh::params_manager::wodle_ciscat_disabled,
-      $wodle_ciscat_timeout                 = $wazuh::params_manager::wodle_ciscat_timeout,
-      $wodle_ciscat_interval                = $wazuh::params_manager::wodle_ciscat_interval,
-      $wodle_ciscat_scan_on_start           = $wazuh::params_manager::wodle_ciscat_scan_on_start,
-      $wodle_ciscat_java_path               = $wazuh::params_manager::wodle_ciscat_java_path,
-      $wodle_ciscat_ciscat_path             = $wazuh::params_manager::wodle_ciscat_ciscat_path,
+  # Authd configuration
+  $ossec_auth_disabled                  = $wazuh::params_manager::ossec_auth_disabled,
+  $ossec_auth_port                      = $wazuh::params_manager::ossec_auth_port,
+  $ossec_auth_use_source_ip             = $wazuh::params_manager::ossec_auth_use_source_ip,
+  $ossec_auth_force_enabled             = $wazuh::params_manager::ossec_auth_force_enabled,
+  $ossec_auth_force_key_mismatch        = $wazuh::params_manager::ossec_auth_force_key_mismatch,
+  $ossec_auth_force_disc_time           = $wazuh::params_manager::ossec_auth_force_disc_time,
+  $ossec_auth_force_after_reg_time      = $wazuh::params_manager::ossec_auth_force_after_reg_time,
+  $ossec_auth_purgue                    = $wazuh::params_manager::ossec_auth_purgue,
+  $ossec_auth_use_password              = $wazuh::params_manager::ossec_auth_use_password,
+  $ossec_auth_limit_maxagents           = $wazuh::params_manager::ossec_auth_limit_maxagents,
+  $ossec_auth_ciphers                   = $wazuh::params_manager::ossec_auth_ciphers,
+  $ossec_auth_ssl_verify_host           = $wazuh::params_manager::ossec_auth_ssl_verify_host,
+  $ossec_auth_ssl_manager_cert          = $wazuh::params_manager::ossec_auth_ssl_manager_cert,
+  $ossec_auth_ssl_manager_key           = $wazuh::params_manager::ossec_auth_ssl_manager_key,
+  $ossec_auth_ssl_auto_negotiate        = $wazuh::params_manager::ossec_auth_ssl_auto_negotiate,
 
-      #osquery
-      $wodle_osquery_disabled               = $wazuh::params_manager::wodle_osquery_disabled,
-      $wodle_osquery_run_daemon             = $wazuh::params_manager::wodle_osquery_run_daemon,
-      $wodle_osquery_log_path               = $wazuh::params_manager::wodle_osquery_log_path,
-      $wodle_osquery_config_path            = $wazuh::params_manager::wodle_osquery_config_path,
-      $wodle_osquery_add_labels             = $wazuh::params_manager::wodle_osquery_add_labels,
+  # syscheck
+  $ossec_syscheck_disabled              = $wazuh::params_manager::ossec_syscheck_disabled,
+  $ossec_syscheck_frequency             = $wazuh::params_manager::ossec_syscheck_frequency,
+  $ossec_syscheck_scan_on_start         = $wazuh::params_manager::ossec_syscheck_scan_on_start,
+  $ossec_syscheck_auto_ignore           = $wazuh::params_manager::ossec_syscheck_auto_ignore,
+  $ossec_syscheck_directories_1         = $wazuh::params_manager::ossec_syscheck_directories_1,
+  $ossec_syscheck_directories_2         = $wazuh::params_manager::ossec_syscheck_directories_2,
+  $ossec_syscheck_whodata_directories_1            = $wazuh::params_manager::ossec_syscheck_whodata_directories_1,
+  $ossec_syscheck_realtime_directories_1           = $wazuh::params_manager::ossec_syscheck_realtime_directories_1,
+  $ossec_syscheck_whodata_directories_2            = $wazuh::params_manager::ossec_syscheck_whodata_directories_2,
+  $ossec_syscheck_realtime_directories_2           = $wazuh::params_manager::ossec_syscheck_realtime_directories_2,
+  $ossec_syscheck_ignore_list           = $wazuh::params_manager::ossec_syscheck_ignore_list,
 
-      #syscollector
-      $wodle_syscollector_disabled          = $wazuh::params_manager::wodle_syscollector_disabled,
-      $wodle_syscollector_interval          = $wazuh::params_manager::wodle_syscollector_interval,
-      $wodle_syscollector_scan_on_start     = $wazuh::params_manager::wodle_syscollector_scan_on_start,
-      $wodle_syscollector_hardware          = $wazuh::params_manager::wodle_syscollector_hardware,
-      $wodle_syscollector_os                = $wazuh::params_manager::wodle_syscollector_os,
-      $wodle_syscollector_network           = $wazuh::params_manager::wodle_syscollector_network,
-      $wodle_syscollector_packages          = $wazuh::params_manager::wodle_syscollector_packages,
-      $wodle_syscollector_ports             = $wazuh::params_manager::wodle_syscollector_ports,
-      $wodle_syscollector_processes         = $wazuh::params_manager::wodle_syscollector_processes,
+  $ossec_syscheck_ignore_type_1         = $wazuh::params_manager::ossec_syscheck_ignore_type_1,
+  $ossec_syscheck_ignore_type_2         = $wazuh::params_manager::ossec_syscheck_ignore_type_2,
+  $ossec_syscheck_process_priority             = $wazuh::params_manager::ossec_syscheck_process_priority,
+  $ossec_syscheck_synchronization_enabled      = $wazuh::params_manager::ossec_syscheck_synchronization_enabled,
+  $ossec_syscheck_synchronization_interval     = $wazuh::params_manager::ossec_syscheck_synchronization_interval,
+  $ossec_syscheck_synchronization_max_eps      = $wazuh::params_manager::ossec_syscheck_synchronization_max_eps,
+  $ossec_syscheck_synchronization_max_interval = $wazuh::params_manager::ossec_syscheck_synchronization_max_interval,
 
-      #docker-listener
-      $wodle_docker_listener_disabled       = $wazuh::params_manager::wodle_docker_listener_disabled,
+  $ossec_syscheck_nodiff                = $wazuh::params_manager::ossec_syscheck_nodiff,
+  $ossec_syscheck_skip_nfs              = $wazuh::params_manager::ossec_syscheck_skip_nfs,
 
-      #vulnerability-detection
-      $vulnerability_detection_enabled                  = $wazuh::params_manager::vulnerability_detection_enabled,
-      $vulnerability_detection_index_status             = $wazuh::params_manager::vulnerability_detection_index_status,
-      $vulnerability_detection_feed_update_interval     = $wazuh::params_manager::vulnerability_detection_feed_update_interval,
+  # Cluster
+  $ossec_cluster_name                   = $wazuh::params_manager::ossec_cluster_name,
+  $ossec_cluster_node_name              = $wazuh::params_manager::ossec_cluster_node_name,
+  $ossec_cluster_node_type              = $wazuh::params_manager::ossec_cluster_node_type,
+  $ossec_cluster_key                    = $wazuh::params_manager::ossec_cluster_key,
+  $ossec_cluster_port                   = $wazuh::params_manager::ossec_cluster_port,
+  $ossec_cluster_bind_addr              = $wazuh::params_manager::ossec_cluster_bind_addr,
+  $ossec_cluster_nodes                  = $wazuh::params_manager::ossec_cluster_nodes,
+  $ossec_cluster_hidden                 = $wazuh::params_manager::ossec_cluster_hidden,
+  $ossec_cluster_disabled               = $wazuh::params_manager::ossec_cluster_disabled,
 
-      #vulnerability-indexer
-      $vulnerability_indexer_enabled            = $wazuh::params_manager::vulnerability_indexer_enabled,
-      $vulnerability_indexer_hosts_host         = $wazuh::params_manager::vulnerability_indexer_hosts_host,
-      $vulnerability_indexer_hosts_port         = $wazuh::params_manager::vulnerability_indexer_hosts_port,
-      $vulnerability_indexer_username           = $wazuh::params_manager::vulnerability_indexer_username,
-      $vulnerability_indexer_password           = $wazuh::params_manager::vulnerability_indexer_password,
-      $vulnerability_indexer_ssl_ca             = $wazuh::params_manager::vulnerability_indexer_ssl_ca,
-      $vulnerability_indexer_ssl_certificate    = $wazuh::params_manager::vulnerability_indexer_ssl_certificate,
-      $vulnerability_indexer_ssl_key            = $wazuh::params_manager::vulnerability_indexer_ssl_key,
+  #----- End of ossec.conf parameters -------
 
-      # syslog
-      $syslog_output                        = $wazuh::params_manager::syslog_output,
-      $syslog_output_level                  = $wazuh::params_manager::syslog_output_level,
-      $syslog_output_port                   = $wazuh::params_manager::syslog_output_port,
-      $syslog_output_server                 = $wazuh::params_manager::syslog_output_server,
-      $syslog_output_format                 = $wazuh::params_manager::syslog_output_format,
+  $ossec_cluster_enable_firewall        = $wazuh::params_manager::ossec_cluster_enable_firewall,
 
-      # Authd configuration
-      $ossec_auth_disabled                  = $wazuh::params_manager::ossec_auth_disabled,
-      $ossec_auth_port                      = $wazuh::params_manager::ossec_auth_port,
-      $ossec_auth_use_source_ip             = $wazuh::params_manager::ossec_auth_use_source_ip,
-      $ossec_auth_force_enabled             = $wazuh::params_manager::ossec_auth_force_enabled,
-      $ossec_auth_force_key_mismatch        = $wazuh::params_manager::ossec_auth_force_key_mismatch,
-      $ossec_auth_force_disc_time           = $wazuh::params_manager::ossec_auth_force_disc_time,
-      $ossec_auth_force_after_reg_time      = $wazuh::params_manager::ossec_auth_force_after_reg_time,
-      $ossec_auth_purgue                    = $wazuh::params_manager::ossec_auth_purgue,
-      $ossec_auth_use_password              = $wazuh::params_manager::ossec_auth_use_password,
-      $ossec_auth_limit_maxagents           = $wazuh::params_manager::ossec_auth_limit_maxagents,
-      $ossec_auth_ciphers                   = $wazuh::params_manager::ossec_auth_ciphers,
-      $ossec_auth_ssl_verify_host           = $wazuh::params_manager::ossec_auth_ssl_verify_host,
-      $ossec_auth_ssl_manager_cert          = $wazuh::params_manager::ossec_auth_ssl_manager_cert,
-      $ossec_auth_ssl_manager_key           = $wazuh::params_manager::ossec_auth_ssl_manager_key,
-      $ossec_auth_ssl_auto_negotiate        = $wazuh::params_manager::ossec_auth_ssl_auto_negotiate,
+  $ossec_prefilter                      = $wazuh::params_manager::ossec_prefilter,
+  $ossec_integratord_enabled            = $wazuh::params_manager::ossec_integratord_enabled,
 
+  $manage_client_keys                   = $wazuh::params_manager::manage_client_keys,
+  $agent_auth_password                  = $wazuh::params_manager::agent_auth_password,
+  $ar_repeated_offenders                = $wazuh::params_manager::ar_repeated_offenders,
 
-      # syscheck
-      $ossec_syscheck_disabled              = $wazuh::params_manager::ossec_syscheck_disabled,
-      $ossec_syscheck_frequency             = $wazuh::params_manager::ossec_syscheck_frequency,
-      $ossec_syscheck_scan_on_start         = $wazuh::params_manager::ossec_syscheck_scan_on_start,
-      $ossec_syscheck_auto_ignore           = $wazuh::params_manager::ossec_syscheck_auto_ignore,
-      $ossec_syscheck_directories_1         = $wazuh::params_manager::ossec_syscheck_directories_1,
-      $ossec_syscheck_directories_2         = $wazuh::params_manager::ossec_syscheck_directories_2,
-      $ossec_syscheck_whodata_directories_1            = $wazuh::params_manager::ossec_syscheck_whodata_directories_1,
-      $ossec_syscheck_realtime_directories_1           = $wazuh::params_manager::ossec_syscheck_realtime_directories_1,
-      $ossec_syscheck_whodata_directories_2            = $wazuh::params_manager::ossec_syscheck_whodata_directories_2,
-      $ossec_syscheck_realtime_directories_2           = $wazuh::params_manager::ossec_syscheck_realtime_directories_2,
-      $ossec_syscheck_ignore_list           = $wazuh::params_manager::ossec_syscheck_ignore_list,
+  $local_decoder_template               = $wazuh::params_manager::local_decoder_template,
+  $decoder_exclude                      = $wazuh::params_manager::decoder_exclude,
+  $local_rules_template                 = $wazuh::params_manager::local_rules_template,
+  $rule_exclude                         = $wazuh::params_manager::rule_exclude,
+  $shared_agent_template                = $wazuh::params_manager::shared_agent_template,
 
-      $ossec_syscheck_ignore_type_1         = $wazuh::params_manager::ossec_syscheck_ignore_type_1,
-      $ossec_syscheck_ignore_type_2         = $wazuh::params_manager::ossec_syscheck_ignore_type_2,
-      $ossec_syscheck_process_priority             = $wazuh::params_manager::ossec_syscheck_process_priority,
-      $ossec_syscheck_synchronization_enabled      = $wazuh::params_manager::ossec_syscheck_synchronization_enabled,
-      $ossec_syscheck_synchronization_interval     = $wazuh::params_manager::ossec_syscheck_synchronization_interval,
-      $ossec_syscheck_synchronization_max_eps      = $wazuh::params_manager::ossec_syscheck_synchronization_max_eps,
-      $ossec_syscheck_synchronization_max_interval = $wazuh::params_manager::ossec_syscheck_synchronization_max_interval,
+  $wazuh_manager_verify_manager_ssl     = $wazuh::params_manager::wazuh_manager_verify_manager_ssl,
+  $wazuh_manager_server_crt             = $wazuh::params_manager::wazuh_manager_server_crt,
+  $wazuh_manager_server_key             = $wazuh::params_manager::wazuh_manager_server_key,
 
-      $ossec_syscheck_nodiff                = $wazuh::params_manager::ossec_syscheck_nodiff,
-      $ossec_syscheck_skip_nfs              = $wazuh::params_manager::ossec_syscheck_skip_nfs,
+  $ossec_local_files                    = $wazuh::params_manager::default_local_files,
 
-      # Cluster
+  # API
+  $wazuh_api_host                           = $wazuh::params_manager::wazuh_api_host,
+  $wazuh_api_port                           = $wazuh::params_manager::wazuh_api_port,
+  $wazuh_api_file                           = $wazuh::params_manager::wazuh_api_file,
+  $wazuh_api_https_enabled                  = $wazuh::params_manager::wazuh_api_https_enabled,
+  $wazuh_api_https_key                      = $wazuh::params_manager::wazuh_api_https_key,
+  $wazuh_api_https_cert                     = $wazuh::params_manager::wazuh_api_https_cert,
+  $wazuh_api_https_use_ca                   = $wazuh::params_manager::wazuh_api_https_use_ca,
+  $wazuh_api_https_ca                       = $wazuh::params_manager::wazuh_api_https_ca,
+  $wazuh_api_logs_level                     = $wazuh::params_manager::wazuh_api_logs_level,
+  $wazuh_api_logs_format                    = $wazuh::params_manager::wazuh_api_logs_format,
+  $wazuh_api_ssl_ciphers                    = $wazuh::params_manager::wazuh_api_ssl_ciphers,
+  $wazuh_api_ssl_protocol                   = $wazuh::params_manager::wazuh_api_ssl_protocol,
+  $wazuh_api_cors_enabled                   = $wazuh::params_manager::wazuh_api_cors_enabled,
+  $wazuh_api_cors_source_route              = $wazuh::params_manager::wazuh_api_cors_source_route,
+  $wazuh_api_cors_expose_headers            = $wazuh::params_manager::wazuh_api_cors_expose_headers,
+  $wazuh_api_cors_allow_credentials         = $wazuh::params_manager::wazuh_api_cors_allow_credentials,
+  $wazuh_api_access_max_login_attempts      = $wazuh::params_manager::wazuh_api_access_max_login_attempts,
+  $wazuh_api_access_block_time              = $wazuh::params_manager::wazuh_api_access_block_time,
+  $wazuh_api_access_max_request_per_minute  = $wazuh::params_manager::wazuh_api_access_max_request_per_minute,
+  $wazuh_api_drop_privileges                = $wazuh::params_manager::wazuh_api_drop_privileges,
+  $wazuh_api_experimental_features          = $wazuh::params_manager::wazuh_api_experimental_features,
 
-      $ossec_cluster_name                   = $wazuh::params_manager::ossec_cluster_name,
-      $ossec_cluster_node_name              = $wazuh::params_manager::ossec_cluster_node_name,
-      $ossec_cluster_node_type              = $wazuh::params_manager::ossec_cluster_node_type,
-      $ossec_cluster_key                    = $wazuh::params_manager::ossec_cluster_key,
-      $ossec_cluster_port                   = $wazuh::params_manager::ossec_cluster_port,
-      $ossec_cluster_bind_addr              = $wazuh::params_manager::ossec_cluster_bind_addr,
-      $ossec_cluster_nodes                  = $wazuh::params_manager::ossec_cluster_nodes,
-      $ossec_cluster_hidden                 = $wazuh::params_manager::ossec_cluster_hidden,
-      $ossec_cluster_disabled               = $wazuh::params_manager::ossec_cluster_disabled,
+  $remote_commands_localfile                = $wazuh::params_manager::remote_commands_localfile,
+  $remote_commands_localfile_exceptions     = $wazuh::params_manager::remote_commands_localfile_exceptions,
+  $remote_commands_wodle                    = $wazuh::params_manager::remote_commands_wodle,
+  $remote_commands_wodle_exceptions         = $wazuh::params_manager::remote_commands_wodle_exceptions,
+  $limits_eps                               = $wazuh::params_manager::limits_eps,
 
-      #----- End of ossec.conf parameters -------
-
-      $ossec_cluster_enable_firewall        = $wazuh::params_manager::ossec_cluster_enable_firewall,
-
-      $ossec_prefilter                      = $wazuh::params_manager::ossec_prefilter,
-      $ossec_integratord_enabled            = $wazuh::params_manager::ossec_integratord_enabled,
-
-      $manage_client_keys                   = $wazuh::params_manager::manage_client_keys,
-      $agent_auth_password                  = $wazuh::params_manager::agent_auth_password,
-      $ar_repeated_offenders                = $wazuh::params_manager::ar_repeated_offenders,
-
-      $local_decoder_template               = $wazuh::params_manager::local_decoder_template,
-      $decoder_exclude                      = $wazuh::params_manager::decoder_exclude,
-      $local_rules_template                 = $wazuh::params_manager::local_rules_template,
-      $rule_exclude                         = $wazuh::params_manager::rule_exclude,
-      $shared_agent_template                = $wazuh::params_manager::shared_agent_template,
-
-      $wazuh_manager_verify_manager_ssl     = $wazuh::params_manager::wazuh_manager_verify_manager_ssl,
-      $wazuh_manager_server_crt             = $wazuh::params_manager::wazuh_manager_server_crt,
-      $wazuh_manager_server_key             = $wazuh::params_manager::wazuh_manager_server_key,
-
-      $ossec_local_files                    = $::wazuh::params_manager::default_local_files,
-
-      # API
-
-
-      $wazuh_api_host                           = $wazuh::params_manager::wazuh_api_host,
-
-      $wazuh_api_port                           = $wazuh::params_manager::wazuh_api_port,
-      $wazuh_api_file                           = $wazuh::params_manager::wazuh_api_file,
-
-      $wazuh_api_https_enabled                  = $wazuh::params_manager::wazuh_api_https_enabled,
-      $wazuh_api_https_key                      = $wazuh::params_manager::wazuh_api_https_key,
-
-      $wazuh_api_https_cert                     = $wazuh::params_manager::wazuh_api_https_cert,
-      $wazuh_api_https_use_ca                   = $wazuh::params_manager::wazuh_api_https_use_ca,
-      $wazuh_api_https_ca                       = $wazuh::params_manager::wazuh_api_https_ca,
-      $wazuh_api_logs_level                     = $wazuh::params_manager::wazuh_api_logs_level,
-      $wazuh_api_logs_format                    = $wazuh::params_manager::wazuh_api_logs_format,
-      $wazuh_api_ssl_ciphers                    = $wazuh::params_manager::wazuh_api_ssl_ciphers,
-      $wazuh_api_ssl_protocol                   = $wazuh::params_manager::wazuh_api_ssl_protocol,
-
-      $wazuh_api_cors_enabled                   = $wazuh::params_manager::wazuh_api_cors_enabled,
-      $wazuh_api_cors_source_route              = $wazuh::params_manager::wazuh_api_cors_source_route,
-      $wazuh_api_cors_expose_headers            = $wazuh::params_manager::wazuh_api_cors_expose_headers,
-
-
-      $wazuh_api_cors_allow_credentials         = $::wazuh::params_manager::wazuh_api_cors_allow_credentials,
-
-      $wazuh_api_access_max_login_attempts      = $::wazuh::params_manager::wazuh_api_access_max_login_attempts,
-      $wazuh_api_access_block_time              = $::wazuh::params_manager::wazuh_api_access_block_time,
-      $wazuh_api_access_max_request_per_minute  = $::wazuh::params_manager::wazuh_api_access_max_request_per_minute,
-      $wazuh_api_drop_privileges                = $::wazuh::params_manager::wazuh_api_drop_privileges,
-      $wazuh_api_experimental_features          = $::wazuh::params_manager::wazuh_api_experimental_features,
-
-      $remote_commands_localfile                = $::wazuh::params_manager::remote_commands_localfile,
-      $remote_commands_localfile_exceptions     = $::wazuh::params_manager::remote_commands_localfile_exceptions,
-      $remote_commands_wodle                    = $::wazuh::params_manager::remote_commands_wodle,
-      $remote_commands_wodle_exceptions         = $::wazuh::params_manager::remote_commands_wodle_exceptions,
-      $limits_eps                               = $::wazuh::params_manager::limits_eps,
-
-      $wazuh_api_template                       = $::wazuh::params_manager::wazuh_api_template,
-
-
-
+  $wazuh_api_template                       = $wazuh::params_manager::wazuh_api_template,
 
 ) inherits wazuh::params_manager {
-  validate_legacy(
-    Boolean, 'validate_bool', $syslog_output,$wazuh_manager_verify_manager_ssl
-  )
-  validate_legacy(
-    Array, 'validate_array', $decoder_exclude, $rule_exclude
-  )
-
   ## Determine which kernel and family puppet is running on. Will be used on _localfile, _rootcheck, _syscheck & _sca
-
-  if ($::kernel == 'windows') {
+  if ($facts['kernel'] == 'windows') {
     $kernel = 'Linux'
-
-  }else{
+  }
+  else {
     $kernel = 'Linux'
-    if ($::osfamily == 'Debian'){
+    if ($facts['os']['family'] == 'Debian') {
       $os_family = 'debian'
-    }else{
+    } else {
       $os_family = 'centos'
     }
   }
 
-
   if ( $ossec_syscheck_whodata_directories_1 == 'yes' ) or ( $ossec_syscheck_whodata_directories_2 == 'yes' ) {
-    case $::operatingsystem {
+    case $facts['os']['name'] {
       'Debian', 'debian', 'Ubuntu', 'ubuntu': {
         package { 'Installing Auditd...':
           name => 'auditd',
@@ -333,7 +303,7 @@ class wazuh::manager (
       }
       default: {
         package { 'Installing Audit...':
-          name => 'audit'
+          name => 'audit',
         }
       }
     }
@@ -345,17 +315,13 @@ class wazuh::manager (
 
   # This allows arrays of integers, sadly
   # (commented due to stdlib version requirement)
-  validate_legacy(Boolean, 'validate_bool', $ossec_emailnotification)
   if ($ossec_emailnotification) {
     if $ossec_smtp_server == undef {
       fail('$ossec_emailnotification is enabled but $smtp_server was not set')
     }
-    validate_legacy(String, 'validate_string', $ossec_smtp_server)
-    validate_legacy(String, 'validate_string', $ossec_emailfrom)
-    validate_legacy(Array, 'validate_array', $ossec_emailto)
   }
 
-  if $::osfamily == 'windows' {
+  if $facts['os']['family'] == 'windows' {
     fail('The ossec module does not yet support installing the OSSEC HIDS server on Windows')
   }
 
@@ -404,36 +370,39 @@ class wazuh::manager (
 
   ## Declaring variables for localfile and wodles generation
 
-  case $::operatingsystem{
+  case $facts['os']['name'] {
     'RedHat', 'OracleLinux':{
       $apply_template_os = 'rhel'
-      if ( $::operatingsystemrelease =~ /^9.*/ ){
+      if ( $facts['os']['release']['full'] =~ /^9.*/ ) {
         $rhel_version = '9'
-      }elsif ( $::operatingsystemrelease =~ /^8.*/ ){
+      }
+      elsif ( $facts['os']['release']['full'] =~ /^8.*/ ) {
         $rhel_version = '8'
-      }elsif ( $::operatingsystemrelease =~ /^7.*/ ){
+      }
+      elsif ( $facts['os']['release']['full'] =~ /^7.*/ ) {
         $rhel_version = '7'
-      }elsif ( $::operatingsystemrelease =~ /^6.*/ ){
+      }
+      elsif ( $facts['os']['release']['full'] =~ /^6.*/ ) {
         $rhel_version = '6'
-      }elsif ( $::operatingsystemrelease =~ /^5.*/ ){
+      }
+      elsif ( $facts['os']['release']['full'] =~ /^5.*/ ) {
         $rhel_version = '5'
-      }else{
+      }
+      else {
         fail('This ossec module has not been tested on your distribution')
       }
-    }'Debian', 'debian', 'Ubuntu', 'ubuntu':{
+    } 'Debian', 'debian', 'Ubuntu', 'ubuntu':{
       $apply_template_os = 'debian'
-      if ( $::lsbdistcodename == 'wheezy') or ($::lsbdistcodename == 'jessie'){
+      if ( $facts['os']['distro']['codename'] == 'wheezy') or ($facts['os']['distro']['codename'] == 'jessie') {
         $debian_additional_templates = 'yes'
       }
-    }'Amazon':{
+    } 'Amazon':{
       $apply_template_os = 'amazon'
-    }'CentOS','Centos','centos':{
+    } 'CentOS','Centos','centos':{
       $apply_template_os = 'centos'
     }
     default: { fail('This ossec module has not been tested on your distribution') }
   }
-
-
 
   concat { 'manager_ossec.conf':
     path    => $wazuh::params_manager::config_file,
@@ -446,15 +415,15 @@ class wazuh::manager (
   concat::fragment {
     'ossec.conf_header':
       target  => 'manager_ossec.conf',
-      order   => 00,
+      order   => '00',
       content => "<ossec_config>\n";
     'ossec.conf_main':
       target  => 'manager_ossec.conf',
-      order   => 01,
+      order   => '01',
       content => template($ossec_manager_template);
   }
 
-  if ($syslog_output == true){
+  if ($syslog_output == true) {
     concat::fragment {
       'ossec.conf_syslog_output':
         target  => 'manager_ossec.conf',
@@ -462,16 +431,16 @@ class wazuh::manager (
     }
   }
 
-  if($configure_rootcheck == true){
+  if($configure_rootcheck == true) {
     concat::fragment {
-        'ossec.conf_rootcheck':
-          order   => 10,
-          target  => 'manager_ossec.conf',
-          content => template($ossec_rootcheck_template);
-      }
+      'ossec.conf_rootcheck':
+        order   => 10,
+        target  => 'manager_ossec.conf',
+        content => template($ossec_rootcheck_template);
+    }
   }
 
-  if ($configure_wodle_openscap == true){
+  if ($configure_wodle_openscap == true) {
     concat::fragment {
       'ossec.conf_wodle_openscap':
         order   => 15,
@@ -479,7 +448,7 @@ class wazuh::manager (
         content => template($ossec_wodle_openscap_template);
     }
   }
-  if ($configure_wodle_cis_cat == true){
+  if ($configure_wodle_cis_cat == true) {
     concat::fragment {
       'ossec.conf_wodle_ciscat':
         order   => 20,
@@ -487,7 +456,7 @@ class wazuh::manager (
         content => template($ossec_wodle_cis_cat_template);
     }
   }
-  if ($configure_wodle_osquery== true){
+  if ($configure_wodle_osquery== true) {
     concat::fragment {
       'ossec.conf_wodle_osquery':
         order   => 25,
@@ -495,7 +464,7 @@ class wazuh::manager (
         content => template($ossec_wodle_osquery_template);
     }
   }
-  if ($configure_wodle_syscollector == true){
+  if ($configure_wodle_syscollector == true) {
     concat::fragment {
       'ossec.conf_wodle_syscollector':
         order   => 30,
@@ -503,7 +472,7 @@ class wazuh::manager (
         content => template($ossec_wodle_syscollector_template);
     }
   }
-  if ($configure_wodle_docker_listener == true){
+  if ($configure_wodle_docker_listener == true) {
     concat::fragment {
       'ossec.conf_wodle_docker_listener':
         order   => 30,
@@ -511,15 +480,15 @@ class wazuh::manager (
         content => template($ossec_wodle_docker_listener_template);
     }
   }
-  if ($configure_sca == true){
+  if ($configure_sca == true) {
     concat::fragment {
       'ossec.conf_sca':
         order   => 40,
         target  => 'manager_ossec.conf',
         content => template($ossec_sca_template);
-      }
+    }
   }
-  if($configure_vulnerability_detection == true){
+  if($configure_vulnerability_detection == true) {
     concat::fragment {
       'ossec.conf_vulnerability_detection':
         order   => 45,
@@ -527,7 +496,7 @@ class wazuh::manager (
         content => template($ossec_vulnerability_detection_template);
     }
   }
-  if($configure_vulnerability_detection == true) or ($configure_vulnerability_indexer == true){
+  if($configure_vulnerability_detection == true) or ($configure_vulnerability_indexer == true) {
     concat::fragment {
       'ossec.conf_vulnerability_indexer':
         order   => 49,
@@ -535,7 +504,7 @@ class wazuh::manager (
         content => template($ossec_vulnerability_indexer_template);
     }
   }
-  if($configure_syscheck == true){
+  if($configure_syscheck == true) {
     concat::fragment {
       'ossec.conf_syscheck':
         order   => 55,
@@ -543,15 +512,15 @@ class wazuh::manager (
         content => template($ossec_syscheck_template);
     }
   }
-  if ($configure_command == true){
+  if ($configure_command == true) {
     concat::fragment {
-          'ossec.conf_command':
-            order   => 60,
-            target  => 'manager_ossec.conf',
-            content => template($ossec_default_commands_template);
-      }
+      'ossec.conf_command':
+        order   => 60,
+        target  => 'manager_ossec.conf',
+        content => template($ossec_default_commands_template);
+    }
   }
-  if ($configure_localfile == true){
+  if ($configure_localfile == true) {
     concat::fragment {
       'ossec.conf_localfile':
         order   => 65,
@@ -559,31 +528,31 @@ class wazuh::manager (
         content => template($ossec_localfile_template);
     }
   }
-  if($configure_ruleset == true){
+  if($configure_ruleset == true) {
     concat::fragment {
-        'ossec.conf_ruleset':
-          order   => 75,
-          target  => 'manager_ossec.conf',
-          content => template($ossec_ruleset_template);
-      }
+      'ossec.conf_ruleset':
+        order   => 75,
+        target  => 'manager_ossec.conf',
+        content => template($ossec_ruleset_template);
+    }
   }
-  if ($configure_auth == true){
+  if ($configure_auth == true) {
     concat::fragment {
-        'ossec.conf_auth':
-          order   => 80,
-          target  => 'manager_ossec.conf',
-          content => template($ossec_auth_template);
-      }
+      'ossec.conf_auth':
+        order   => 80,
+        target  => 'manager_ossec.conf',
+        content => template($ossec_auth_template);
+    }
   }
-  if ($configure_cluster == true){
+  if ($configure_cluster == true) {
     concat::fragment {
-        'ossec.conf_cluster':
-          order   => 85,
-          target  => 'manager_ossec.conf',
-          content => template($ossec_cluster_template);
-      }
+      'ossec.conf_cluster':
+        order   => 85,
+        target  => 'manager_ossec.conf',
+        content => template($ossec_cluster_template);
+    }
   }
-  if ($configure_active_response == true){
+  if ($configure_active_response == true) {
     wazuh::activeresponse { 'active-response configuration':
       active_response_command            => $ossec_active_response_command,
       active_response_location           => $ossec_active_response_location,
@@ -592,7 +561,7 @@ class wazuh::manager (
       active_response_rules_id           => $ossec_active_response_rules_id,
       active_response_timeout            => $ossec_active_response_timeout,
       active_response_repeated_offenders => $ossec_active_response_repeated_offenders,
-      order_arg                          => 90
+      order_arg                          => 90,
     }
   }
   concat::fragment {
@@ -628,12 +597,7 @@ class wazuh::manager (
 
   # https://documentation.wazuh.com/current/user-manual/registering/use-registration-service.html#verify-manager-via-ssl
   if $wazuh_manager_verify_manager_ssl {
-
     if ($wazuh_manager_server_crt != undef) and ($wazuh_manager_server_key != undef) {
-      validate_legacy(
-        String, 'validate_string', $wazuh_manager_server_crt, $wazuh_manager_server_key
-      )
-
       file { '/var/ossec/etc/sslmanager.key':
         content => $wazuh_manager_server_key,
         owner   => 'root',
@@ -664,10 +628,10 @@ class wazuh::manager (
       state  => [
         'NEW',
         'RELATED',
-        'ESTABLISHED'],
+      'ESTABLISHED'],
     }
   }
-  if $ossec_cluster_enable_firewall == 'yes'{
+  if $ossec_cluster_enable_firewall == 'yes' {
     include firewall
     firewall { '1516 wazuh-manager':
       dport  => $ossec_cluster_port,
@@ -676,7 +640,7 @@ class wazuh::manager (
       state  => [
         'NEW',
         'RELATED',
-        'ESTABLISHED'],
+      'ESTABLISHED'],
     }
   }
 
@@ -684,7 +648,7 @@ class wazuh::manager (
     exec { 'Ensure wazuh-fim rule is added to auditctl':
       command => '/sbin/auditctl -l',
       unless  => '/sbin/auditctl -l | grep wazuh_fim',
-      tries   => 2
+      tries   => 2,
     }
   }
 
@@ -694,7 +658,6 @@ class wazuh::manager (
     mode    => '0640',
     content => template('wazuh/wazuh_api_yml.erb'),
     require => Package[$wazuh::params_manager::server_package],
-    notify  => Service[$wazuh::params_manager::server_service]
+    notify  => Service[$wazuh::params_manager::server_service],
   }
-
 }

--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -103,7 +103,6 @@ class wazuh::params_agent {
   $ossec_labels_template = 'wazuh/fragments/_labels.erb'
   $ossec_labels = []
 
-
   ## Rootcheck
   $ossec_rootcheck_disabled = 'no'
   $ossec_rootcheck_check_files = 'yes'
@@ -127,7 +126,6 @@ class wazuh::params_agent {
   $ossec_rootcheck_windows_disabled = 'no'
   $ossec_rootcheck_windows_windows_apps = './shared/win_applications_rcl.txt'
   $ossec_rootcheck_windows_windows_malware = './shared/win_malware_rcl.txt'
-
 
   # SCA
 
@@ -159,13 +157,11 @@ class wazuh::params_agent {
   $sca_else_skip_nfs = 'yes'
   $sca_else_policies = []
 
-
   ## open-scap
   $wodle_openscap_disabled = 'yes'
   $wodle_openscap_timeout = '1800'
   $wodle_openscap_interval = '1d'
   $wodle_openscap_scan_on_start = 'yes'
-
 
   ## syscheck
   $ossec_syscheck_disabled = 'no'
@@ -209,7 +205,6 @@ class wazuh::params_agent {
   $ossec_syscheck_nodiff = '/etc/ssl/private.key'
   $ossec_syscheck_skip_nfs = 'yes'
 
-
   # Audit
   $audit_manage_rules                = false
   $audit_buffer_bytes                = '8192'
@@ -217,7 +212,7 @@ class wazuh::params_agent {
   $audit_rules                       = [
     "-b ${audit_buffer_bytes}",
     "--backlog_wait_time ${audit_backlog_wait_time}",
-    '-f 1'
+    '-f 1',
   ]
 
   $windows_audit_interval = 300
@@ -225,9 +220,8 @@ class wazuh::params_agent {
   # active-response
   $active_response_linux_ca_store = '/var/ossec/etc/wpk_root.pem'
 
-
   # OS specific configurations
-  case $::kernel {
+  case $facts['kernel'] {
     'Linux': {
       $agent_package_name = 'wazuh-agent'
       $agent_service_name = 'wazuh-agent'
@@ -292,7 +286,7 @@ class wazuh::params_agent {
       $ossec_ruleset_decoder_dir = 'ruleset/decoders'
       $ossec_ruleset_rule_dir = 'ruleset/rules'
       $ossec_ruleset_rule_exclude = '0215-policy_rules.xml'
-      $ossec_ruleset_list = [ 'etc/lists/audit-keys',
+      $ossec_ruleset_list = ['etc/lists/audit-keys',
         'etc/lists/amazon/aws-eventnames',
         'etc/lists/security-eventchannel',
       ]
@@ -300,7 +294,7 @@ class wazuh::params_agent {
       $ossec_ruleset_user_defined_decoder_dir = 'etc/decoders'
       $ossec_ruleset_user_defined_rule_dir = 'etc/rules'
 
-      case $::osfamily {
+      case $facts['os']['family'] {
         'Debian': {
           $service_has_status = false
           $ossec_service_provider = undef
@@ -312,15 +306,15 @@ class wazuh::params_agent {
             { 'location' => '/var/log/dpkg.log', 'log_format' => 'syslog' },
             { 'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog' },
           ]
-          case $::lsbdistcodename {
+          case $facts['os']['distro']['codename'] {
             'xenial': {
               $wodle_openscap_content = {
                 'ssg-ubuntu-1604-ds.xml'        => {
                   'type'   => 'xccdf',
                   profiles => ['xccdf_org.ssgproject.content_profile_common'],
                 }, 'cve-ubuntu-xenial-oval.xml' => {
-                  'type' => 'oval'
-                }
+                  'type' => 'oval',
+                },
               }
             }
             'jessie': {
@@ -331,7 +325,7 @@ class wazuh::params_agent {
                 },
                 'cve-debian-8-oval.xml' => {
                   'type' => 'oval',
-                }
+                },
               }
             }
             /^(wheezy|stretch|buster|bullseye|bookworm|sid|precise|trusty|vivid|wily|xenial|bionic|focal|groovy|jammy)$/: {
@@ -340,10 +334,9 @@ class wazuh::params_agent {
               $wodle_openscap_content = undef
             }
             default: {
-              fail("Module ${module_name} is not supported on ${::operatingsystem}")
+              fail("Module ${module_name} is not supported on ${facts['os']['name']}")
             }
           }
-
         }
         'RedHat': {
           $service_has_status = true
@@ -355,13 +348,12 @@ class wazuh::params_agent {
             { 'location' => '/var/log/secure', 'log_format' => 'syslog' },
             { 'location' => '/var/log/maillog', 'log_format' => 'syslog' },
           ]
-          case $::operatingsystem {
+          case $facts['os']['name'] {
             'Amazon': {
               $ossec_service_provider = 'systemd'
             }
             'CentOS': {
-
-              if ( $::operatingsystemrelease =~ /^6.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^6.*/ ) {
                 $ossec_service_provider = 'redhat'
 
                 $wodle_openscap_content = {
@@ -370,11 +362,11 @@ class wazuh::params_agent {
                     profiles => [
                       'xccdf_org.ssgproject.content_profile_pci-dss',
                       'xccdf_org.ssgproject.content_profile_server',
-                    ]
-                  }
+                    ],
+                  },
                 }
               }
-              if ( $::operatingsystemrelease =~ /^7.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^7.*/ ) {
                 $ossec_service_provider = 'systemd'
 
                 $wodle_openscap_content = {
@@ -383,13 +375,13 @@ class wazuh::params_agent {
                     profiles => [
                       'xccdf_org.ssgproject.content_profile_pci-dss',
                       'xccdf_org.ssgproject.content_profile_common',
-                    ]
-                  }
+                    ],
+                  },
                 }
               }
             }
             /^(RedHat|OracleLinux)$/: {
-              if ( $::operatingsystemrelease =~ /^6.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^6.*/ ) {
                 $ossec_service_provider = 'redhat'
 
                 $wodle_openscap_content = {
@@ -398,14 +390,14 @@ class wazuh::params_agent {
                     profiles => [
                       'xccdf_org.ssgproject.content_profile_pci-dss',
                       'xccdf_org.ssgproject.content_profile_server',
-                    ]
+                    ],
                   },
                   'cve-redhat-6-ds.xml' => {
                     'type' => 'xccdf',
-                  }
+                  },
                 }
               }
-              if ( $::operatingsystemrelease =~ /^7.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^7.*/ ) {
                 $ossec_service_provider = 'systemd'
 
                 $wodle_openscap_content = {
@@ -414,14 +406,14 @@ class wazuh::params_agent {
                     profiles => [
                       'xccdf_org.ssgproject.content_profile_pci-dss',
                       'xccdf_org.ssgproject.content_profile_common',
-                    ]
+                    ],
                   },
                   'cve-redhat-7-ds.xml' => {
                     'type' => 'xccdf',
-                  }
+                  },
                 }
               }
-              if ( $::operatingsystemrelease =~ /^8.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^8.*/ ) {
                 $ossec_service_provider = 'systemd'
 
                 $wodle_openscap_content = {
@@ -430,16 +422,16 @@ class wazuh::params_agent {
                     profiles => [
                       'xccdf_org.ssgproject.content_profile_pci-dss',
                       'xccdf_org.ssgproject.content_profile_common',
-                    ]
+                    ],
                   },
                   'cve-redhat-8-ds.xml' => {
                     'type' => 'xccdf',
-                  }
+                  },
                 }
               }
             }
             'Fedora': {
-              if ( $::operatingsystemrelease =~ /^(23|24|25).*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^(23|24|25).*/ ) {
                 $ossec_service_provider = 'redhat'
 
                 $wodle_openscap_content = {
@@ -448,18 +440,18 @@ class wazuh::params_agent {
                     profiles => [
                       'xccdf_org.ssgproject.content_profile_standard',
                       'xccdf_org.ssgproject.content_profile_common',
-                    ]
+                    ],
                   },
                 }
               }
             }
             'AlmaLinux': {
-              if ( $::operatingsystemrelease =~ /^8.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^8.*/ ) {
                 $ossec_service_provider = 'redhat'
               }
             }
             'Rocky': {
-              if ( $::operatingsystemrelease =~ /^8.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^8.*/ ) {
                 $ossec_service_provider = 'redhat'
               }
             }
@@ -476,9 +468,9 @@ class wazuh::params_agent {
             { 'location' => '/var/log/secure', 'log_format' => 'syslog' },
             { 'location' => '/var/log/maillog', 'log_format' => 'syslog' },
           ]
-          case $::operatingsystem {
+          case $facts['os']['name'] {
             'SLES': {
-              if ( $::operatingsystemrelease =~ /^(12|15).*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^(12|15).*/ ) {
                 $ossec_service_provider = 'redhat'
               }
             }

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -1,15 +1,14 @@
 # Copyright (C) 2015, Wazuh Inc.
 # Paramas file
 class wazuh::params_manager {
-  case $::kernel {
+  case $facts['kernel'] {
     'Linux': {
-
-    # Installation
+      # Installation
       $server_package_version                          = '5.0.0-1'
 
       $manage_firewall                                 = false
 
-    ### Ossec.conf blocks
+      ### Ossec.conf blocks
 
       ## Global
       $ossec_logall                                    = 'no'
@@ -31,7 +30,7 @@ class wazuh::params_manager {
       $ossec_remote_allowed_ips                        = undef
       $ossec_remote_queue_size                         = 131072
 
-    # ossec.conf generation parameters
+      # ossec.conf generation parameters
 
       $configure_rootcheck                             = true
       $configure_wodle_openscap                        = true
@@ -50,8 +49,7 @@ class wazuh::params_manager {
       $configure_cluster                               = true
       $configure_active_response                       = false
 
-
-    # ossec.conf templates paths
+      # ossec.conf templates paths
       $ossec_manager_template                          = 'wazuh/wazuh_manager.conf.erb'
       $ossec_rootcheck_template                        = 'wazuh/fragments/_rootcheck.erb'
       $ossec_wodle_openscap_template                   = 'wazuh/fragments/_wodle_openscap.erb'
@@ -72,7 +70,6 @@ class wazuh::params_manager {
       $ossec_syslog_output_template                    = 'wazuh/fragments/_syslog_output.erb'
 
       ## Rootcheck
-
       $ossec_rootcheck_disabled                        = 'no'
       $ossec_rootcheck_check_files                     = 'yes'
       $ossec_rootcheck_check_trojans                   = 'yes'
@@ -111,7 +108,6 @@ class wazuh::params_manager {
       $sca_else_interval = '12h'
       $sca_else_skip_nfs = 'yes'
       $sca_else_policies = []
-
 
       ## Wodles
 
@@ -199,7 +195,6 @@ class wazuh::params_manager {
       $ossec_auth_ssl_manager_key                      = '/var/ossec/etc/sslmanager.key'
       $ossec_auth_ssl_auto_negotiate                   = 'no'
 
-
       # syscheck
 
       $ossec_syscheck_disabled                         = 'no'
@@ -213,21 +208,21 @@ class wazuh::params_manager {
       $ossec_syscheck_whodata_directories_2            = 'no'
       $ossec_syscheck_realtime_directories_2           = 'no'
       $ossec_syscheck_ignore_list                      = ['/etc/mtab',
-                                              '/etc/hosts.deny',
-                                              '/etc/mail/statistics',
-                                              '/etc/random-seed',
-                                              '/etc/random.seed',
-                                              '/etc/adjtime',
-                                              '/etc/httpd/logs',
-                                              '/etc/utmpx',
-                                              '/etc/wtmpx',
-                                              '/etc/cups/certs',
-                                              '/etc/dumpdates',
-                                              '/etc/svc/volatile',
-                                              '/sys/kernel/security',
-                                              '/sys/kernel/debug',
-                                              '/dev/core',
-                                            ]
+        '/etc/hosts.deny',
+        '/etc/mail/statistics',
+        '/etc/random-seed',
+        '/etc/random.seed',
+        '/etc/adjtime',
+        '/etc/httpd/logs',
+        '/etc/utmpx',
+        '/etc/wtmpx',
+        '/etc/cups/certs',
+        '/etc/dumpdates',
+        '/etc/svc/volatile',
+        '/sys/kernel/security',
+        '/sys/kernel/debug',
+        '/dev/core',
+      ]
       $ossec_syscheck_ignore_type_1                    = '^/proc'
       $ossec_syscheck_ignore_type_2                    = '.log$|.swp$'
 
@@ -244,7 +239,7 @@ class wazuh::params_manager {
       $ossec_ruleset_decoder_dir = 'ruleset/decoders'
       $ossec_ruleset_rule_dir = 'ruleset/rules'
       $ossec_ruleset_rule_exclude = '0215-policy_rules.xml'
-      $ossec_ruleset_list = [ 'etc/lists/audit-keys',
+      $ossec_ruleset_list = ['etc/lists/audit-keys',
         'etc/lists/amazon/aws-eventnames',
         'etc/lists/security-eventchannel',
       ]
@@ -266,12 +261,10 @@ class wazuh::params_manager {
 
       $ossec_cluster_enable_firewall                   = 'no'
 
-
       #----- End of ossec.conf parameters -------
 
       $ossec_prefilter                     = false
       $ossec_integratord_enabled           = false
-
 
       $manage_client_keys                  = 'yes'
       $agent_auth_password                 = undef
@@ -287,7 +280,6 @@ class wazuh::params_manager {
       $wazuh_manager_server_crt            = undef
       $wazuh_manager_server_key            = undef
 
-
       ## Wazuh config folders and modes
 
       $config_file = '/var/ossec/etc/ossec.conf'
@@ -302,7 +294,6 @@ class wazuh::params_manager {
       $keys_owner = 'root'
       $keys_group = 'wazuh'
 
-
       $authd_pass_file = '/var/ossec/etc/authd.pass'
 
       $validate_cmd_conf = '/var/ossec/bin/verify-agent-conf -f %'
@@ -313,10 +304,8 @@ class wazuh::params_manager {
       $processlist_group = 'wazuh'
 
       #API
-
       $wazuh_api_host = ['0.0.0.0']
       $wazuh_api_port = '55000'
-
       $wazuh_api_file =  undef
 
       # Advanced configuration
@@ -362,10 +351,8 @@ class wazuh::params_manager {
       # Wazuh API template path
       $wazuh_api_template = 'wazuh/wazuh_api_yml.erb'
 
-
-      case $::osfamily {
+      case $facts['os']['family'] {
         'Debian': {
-
           $agent_service  = 'wazuh-agent'
           $agent_package  = 'wazuh-agent'
           $service_has_status  = false
@@ -376,9 +363,9 @@ class wazuh::params_manager {
             { 'location' => '/var/log/dpkg.log', 'log_format' => 'syslog' },
             { 'location' => '/var/log/kern.log', 'log_format' => 'syslog' },
             { 'location' => '/var/log/auth.log', 'log_format' => 'syslog' },
-            {  'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog'},
+            { 'location' => '/var/ossec/logs/active-responses.log', 'log_format' => 'syslog' },
           ]
-          case $::lsbdistcodename {
+          case $facts['os']['distro']['codename'] {
             'xenial': {
               $server_service = 'wazuh-manager'
               $server_package = 'wazuh-manager'
@@ -387,8 +374,8 @@ class wazuh::params_manager {
                   'type' => 'xccdf',
                   profiles => ['xccdf_org.ssgproject.content_profile_common'],
                 },'cve-ubuntu-xenial-oval.xml' => {
-                  'type' => 'oval'
-                }
+                  'type' => 'oval',
+                },
               }
             }
             'jessie': {
@@ -401,7 +388,7 @@ class wazuh::params_manager {
                 },
                 'cve-debian-8-oval.xml' => {
                   'type' => 'oval',
-                }
+                },
               }
             }
             /^(wheezy|stretch|buster|bullseye|bookworm|sid|precise|trusty|vivid|wily|xenial|bionic|focal|groovy|jammy)$/: {
@@ -409,28 +396,26 @@ class wazuh::params_manager {
               $server_package = 'wazuh-manager'
               $wodle_openscap_content = undef
             }
-        default: {
-          fail("Module ${module_name} is not supported on ${::operatingsystem}")
-        }
+            default: {
+              fail("Module ${module_name} is not supported on ${facts['os']['name']}")
+            }
           }
-
         }
         'RedHat': {
-
           $agent_service  = 'wazuh-agent'
           $agent_package  = 'wazuh-agent'
           $server_service = 'wazuh-manager'
           $server_package = 'wazuh-manager'
           $service_has_status  = true
 
-          $default_local_files =[
-              {  'location' => '/var/log/audit/audit.log' , 'log_format' => 'audit'},
-              {  'location' => '/var/ossec/logs/active-responses.log' , 'log_format' => 'syslog'},
-              {  'location' => '/var/log/messages', 'log_format' => 'syslog'},
-              {  'location' => '/var/log/secure' , 'log_format' => 'syslog'},
-              {  'location' => '/var/log/maillog' , 'log_format' => 'syslog'},
+          $default_local_files = [
+            { 'location' => '/var/log/audit/audit.log' , 'log_format' => 'audit' },
+            { 'location' => '/var/ossec/logs/active-responses.log' , 'log_format' => 'syslog' },
+            { 'location' => '/var/log/messages', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/secure' , 'log_format' => 'syslog' },
+            { 'location' => '/var/log/maillog' , 'log_format' => 'syslog' },
           ]
-          case $::operatingsystem {
+          case $facts['os']['name'] {
             'Amazon': {
               $ossec_service_provider = 'systemd'
               $api_service_provider = 'systemd'
@@ -441,69 +426,69 @@ class wazuh::params_manager {
               $wodle_openscap_content = undef
             }
             'CentOS': {
-              if ( $::operatingsystemrelease =~ /^6.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^6.*/ ) {
                 $ossec_service_provider = 'redhat'
                 $api_service_provider = 'redhat'
                 $wodle_openscap_content = {
                   'ssg-centos-6-ds.xml' => {
                     'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
-                  }
+                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',],
+                  },
                 }
               }
-              if ( $::operatingsystemrelease =~ /^7.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^7.*/ ) {
                 $ossec_service_provider = 'systemd'
                 $api_service_provider = 'systemd'
                 $wodle_openscap_content = {
                   'ssg-centos-7-ds.xml' => {
                     'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
-                  }
+                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',],
+                  },
                 }
               }
             }
             /^(RedHat|OracleLinux)$/: {
-              if ( $::operatingsystemrelease =~ /^6.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^6.*/ ) {
                 $ossec_service_provider = 'redhat'
                 $api_service_provider = 'redhat'
                 $wodle_openscap_content = {
                   'ssg-rhel-6-ds.xml' => {
                     'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',]
+                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_server',],
                   },
                   'cve-redhat-6-ds.xml' => {
                     'type' => 'xccdf',
-                  }
+                  },
                 }
               }
-              if ( $::operatingsystemrelease =~ /^7.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^7.*/ ) {
                 $ossec_service_provider = 'systemd'
                 $api_service_provider = 'systemd'
                 $wodle_openscap_content = {
                   'ssg-rhel-7-ds.xml' => {
                     'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',]
+                    profiles => ['xccdf_org.ssgproject.content_profile_pci-dss', 'xccdf_org.ssgproject.content_profile_common',],
                   },
                   'cve-redhat-7-ds.xml' => {
                     'type' => 'xccdf',
-                  }
+                  },
                 }
               }
             }
             'Fedora': {
-              if ( $::operatingsystemrelease =~ /^(23|24|25).*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^(23|24|25).*/ ) {
                 $ossec_service_provider = 'redhat'
                 $api_service_provider = 'redhat'
                 $wodle_openscap_content = {
                   'ssg-fedora-ds.xml' => {
                     'type' => 'xccdf',
-                    profiles => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',]
+                    profiles => ['xccdf_org.ssgproject.content_profile_standard', 'xccdf_org.ssgproject.content_profile_common',],
                   },
                 }
               }
             }
             'AlmaLinux': {
-              if ( $::operatingsystemrelease =~ /^8.*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^8.*/ ) {
                 $ossec_service_provider = 'redhat'
                 $api_service_provider = 'redhat'
               }
@@ -512,23 +497,22 @@ class wazuh::params_manager {
           }
         }
         'Suse': {
-
           $agent_service  = 'wazuh-agent'
           $agent_package  = 'wazuh-agent'
           $server_service = 'wazuh-manager'
           $server_package = 'wazuh-manager'
           $service_has_status  = true
 
-          $default_local_files =[
-              {  'location' => '/var/log/audit/audit.log' , 'log_format' => 'audit'},
-              {  'location' => '/var/ossec/logs/active-responses.log' , 'log_format' => 'syslog'},
-              {  'location' => '/var/log/messages', 'log_format' => 'syslog'},
-              {  'location' => '/var/log/secure' , 'log_format' => 'syslog'},
-              {  'location' => '/var/log/maillog' , 'log_format' => 'syslog'},
+          $default_local_files = [
+            { 'location' => '/var/log/audit/audit.log' , 'log_format' => 'audit' },
+            { 'location' => '/var/ossec/logs/active-responses.log' , 'log_format' => 'syslog' },
+            { 'location' => '/var/log/messages', 'log_format' => 'syslog' },
+            { 'location' => '/var/log/secure' , 'log_format' => 'syslog' },
+            { 'location' => '/var/log/maillog' , 'log_format' => 'syslog' },
           ]
-          case $::operatingsystem {
+          case $facts['os']['name'] {
             'SLES': {
-              if ( $::operatingsystemrelease =~ /^(12|15).*/ ) {
+              if ( $facts['os']['release']['full'] =~ /^(12|15).*/ ) {
                 $ossec_service_provider = 'redhat'
                 $api_service_provider = 'redhat'
               }
@@ -563,15 +547,14 @@ class wazuh::params_manager {
       # TODO
       $validate_cmd_conf = undef
       # Pushed by shared agent config now
-      $default_local_files =  [
-        {'location' => 'Security' , 'log_format' => 'eventchannel',
+      $default_local_files = [
+        { 'location' => 'Security' , 'log_format' => 'eventchannel',
         'query' => 'Event/System[EventID != 5145 and EventID != 5156 and EventID != 5447 and EventID != 4656 and EventID != 4658\
-        and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID!= 4703 and EventID != 4907]'},
-        {'location' => 'System' , 'log_format' =>  'eventlog'  },
-        {'location' => 'active-response\active-responses.log' , 'log_format' =>  'syslog'  },
+        and EventID != 4663 and EventID != 4660 and EventID != 4670 and EventID != 4690 and EventID!= 4703 and EventID != 4907]' },
+        { 'location' => 'System' , 'log_format' => 'eventlog' },
+        { 'location' => 'active-response\active-responses.log' , 'log_format' => 'syslog' },
       ]
-
     }
-  default: { fail('This ossec module has not been tested on your distribution') }
+    default: { fail('This ossec module has not been tested on your distribution') }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -2,31 +2,30 @@
 # Wazuh repository installation
 class wazuh::repo (
 ) {
-
-  case $::osfamily {
+  case $facts['os']['family'] {
     'Debian' : {
       $wazuh_repo_url = 'https://packages.wazuh.com/4.x/apt'
       $repo_release = 'stable'
 
-      if $::lsbdistcodename =~ /(jessie|wheezy|stretch|precise|trusty|vivid|wily|xenial|yakketi|groovy)/
+      if $facts['os']['distro']['codename'] =~ /(jessie|wheezy|stretch|precise|trusty|vivid|wily|xenial|yakketi|groovy)/
       and ! defined(Package['apt-transport-https']) and ! defined(Package['gnupg']) {
-        ensure_packages(['apt-transport-https', 'gnupg'], {'ensure' => 'present'})
+        ensure_packages(['apt-transport-https', 'gnupg'], { 'ensure' => 'present' })
       }
       exec { 'import-wazuh-key':
-        path =>  [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
+        path    => ['/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/'],
         command => 'curl -s https://packages.wazuh.com/key/GPG-KEY-WAZUH | gpg --no-default-keyring --keyring /usr/share/keyrings/wazuh.gpg --import',
         unless  => 'gpg --no-default-keyring --keyring /usr/share/keyrings/wazuh.gpg --list-keys | grep -q 29111145',
       }
 
       # Ensure permissions on the keyring
       file { '/usr/share/keyrings/wazuh.gpg':
-        ensure => file,
-        owner  => 'root',
-        group  => 'root',
-        mode   => '0644',
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
         require => Exec['import-wazuh-key'],
       }
-      case $::lsbdistcodename {
+      case $facts['os']['distro']['codename'] {
         /(jessie|wheezy|stretch|buster|bullseye|bookworm|sid|precise|trusty|vivid|wily|xenial|yakketi|bionic|focal|groovy|jammy)/: {
           apt::source { 'wazuh':
             ensure   => present,
@@ -38,19 +37,19 @@ class wazuh::repo (
               'src' => false,
               'deb' => true,
             },
-            require => File['/usr/share/keyrings/wazuh.gpg'],
+            require  => File['/usr/share/keyrings/wazuh.gpg'],
           }
           # Manage the APT source list file content using concat
           concat { '/etc/apt/sources.list.d/wazuh.list':
-            ensure  => present,
-            owner   => 'root',
-            group   => 'root',
-            mode    => '0644',
+            ensure => present,
+            owner  => 'root',
+            group  => 'root',
+            mode   => '0644',
           }
 
           concat::fragment { 'wazuh-source':
             target  => '/etc/apt/sources.list.d/wazuh.list',
-            content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] $wazuh_repo_url $repo_release main\n",
+            content => "deb [signed-by=/usr/share/keyrings/wazuh.gpg] ${wazuh_repo_url} ${repo_release} main\n",
             order   => '01',
             require => File['/usr/share/keyrings/wazuh.gpg'],
           }
@@ -65,43 +64,42 @@ class wazuh::repo (
       }
     }
     'Linux', 'RedHat', 'Suse' : {
-        case $::os[name] {
-          /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux|Rocky|SLES)$/: {
-
-            if ( $::operatingsystemrelease =~ /^5.*/ ) {
-              $baseurl  = 'https://packages.wazuh.com/4.x/yum/5/'
-              $gpgkey   = 'http://packages.wazuh.com/key/GPG-KEY-WAZUH'
-            } else {
-              $baseurl  = 'https://packages.wazuh.com/4.x/yum/'
-              $gpgkey   = 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
-            }
-          }
-          default: { fail('This ossec module has not been tested on your distribution.') }
-        }
-        # Set up OSSEC repo
-        case $::os[name] {
-          /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux)$/: {
-            yumrepo { 'wazuh':
-              descr    => 'WAZUH OSSEC Repository - www.wazuh.com',
-              enabled  => true,
-              gpgcheck => 1,
-              gpgkey   => $gpgkey,
-              baseurl  => $baseurl
-            }
-          }
-          /^(SLES)$/: {
-            zypprepo { 'wazuh':
-              ensure        => present,
-              name          => 'WAZUH OSSEC Repository - www.wazuh.com',
-              enabled       => 1,
-              gpgcheck      => 0,
-              repo_gpgcheck => 0,
-              pkg_gpgcheck  => 0,
-              gpgkey        => $gpgkey,
-              baseurl       => $baseurl
-            }
+      case $facts['os'][name] {
+        /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux|Rocky|SLES)$/: {
+          if ( $facts['os']['release']['full'] =~ /^5.*/ ) {
+            $baseurl  = 'https://packages.wazuh.com/4.x/yum/5/'
+            $gpgkey   = 'http://packages.wazuh.com/key/GPG-KEY-WAZUH'
+          } else {
+            $baseurl  = 'https://packages.wazuh.com/4.x/yum/'
+            $gpgkey   = 'https://packages.wazuh.com/key/GPG-KEY-WAZUH'
           }
         }
+        default: { fail('This ossec module has not been tested on your distribution.') }
+      }
+      # Set up OSSEC repo
+      case $facts['os'][name] {
+        /^(CentOS|RedHat|OracleLinux|Fedora|Amazon|AlmaLinux)$/: {
+          yumrepo { 'wazuh':
+            descr    => 'WAZUH OSSEC Repository - www.wazuh.com',
+            enabled  => true,
+            gpgcheck => 1,
+            gpgkey   => $gpgkey,
+            baseurl  => $baseurl,
+          }
+        }
+        /^(SLES)$/: {
+          zypprepo { 'wazuh':
+            ensure        => present,
+            name          => 'WAZUH OSSEC Repository - www.wazuh.com',
+            enabled       => 1,
+            gpgcheck      => 0,
+            repo_gpgcheck => 0,
+            pkg_gpgcheck  => 0,
+            gpgkey        => $gpgkey,
+            baseurl       => $baseurl,
+          }
+        }
+      }
     }
   }
 }

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -1,6 +1,6 @@
 # Copyright (C) 2015, Wazuh Inc.
 #Define for a Reports section
-define wazuh::reports(
+define wazuh::reports (
   Optional[String] $r_group               = undef,
   Optional[String] $r_category            = undef,
   Optional[Integer] $r_rule               = undef,
@@ -12,12 +12,11 @@ define wazuh::reports(
   $r_email_to                             = '',
   Optional[Enum['yes', 'no']] $r_showlogs = undef,
 ) {
-
   require wazuh::params_manager
 
   concat::fragment { $name:
     target  => 'manager_ossec.conf',
     order   => 70,
-    content => template('wazuh/fragments/_reports.erb')
+    content => template('wazuh/fragments/_reports.erb'),
   }
 }

--- a/manifests/tests.pp
+++ b/manifests/tests.pp
@@ -1,3 +1,3 @@
 node 'default-centos-7' {
-  class { 'wazuh::manager':}
+  class { 'wazuh::manager': }
 }

--- a/templates/wazuh_indexer_yml.erb
+++ b/templates/wazuh_indexer_yml.erb
@@ -28,7 +28,7 @@ plugins.security.authcz.admin_dn:
 plugins.security.check_snapshot_restore_write_privileges: true
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.nodes_dn:
-<% @indexer_cluster_CN.each do |cn| -%>
+<% @indexer_cluster_cn.each do |cn| -%>
 - "CN=indexer-<%= cn %>,OU=Wazuh,O=Wazuh,L=California,C=US"
 <% end -%>
 plugins.security.restapi.roles_enabled:


### PR DESCRIPTION
drop deprecated function validate_legacy

use variables for cert content

general format tidying

fix indexer_cluster_cn

re-opening, this was closed when master branch was re-named to main.

Any feedback would be welcome, rather than being ignored.