### PR TITLE
Merge 4.14.0 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ All notable changes to this project will be documented in this file.
 
 - None
 
+## [4.14.0]
+
+### Added
+
+- None
+
+### Changed
+
+- None
+
+### Fixed
+
+- None
+
+### Deleted
+
+- None
+
 ## [4.13.0]
 
 ### Added

--- a/metadata.json
+++ b/metadata.json
@@ -110,7 +110,7 @@
   "tags": [
     "ossec",
     "hids",
-    "4.13",
+    "5.0",
     "wazuh"
   ],
   "pdk-version": "1.14.1",


### PR DESCRIPTION
### Description

- Merge 4.14.0 into main
- Update [this missing reference](https://github.com/wazuh/wazuh-puppet/blob/59af6dc/metadata.json#L113) in `main` (check this for example for [4.14.0](https://github.com/wazuh/wazuh-puppet/blob/4.14.0/metadata.json#L113))

### Related issue:
- https://github.com/wazuh/wazuh-puppet/issues/1328