### PR TITLE
Reported skipped bumps in the repository bumper workflow instead of failing

### DIFF
--- a/.github/workflows/4_bumper_repository.yml
+++ b/.github/workflows/4_bumper_repository.yml
@@ -102,14 +102,34 @@ jobs:
           echo "Running bump script"
           bash ${{ env.BUMP_SCRIPT_PATH }} ${{ steps.vars.outputs.script_params }}
 
-      - name: Commit and push changes
+      - name: Check for changes
+        id: check_changes
         run: |
           git add .
+          if git diff --staged --quiet; then
+            echo "No changes produced by the bump script."
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Commit changes (Bump)
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
           git commit -m "feat: bump ${{ github.ref_name }}"
+
+      - name: "Result: no changes to commit"
+        if: steps.check_changes.outputs.has_changes == 'false'
+        run: echo "The bump produced no changes, no pull request was created."
+
+      - name: Push changes
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
           git push origin ${{ steps.vars.outputs.branch_name }}
 
       - name: Create pull request
         id: create_pr
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           gh auth setup-git
           PR_URL=$(gh pr create \
@@ -122,14 +142,19 @@ jobs:
           echo "pull_request_url=${PR_URL}" >> $GITHUB_OUTPUT
 
       - name: Merge pull request
+        if: steps.check_changes.outputs.has_changes == 'true'
         run: |
           # Any checks for the PR are bypassed since the branch is expected to be functional (i.e. the bump process does not introduce any bugs)
           gh pr merge "${{ steps.create_pr.outputs.pull_request_url }}" --merge --admin
 
       - name: Show logs
         run: |
-          echo "Bump complete."
-          echo "Branch: ${{ steps.vars.outputs.branch_name }}"
-          echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          if [[ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]]; then
+            echo "Bump complete."
+            echo "Branch: ${{ steps.vars.outputs.branch_name }}"
+            echo "PR: ${{ steps.create_pr.outputs.pull_request_url }}"
+          else
+            echo "Bump skipped: the repository is already at the requested version/stage."
+          fi
           echo "Bumper scripts logs:"
           cat ${BUMP_LOG_PATH}/repository_bumper*log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- None
+- Report skipped bumps in the repository bumper workflow ([#1671](https://github.com/wazuh/wazuh-puppet/issues/1671))
 
 ### Deleted
 


### PR DESCRIPTION
## Related issue #1671 

##  Description

`.github/workflows/4_bumper_repository.yml` ended with the `failure`conclusion whenever the bump script produced no changes: the `Commit and push changes` step ran `git commit` unconditionally, which fails with "nothing to commit" in that case. The release orchestrator in `wazuh-qa-automation` (wazuh-qa-automation#8027) can now tell apart
a real failure from a no-op bump, but only by reading the **names of the steps** that ran — so this workflow needed to stop failing in that case and explicitly report it.

## Scope note: revert functionality does not exist in this repository

The parent issue's checklist also describes a `revert` scenario (`Revert references (Revert)` step, `pr_found` output, and the `"Result: original bump pull request not found"` result step). This repository's bumper workflow has **no revert functionality at all** —no `revert` input, no revert-related step, in this or any other workflow file in `.github/workflows/`. That part of the issue does not apply here; only the "no changes to commit" reporting was implemented.

## Changes

- **`Check for changes`** (new step, `id: check_changes`): stages  changes and decides `has_changes` without failing, replacing the  previous unconditional commit.
- **`Commit changes (Bump)`**, **`Push changes`**, **`Create pull  request`**, **`Merge pull request`**: all now conditioned on  `steps.check_changes.outputs.has_changes == 'true'`.
- **`"Result: no changes to commit"`** (new step): runs when  `has_changes == 'false'`, with the exact name matched by the release  orchestrator.
- **`Show logs`**: adjusted to report "Bump skipped" instead of  referencing an empty PR URL when there was nothing to bump.

## Validation

Ran the workflow twice against a disposable branch (`test/1671-validation`, deleted after validation), using `Use
workflow from: fix/1671-report-skipped-bumps` so the fixed code was exercised, with a throwaway version (`9.9.9-alpha0`) to avoid touching anything real.

| # | Scenario | Result | Run |
|---|---|---|---|
| 1 | Normal bump | ✅ Success — PR created & merged, result step skipped | [Run](https://github.com/wazuh/wazuh-puppet/actions/runs/32467228987) |
| 2 | Bump with no changes | ✅ Success — `Result: no changes to commit` ran, Push/Create PR/Merge PR skipped | [Run](https://github.com/wazuh/wazuh-puppet/actions/runs/32467529364) |

Both scenarios match the behaviour required by the issue. The test branch and its bump branch were deleted after validation (the PR merge auto-deleted the bump branch; the disposable base branch was deleted manually).