### PR TITLE
Add missing `malicious-ioc` ruleset lists

### DIFF
--- a/manifests/params_agent.pp
+++ b/manifests/params_agent.pp
@@ -295,6 +295,9 @@ class wazuh::params_agent {
       $ossec_ruleset_list = [ 'etc/lists/audit-keys',
         'etc/lists/amazon/aws-eventnames',
         'etc/lists/security-eventchannel',
+        'etc/lists/malicious-ioc/malicious-ip',
+        'etc/lists/malicious-ioc/malicious-domains',
+        'etc/lists/malicious-ioc/malware-hashes',
       ]
 
       $ossec_ruleset_user_defined_decoder_dir = 'etc/decoders'

--- a/manifests/params_manager.pp
+++ b/manifests/params_manager.pp
@@ -247,6 +247,9 @@ class wazuh::params_manager {
       $ossec_ruleset_list = [ 'etc/lists/audit-keys',
         'etc/lists/amazon/aws-eventnames',
         'etc/lists/security-eventchannel',
+        'etc/lists/malicious-ioc/malicious-ip',
+        'etc/lists/malicious-ioc/malicious-domains',
+        'etc/lists/malicious-ioc/malware-hashes',
       ]
 
       $ossec_ruleset_user_defined_decoder_dir = 'etc/decoders'


### PR DESCRIPTION
# Description

This PR aims to add the new lists to the `ossec.conf` section of ossec.conf

## Tests 

- https://github.com/wazuh/wazuh-puppet/issues/1351#issuecomment-2956943954