### PR TITLE
Removed 4.12.2 reference from 4.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,24 +20,6 @@ All notable changes to this project will be documented in this file.
 - Remove default puppet reference version from workflow ([#1284](https://github.com/wazuh/wazuh-puppet/pull/1284))
 - Remove 'stable' branch ocurrencies ([#1281](https://github.com/wazuh/wazuh-puppet/pull/1281))
 
-## [4.12.2]
-
-### Added
-
-- None
-
-### Changed
-
-- None
-
-### Fixed
-
-- None
-
-### Deleted
-
-- None
-
 ## [4.12.1]
 
 ### Added


### PR DESCRIPTION
related https://github.com/wazuh/wazuh-puppet/issues/1331

Removed 4.12.2 reference from 4.13.0