### PR TITLE
feat: add options to integration

### DIFF
--- a/manifests/integration.pp
+++ b/manifests/integration.pp
@@ -9,6 +9,7 @@ define wazuh::integration(
   $in_location = '',
   $in_format = '',
   $in_max_log = '',
+  $options = '',
 ) {
 
   require wazuh::params_manager

--- a/templates/fragments/_integration.erb
+++ b/templates/fragments/_integration.erb
@@ -21,9 +21,12 @@
     <% if @in_format != '' -%>
     <alert_format><%= @in_format %></alert_format>
     <% end %>
+    <% if @options != '' -%>
+      <options><%= @options %></options>
+    <% end %>
     <% if @in_max_log != '' -%>
       <max_log><%= @in_max_log %></max_log>
     <% end %>
   </integration>
 
-  
+


### PR DESCRIPTION
As noted in the official documentation https://documentation.wazuh.com/current/user-manual/manager/integration-with-external-apis.html there is an field for `<options>` which is an arbitrary json object.

Currently this variable is missing in the template and manifest.

Note that `<max_log>` is not mentioned anymore and maybe could be just removed.